### PR TITLE
fix(test): CPE ID not required for release

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseInformation.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseInformation.jspf
@@ -55,11 +55,11 @@
                    value="<sw360:DisplayCollection value="${release.operatingSystems}" />"/>
         </td>
         <td width="33%">
-            <label class="textlabel stackedLabel mandatory" for="comp_id">CPE ID</label>
+            <label class="textlabel stackedLabel" for="comp_id">CPE ID</label>
             <input id="comp_id" name="<portlet:namespace/><%=Release._Fields.CPEID%>" type="text"
                    class="toplabelledInput followedByImg"
                    value="<sw360:out value="${release.cpeid}"/>"
-                   placeholder="Enter CPE ID" required="" />
+                   placeholder="Enter CPE ID"/>
             <img class="infopic" src="<%=request.getContextPath()%>/images/ic_info.png"
                  title="The formula for CPE ID creation is &#13;'cpe:2.3:a:VENDORNAME:COMPONENTNAME:VERSION'  "/>
         </td>


### PR DESCRIPTION
Regarding conversation with Michael Jaeger, we want to proceed with release adding without CPE ID for components from NPM