### PR TITLE
chore(git): restore .gitignore that's gone missing during the move

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+target/
+
+# Ignore private and public keys
+*id_rsa*
+*key_vagrant
+
+#ignore Idea/intelliJ files
+*.idea
+*.iml
+
+#ignore Eclipse files
+.classpath
+.project
+.settings
+
+#ignore backup files
+*.bak
+*.orig
+
+
+#ignore any log files
+*.log
+
+/backend/src-common/src/main/resources/sw360.properties


### PR DESCRIPTION
closes eclipse/sw360#85