### PR TITLE
Allow For Changing User Email Address

### DIFF
--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -58,8 +58,8 @@ public class ComponentDatabaseHandlerTest {
     private static final String email1 = "cedric.bodet@tngtech.com";
     private static final String email2 = "johannes.najjar@tngtech.com";
 
-    private static final User user1 = new User().setEmail(email1).setDepartment("AB CD EF").setId(email1);
-    private static final User user2 = new User().setEmail(email2).setDepartment("AB CD EF").setId(email2);
+    private static final User user1 = new User().setEmail(email1).setDepartment("AB CD EF").setId("481489458");
+    private static final User user2 = new User().setEmail(email2).setDepartment("AB CD EF").setId("4786487647680");
 
     @Rule
     public final ExpectedException exception = ExpectedException.none();

--- a/backend/src/src-moderation/src/test/java/org/eclipse/sw360/moderation/TestModerationClient.java
+++ b/backend/src/src-moderation/src/test/java/org/eclipse/sw360/moderation/TestModerationClient.java
@@ -33,7 +33,7 @@ public class TestModerationClient {
         TProtocol protocol = new TCompactProtocol(thriftClient);
         ModerationService.Iface client = new ModerationService.Client(protocol);
 
-        List<ModerationRequest> requestsByModerator = client.getRequestsByModerator(new User().setId("").setEmail("cedric.bodet@tngtech.com").setDepartment("BB"));
+        List<ModerationRequest> requestsByModerator = client.getRequestsByModerator(new User().setId("58245y9845").setEmail("cedric.bodet@tngtech.com").setDepartment("BB"));
 
 
         System.out.println("Fetched " + requestsByModerator.size() + " moderation requests from moderation service");

--- a/backend/src/src-users/src/main/java/org/eclipse/sw360/users/UserHandler.java
+++ b/backend/src/src-users/src/main/java/org/eclipse/sw360/users/UserHandler.java
@@ -10,16 +10,15 @@
  */
 package org.eclipse.sw360.users;
 
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserService;
 import org.eclipse.sw360.users.db.UserDatabaseHandler;
-import org.apache.log4j.Logger;
-import org.apache.thrift.TException;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.util.List;
 
 import static org.eclipse.sw360.datahandler.common.SW360Assert.assertNotEmpty;
@@ -41,16 +40,25 @@ public class UserHandler implements UserService.Iface {
     }
 
     @Override
+    public User getUser(String id) throws TException {
+        return db.getUser(id);
+    }
+
+    @Override
     public User getByEmail(String email) throws TException {
         StackTraceElement stackTraceElement = Thread.currentThread().getStackTrace()[2];
         assertNotEmpty(email, "Invalid empty email " + stackTraceElement.getFileName() + ": "  + stackTraceElement.getLineNumber());
 
         if (log.isTraceEnabled()) log.trace("getByEmail: " + email);
 
-        // Get user from database
-        User user = db.getByEmail(email);
+        return db.getByEmail(email);
+    }
+
+    @Override
+    public User getByEmailOrExternalId(String email, String externalId) throws TException {
+        User user = getByEmail(email);
         if (user == null) {
-            log.info("User does not exist in DB");
+            user = db.getByExternalId(externalId);
         }
         return user;
     }

--- a/backend/src/src-users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
+++ b/backend/src/src-users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
@@ -21,7 +21,6 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.ektorp.http.HttpClient;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -49,7 +48,11 @@ public class UserDatabaseHandler {
     }
 
     public User getByEmail(String email) {
-        return db.get(User.class, email);
+        return repository.getByEmail(email);
+    }
+
+    public User getUser(String id) {
+        return db.get(User.class, id);
     }
 
     private void prepareUser(User user) throws SW360Exception {
@@ -86,5 +89,9 @@ public class UserDatabaseHandler {
 
     public List<User> searchUsers(String searchText) {
         return userSearch.searchByNameAndEmail(searchText);
+    }
+
+    public User getByExternalId(String externalId) {
+        return repository.getByExternalId(externalId);
     }
 }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/CustomFieldHelper.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/CustomFieldHelper.java
@@ -13,15 +13,12 @@ package org.eclipse.sw360.portal.common;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
-import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.model.ResourceConstants;
 import com.liferay.portal.model.Role;
 import com.liferay.portal.model.RoleConstants;
 import com.liferay.portal.security.permission.ActionKeys;
 import com.liferay.portal.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.service.RoleLocalServiceUtil;
-import com.liferay.portal.service.UserLocalServiceUtil;
-import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portlet.expando.model.ExpandoBridge;
 import com.liferay.portlet.expando.model.ExpandoColumn;
 import com.liferay.portlet.expando.model.ExpandoColumnConstants;
@@ -29,6 +26,7 @@ import com.liferay.portlet.expando.model.ExpandoTableConstants;
 import com.liferay.portlet.expando.service.ExpandoColumnLocalServiceUtil;
 import org.apache.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.portal.users.UserUtils;
 
 import javax.portlet.PortletRequest;
 
@@ -83,17 +81,11 @@ public class CustomFieldHelper {
     }
 
     private static ExpandoBridge getUserExpandoBridge(PortletRequest request, User user) throws PortalException, SystemException {
-        com.liferay.portal.model.User liferayUser = getLiferayUser(request, user);
+        com.liferay.portal.model.User liferayUser = UserUtils.findLiferayUser(request, user);
         ensureUserCustomFieldExists(liferayUser, CUSTOM_FIELD_PROJECT_GROUP_FILTER, ExpandoColumnConstants.STRING);
         ensureUserCustomFieldExists(liferayUser, CUSTOM_FIELD_COMPONENTS_VIEW_SIZE, ExpandoColumnConstants.INTEGER);
         ensureUserCustomFieldExists(liferayUser, CUSTOM_FIELD_VULNERABILITIES_VIEW_SIZE, ExpandoColumnConstants.INTEGER);
         return liferayUser.getExpandoBridge();
-    }
-
-    private static com.liferay.portal.model.User getLiferayUser(PortletRequest request, User user) throws PortalException, SystemException {
-        ThemeDisplay themeDisplay = (ThemeDisplay) request.getAttribute(WebKeys.THEME_DISPLAY);
-        long companyId = themeDisplay.getCompanyId();
-        return UserLocalServiceUtil.getUserByEmailAddress(companyId, user.email);
     }
 
     private static void ensureUserCustomFieldExists(com.liferay.portal.model.User liferayUser, String customFieldName, int customFieldType) throws PortalException, SystemException {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/signup/SignupPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/signup/SignupPortlet.java
@@ -101,7 +101,7 @@ public class SignupPortlet extends Sw360Portlet {
         try {
             com.liferay.portal.model.User liferayUser = registrant.addLifeRayUser(request);
             if (liferayUser != null) {
-                user = UserUtils.synchronizeUserWithDatabase(registrant, thriftClients, registrant::getEmail, UserUtils::fillThriftUserFromThriftUser);
+                user = UserUtils.synchronizeUserWithDatabase(registrant, thriftClients, registrant::getEmail, registrant::getExternalid, UserUtils::fillThriftUserFromThriftUser);
             }
         } catch (PortalException | SystemException e) {
             log.error(e);

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/OrganizationHelper.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/OrganizationHelper.java
@@ -53,7 +53,7 @@ public class OrganizationHelper {
     public void reassignUserToOrganizationIfNecessary(User user, Organization organization) throws PortalException, SystemException {
         if (organization != null && userIsNotInOrganization(user, organization.getOrganizationId())) {
             removeUserFromOtherOrganizations(user);
-            log.debug("OrganizationHelper adds user " + user.getEmailAddress() + " to the organization " + organization.getName());
+            log.info("OrganizationHelper adds user " + user.getEmailAddress() + " to the organization " + organization.getName());
             UserLocalServiceUtil.addOrganizationUsers(organization.getOrganizationId(), Collections.singletonList(user));
         }
     }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/PortletRequestAdapter.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/PortletRequestAdapter.java
@@ -13,13 +13,10 @@ package org.eclipse.sw360.portal.users;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.servlet.SessionMessages;
-import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceContextFactory;
-import com.liferay.portal.theme.ThemeDisplay;
 
 import javax.portlet.PortletRequest;
-import javax.servlet.http.HttpServletRequest;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -33,8 +30,7 @@ class PortletRequestAdapter implements RequestAdapter {
 
     @Override
     public long getCompanyId() {
-        ThemeDisplay themeDisplay = (ThemeDisplay) request.getAttribute(WebKeys.THEME_DISPLAY);
-        return themeDisplay.getCompanyId();
+        return UserUtils.getCompanyId(request);
     }
 
     @Override

--- a/frontend/sw360-portlet/src/main/webapp/html/preferences/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/preferences/view.jsp
@@ -37,7 +37,7 @@
             <td><sw360:out value="${sw360User.fullname}"/></td>
         </tr>
         <tr>
-            <td>Id (E-Mail):</td>
+            <td>E-mail:</td>
             <td><sw360:DisplayUserEmail email="${sw360User.email}" bare="true"/></td>
         </tr>
         <tr>

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
@@ -143,8 +143,6 @@ public class ThriftValidate {
     public static void prepareUser(User user) throws SW360Exception {
         // Check required fields
         assertNotEmpty(user.getEmail());
-        // Set id to email, in order to have human readable database
-        user.setId(user.getEmail());
         // Set type
         user.setType(TYPE_USER);
         // guarantee that `CommentMadeDuringModerationRequest` is never stored in the database as this is intended to be a transient field

--- a/libraries/lib-datahandler/src/main/thrift/users.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/users.thrift
@@ -56,14 +56,25 @@ struct User {
     11: optional bool wantsMailNotification,
     12: optional string commentMadeDuringModerationRequest,
     13: optional map<string, bool> notificationPreferences,
+    14: optional set<string> formerEmailAddresses,
 }
 
 service UserService {
 
     /**
-     * returns SW360-user with id equal to email
+     * returns SW360-user with given id
+     **/
+    User getUser(1:string id);
+
+    /**
+     * returns SW360-user with given email
      **/
     User getByEmail(1:string email);
+
+    /**
+     * searches for a SW360 user by email, or, if no such user is found, by externalId
+     **/
+    User getByEmailOrExternalId(1:string email, 2:string externalId);
 
     /**
      * get list of all SW360-users in database with name equal to parameter name

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/thrift/ThriftValidateTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/thrift/ThriftValidateTest.java
@@ -17,6 +17,7 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 
 import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.prepareUser;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 public class ThriftValidateTest {
     final String DUMMY_EMAIL_ADDRESS = "dummy.name@dummy.domain.tld";
@@ -36,8 +37,8 @@ public class ThriftValidateTest {
         user.setCommentMadeDuringModerationRequest(DUMMY_MODERATION_COMMENT);
         prepareUser(user);
 
-        assertEquals(user.getEmail(), user.getId());
-        assertEquals(TYPE_USER,user.getType());
+        assertNull(user.getId());
+        assertEquals(TYPE_USER, user.getType());
         assertFalse(user.isSetCommentMadeDuringModerationRequest());
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -166,7 +166,6 @@ class JacksonCustomizations {
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonIgnoreProperties({
-                "id",
                 "revision",
                 "externalid",
                 "wantsMailNotification",
@@ -183,6 +182,9 @@ class JacksonCustomizations {
                 "setDepartment",
                 "notificationPreferencesSize",
                 "setNotificationPreferences",
+                "formerEmailAddressesSize",
+                "formerEmailAddressesIterator",
+                "setFormerEmailAddresses",
                 "setCommentMadeDuringModerationRequest"
         })
         static abstract class UserMixin extends User {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -40,7 +40,7 @@ import org.springframework.hateoas.Resource;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.stereotype.Service;
 
-import java.util.Base64;
+import java.net.URLEncoder;
 import java.util.List;
 import java.util.Set;
 
@@ -97,8 +97,7 @@ public class RestControllerHelper {
         User embeddedUser = convertToEmbeddedUser(user);
         Resource<User> embeddedUserResource = new Resource<>(embeddedUser);
         try {
-            String userUUID = Base64.getEncoder().encodeToString(user.getEmail().getBytes("utf-8"));
-            Link userLink = linkTo(UserController.class).slash("api/users/" + userUUID).withSelfRel();
+            Link userLink = linkTo(UserController.class).slash("api/users/" + URLEncoder.encode(user.getId(), "UTF-8")).withSelfRel();
             embeddedUserResource.add(userLink);
         } catch (Exception e) {
             LOGGER.error("cannot create embedded user with email: " + user.getEmail());

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
@@ -46,6 +46,15 @@ public class Sw360UserService {
         }
     }
 
+    public User getUser(String id) {
+        try {
+            UserService.Iface sw360UserClient = getThriftUserClient();
+            return sw360UserClient.getUser(id);
+        } catch (TException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private UserService.Iface getThriftUserClient() throws TTransportException {
         THttpClient thriftClient = new THttpClient(thriftServerUrl + "/users/thrift");
         TProtocol protocol = new TCompactProtocol(thriftClient);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserResourceProcessor.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/UserResourceProcessor.java
@@ -18,7 +18,7 @@ import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.ResourceProcessor;
 import org.springframework.stereotype.Component;
 
-import java.util.Base64;
+import java.net.URLEncoder;
 
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 
@@ -31,8 +31,7 @@ class UserResourceProcessor implements ResourceProcessor<Resource<User>> {
     public Resource<User> process(Resource<User> resource) {
         try {
             User user = resource.getContent();
-            String userUUID = Base64.getEncoder().encodeToString(user.getEmail().getBytes("utf-8"));
-            Link selfLink = linkTo(UserController.class).slash("api/users/" + userUUID).withSelfRel();
+            Link selfLink = linkTo(UserController.class).slash("api/users/" + URLEncoder.encode(user.getId(), "UTF-8")).withSelfRel();
             resource.add(selfLink);
             return resource;
         } catch (Exception e) {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
@@ -55,7 +55,7 @@ public class ComponentTest extends TestIntegrationBase {
         given(this.componentServiceMock.getComponentsForUser(anyObject())).willReturn(componentList);
 
         User user = new User();
-        user.setId("admin@sw360.org");
+        user.setId("123456789");
         user.setEmail("admin@sw360.org");
         user.setFullname("John Doe");
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -55,7 +55,7 @@ public class ProjectTest extends TestIntegrationBase {
         given(this.projectServiceMock.getProjectsForUser(anyObject())).willReturn(projectList);
 
         User user = new User();
-        user.setId("admin@sw360.org");
+        user.setId("123456789");
         user.setEmail("admin@sw360.org");
         user.setFullname("John Doe");
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/UserTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/UserTest.java
@@ -43,13 +43,13 @@ public class UserTest extends TestIntegrationBase {
 		List<User> userList = new ArrayList<>();
 
         User user = new User();
-        user.setId("admin@sw360.org");
+        user.setId("123456789");
         user.setEmail("admin@sw360.org");
         user.setFullname("John Doe");
         userList.add(user);
 
         user = new User();
-        user.setId("jane@sw360.org");
+        user.setId("987654321");
         user.setEmail("jane@sw360.org");
         user.setFullname("Jane Doe");
         userList.add(user);

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/AttachmentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/AttachmentSpecTest.java
@@ -96,7 +96,7 @@ public class AttachmentSpecTest extends TestRestDocsSpecBase {
         given(this.attachmentServiceMock.getAttachmentByIdForUser(eq(attachment.getAttachmentContentId()), anyObject())).willReturn(attachmentInfo);
 
         User user = new User();
-        user.setId("admin@sw360.org");
+        user.setId("123456789");
         user.setEmail("admin@sw360.org");
         user.setFullname("John Doe");
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -110,7 +110,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
         given(this.componentServiceMock.searchComponentByName(eq(angularComponent.getName()))).willReturn(componentListByName);
 
         User user = new User();
-        user.setId("admin@sw360.org");
+        user.setId("123456789");
         user.setEmail("admin@sw360.org");
         user.setFullname("John Doe");
         user.setDepartment("sw360");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -164,7 +164,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.releaseServiceMock.getReleaseForUserById(eq(release2.getId()), anyObject())).willReturn(release2);
 
         User user = new User();
-        user.setId("admin@sw360.org");
+        user.setId("123456789");
         user.setEmail("admin@sw360.org");
         user.setFullname("John Doe");
         user.setDepartment("sw360");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -104,7 +104,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         given(this.releaseServiceMock.getReleaseForUserById(eq(release.getId()), anyObject())).willReturn(release);
 
         User user = new User();
-        user.setId("admin@sw360.org");
+        user.setId("123456789");
         user.setEmail("admin@sw360.org");
         user.setFullname("John Doe");
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/UserSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/UserSpecTest.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
+import com.google.common.collect.Sets;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
@@ -49,25 +50,27 @@ public class UserSpecTest extends TestRestDocsSpecBase {
     private User user;
 
     @Before
-    public void before() throws UnsupportedEncodingException {
+    public void before() {
         List<User> userList = new ArrayList<>();
 
         user = new User();
         user.setEmail("admin@sw360.org");
-        user.setId(Base64.getEncoder().encodeToString(user.getEmail().getBytes("utf-8")));
+        user.setId("4784587578e87989");
         user.setUserGroup(UserGroup.ADMIN);
         user.setFullname("John Doe");
         user.setGivenname("John");
         user.setLastname("Doe");
         user.setDepartment("SW360 Administration");
         user.setWantsMailNotification(true);
+        user.setFormerEmailAddresses(Sets.newHashSet("admin_bachelor@sw360.org"));
         userList.add(user);
 
         given(this.userServiceMock.getUserByEmail("admin@sw360.org")).willReturn(user);
+        given(this.userServiceMock.getUser("4784587578e87989")).willReturn(user);
 
         User user2 = new User();
         user2.setEmail("jane@sw360.org");
-        user2.setId(Base64.getEncoder().encodeToString(user.getEmail().getBytes("utf-8")));
+        user2.setId("frwey45786rwe");
         user2.setUserGroup(UserGroup.USER);
         user2.setFullname("Jane Doe");
         user2.setGivenname("Jane");
@@ -98,9 +101,9 @@ public class UserSpecTest extends TestRestDocsSpecBase {
     }
 
     @Test
-    public void should_document_get_user() throws Exception {
+    public void should_document_get_user_by_id() throws Exception {
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
-        mockMvc.perform(get("/api/users/" + user.getId())
+        mockMvc.perform(get("/api/users/byid/" + user.getId())
                 .header("Authorization", "Bearer " + accessToken)
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk())
@@ -109,12 +112,38 @@ public class UserSpecTest extends TestRestDocsSpecBase {
                                 linkWithRel("self").description("The <<resources-users,User resource>>")
                         ),
                         responseFields(
+                                fieldWithPath("id").description("The user's id"),
                                 fieldWithPath("email").description("The user's email"),
                                 fieldWithPath("userGroup").description("The user group, possible values are: " + Arrays.asList(UserGroup.values())),
                                 fieldWithPath("fullName").description("The users's full name"),
                                 fieldWithPath("givenName").description("The user's given name"),
                                 fieldWithPath("lastName").description("The user's last name"),
                                 fieldWithPath("department").description("The user's company department"),
+                                fieldWithPath("formerEmailAddresses").description("The user's former email addresses"),
+                                fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
+                        )));
+    }
+
+    @Test
+    public void should_document_get_user() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/users/" + user.getEmail())
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        links(
+                                linkWithRel("self").description("The <<resources-users,User resource>>")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").description("The user's id"),
+                                fieldWithPath("email").description("The user's email"),
+                                fieldWithPath("userGroup").description("The user group, possible values are: " + Arrays.asList(UserGroup.values())),
+                                fieldWithPath("fullName").description("The users's full name"),
+                                fieldWithPath("givenName").description("The user's given name"),
+                                fieldWithPath("lastName").description("The user's last name"),
+                                fieldWithPath("department").description("The user's company department"),
+                                fieldWithPath("formerEmailAddresses").description("The user's former email addresses"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/VulnerabilitySpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/VulnerabilitySpecTest.java
@@ -86,7 +86,7 @@ public class VulnerabilitySpecTest extends TestRestDocsSpecBase {
         vulnerabilityList.add(vulnerability2);
 
         User user = new User();
-        user.setId("admin@sw360.org");
+        user.setId("123456789");
         user.setEmail("admin@sw360.org");
         user.setFullname("John Doe");
 


### PR DESCRIPTION
- handle external change of user email address by storing previously known email addresses and falling back to search by former addresses when necessary
- introduce generic ids for users instead of using emails as ids

closes eclipse/sw360#242