### PR TITLE
feat(release): Add project mainline state to export spreadsheet (clearing status)

### DIFF
--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2018. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -91,6 +91,7 @@ public class ReleaseExporter extends ExcelExporter<Release, ReleaseHelper> {
     private static List<String> makeHeadersForExtendedExport() {
         List<String> additionalHeaders = new ArrayList<>();
         additionalHeaders.add(displayNameFor("project origin", nameToDisplayName));
+        additionalHeaders.add(displayNameFor("project mainline state", nameToDisplayName));
 
         List<String> completeHeaders = new ArrayList<>();
         completeHeaders.addAll(makeHeaders());

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseHelper.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2018. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -135,15 +135,20 @@ class ReleaseHelper implements ExporterHelper<Release> {
                     row.add(ThriftEnumUtils.enumToString(component.getComponentType()));
                 }
 
-                // and project origin only if wanted
+                // project origin and project mainline state only if wanted
                 if (addAdditionalData()) {
                     if (releaseClearingStatusDataByRelease.containsKey(release)) {
-                        row.add(releaseClearingStatusDataByRelease.get(release).getProjectNames());
+                        ReleaseClearingStatusData releaseClearingData = releaseClearingStatusDataByRelease.get(release);
+                        row.add(releaseClearingData.getProjectNames());
+                        row.add(releaseClearingData.getMainlineStates());
                     } else {
+                        row.add("");
                         row.add("");
                     }
                 }
+
                 break;
+
             case VENDOR:
                 addVendorToRow(release.getVendor(), row);
                 break;


### PR DESCRIPTION
- adds new column "project mainline state" to the release spreadsheet export file

closes eclipse/sw360#130