### PR TITLE
fix(homepage): Truncate long document names in homepage datatables

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/css/dataTable_SiemensHomepage.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/dataTable_SiemensHomepage.css
@@ -156,6 +156,10 @@ table.display tr.heading2 td {
 
 table.display td {
 	padding:  0.5em 1.5em;
+	white-space: nowrap;
+	text-overflow:ellipsis;
+	overflow: hidden;
+	max-width:1px;
 }
 
 table.display td.center {

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/mycomponents/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/mycomponents/view.jsp
@@ -25,6 +25,10 @@
 
 <div id="myComponentsDiv" class="homepageListingTable">
     <table id="myComponentsTable" cellpadding="0" cellspacing="0" border="0" class="display">
+         <colgroup>
+               <col style="width: 60%;"/>
+               <col style="width: 40%;"/>
+         </colgroup>
     </table>
 </div>
 
@@ -38,7 +42,7 @@
         result.push({
             "DT_RowId": "${component.id}",
             "0": "<sw360:DisplayComponentLink component="${component}"/>",
-            "1": '<sw360:out value="${component.description}" maxChar="30"/>'
+            "1": '<sw360:out value="${component.description}"/>'
         });
 
         </core_rt:forEach>

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/myprojects/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/myprojects/view.jsp
@@ -24,6 +24,10 @@
 </div>
 <div id="myProjectsDiv" class="homepageListingTable">
     <table id="myProjectsTable" cellpadding="0" cellspacing="0" border="0" class="display">
+         <colgroup>
+               <col style="width: 60%;"/>
+               <col style="width: 40%;"/>
+         </colgroup>
     </table>
 </div>
 
@@ -36,7 +40,7 @@
         result.push({
             "DT_RowId": "${project.id}",
             "0": "<sw360:DisplayProjectLink project="${project}"/>",
-            "1": '<sw360:out value="${project.description}" maxChar="30"/>'
+            "1": '<sw360:out value="${project.description}"/>'
         });
         </core_rt:forEach>
 

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/mytaskassignments/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/mytaskassignments/view.jsp
@@ -31,6 +31,10 @@
 
 <div id="taskassignmentDiv" class="homepageListingTable">
     <table id="taskassignmentTable" cellpadding="0" cellspacing="0" border="0" class="display">
+         <colgroup>
+               <col style="width: 60%;"/>
+               <col style="width: 40%;"/>
+         </colgroup>
     </table>
 </div>
 

--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/mytasksubmissions/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/mytasksubmissions/view.jsp
@@ -31,6 +31,11 @@
 </div>
 <div id="tasksubmissionDiv" class="homepageListingTable">
     <table id="tasksubmissionTable" cellpadding="0" cellspacing="0" border="0" class="display">
+         <colgroup>
+               <col style="width: 60%;"/>
+               <col style="width: 40%;"/>
+               <col style="width: 80px;"/>
+         </colgroup>
     </table>
 </div>
 


### PR DESCRIPTION
- truncates the datatable content on homepage

closes eclipse/sw360#156