### PR TITLE
fix(search): Remove wildcard in advanced search for projects and components

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectSearchHandler.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import static org.eclipse.sw360.datahandler.couchdb.lucene.LuceneAwareDatabaseConnector.prepareWildcardQuery;
+
 public class ProjectSearchHandler {
 
     private static final LuceneSearchView luceneSearchView = new LuceneSearchView("lucene", "projects",
@@ -80,6 +82,10 @@ public class ProjectSearchHandler {
 
     public List<Project> search(String text, final Map<String , Set<String > > subQueryRestrictions, User user ){
         return connector.searchProjectViewWithRestrictionsAndFilter(luceneSearchView, text, subQueryRestrictions, user);
+    }
+
+    public List<Project> search(String searchText) {
+        return connector.searchView(Project.class, luceneSearchView, prepareWildcardQuery(searchText));
     }
 
 }

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseSearchHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Siemens AG, 2018. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.couchdb.lucene.LuceneAwareDatabaseConnector;
+import org.eclipse.sw360.datahandler.couchdb.lucene.LuceneSearchView;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.ektorp.http.HttpClient;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.eclipse.sw360.datahandler.couchdb.lucene.LuceneAwareDatabaseConnector.prepareWildcardQuery;
+
+/**
+ * Lucene search for the Release class
+ *
+ * @author thomas.maier@evosoft.com
+ */
+public class ReleaseSearchHandler {
+
+    private static final LuceneSearchView luceneSearchView
+            = new LuceneSearchView("lucene", "releases",
+            "function(doc) {" +
+                    "  if(doc.type == 'release') { " +
+                    "      var ret = new Document();" +
+                    "      ret.add(doc.name);  " +
+                    "      ret.add(doc.version);  " +
+                    "      return ret;" +
+                    "  }" +
+                    "}");
+
+    private final LuceneAwareDatabaseConnector connector;
+
+    public ReleaseSearchHandler(Supplier<HttpClient> httpClient, String dbName) throws IOException {
+        connector = new LuceneAwareDatabaseConnector(httpClient, dbName);
+        connector.addView(luceneSearchView);
+    }
+
+    public List<Release> search(String searchText) {
+        return connector.searchView(Release.class, luceneSearchView, prepareWildcardQuery(searchText));
+    }
+}

--- a/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -55,6 +55,10 @@ public class ProjectHandler implements ProjectService.Iface {
     // SUMMARY GETTERS //
     /////////////////////
 
+    @Override
+    public List<Project> search(String text) throws TException {
+        return searchHandler.search(text);
+    }
 
     @Override
     public List<Project> refineSearch(String text, Map<String, Set<String>> subQueryRestrictions, User user) throws TException {

--- a/backend/src/src-search/src/main/java/org/eclipse/sw360/search/db/AbstractDatabaseSearchHandler.java
+++ b/backend/src/src-search/src/main/java/org/eclipse/sw360/search/db/AbstractDatabaseSearchHandler.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.eclipse.sw360.datahandler.couchdb.lucene.LuceneAwareDatabaseConnector.prepareWildcardQuery;
+
 /**
  * Class for accessing the Lucene connector on the CouchDB database
  *
@@ -68,7 +70,7 @@ public abstract class AbstractDatabaseSearchHandler {
      * Search the database for a given string
      */
     public List<SearchResult> search(String text, User user) {
-        String queryString = text + "*";
+        String queryString = prepareWildcardQuery(text);
         return getSearchResults(queryString, user);
     }
 
@@ -81,14 +83,8 @@ public abstract class AbstractDatabaseSearchHandler {
             return search(text, user);
         }
 
-        final Function<String, String> addType = new Function<String, String>() {
-            @Override
-            public String apply(String input) {
-                return "type:"+input;
-            }
-        };
-
-        String query  = "( "+ Joiner.on(" OR ").join(FluentIterable.from(typeMask).transform(addType)) + " ) AND " +text+"*";
+        final Function<String, String> addType = input -> "type:" + input;
+        String query = "( " + Joiner.on(" OR ").join(FluentIterable.from(typeMask).transform(addType)) + " ) AND " + prepareWildcardQuery(text);
         return getSearchResults(query, user);
     }
 

--- a/backend/src/src-users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
+++ b/backend/src/src-users/src/main/java/org/eclipse/sw360/users/db/UserDatabaseHandler.java
@@ -12,7 +12,7 @@ package org.eclipse.sw360.users.db;
 
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.db.UserRepository;
-import org.eclipse.sw360.datahandler.db.UserSearch;
+import org.eclipse.sw360.datahandler.db.UserSearchHandler;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ThriftValidate;
@@ -38,13 +38,13 @@ public class UserDatabaseHandler {
      */
     private DatabaseConnector db;
     private UserRepository repository;
-    private UserSearch userSearch;
+    private UserSearchHandler userSearchHandler;
 
     public UserDatabaseHandler(Supplier<HttpClient> httpClient, String dbName) throws IOException {
         // Create the connector
         db = new DatabaseConnector(httpClient, dbName);
         repository = new UserRepository(db);
-        userSearch = new UserSearch(db);
+        userSearchHandler = new UserSearchHandler(db);
     }
 
     public User getByEmail(String email) {
@@ -88,7 +88,7 @@ public class UserDatabaseHandler {
     }
 
     public List<User> searchUsers(String searchText) {
-        return userSearch.searchByNameAndEmail(searchText);
+        return userSearchHandler.searchByNameAndEmail(searchText);
     }
 
     public User getByExternalId(String externalId) {

--- a/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorHandler.java
+++ b/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorHandler.java
@@ -10,14 +10,14 @@
  */
 package org.eclipse.sw360.vendors;
 
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
+import org.eclipse.sw360.datahandler.db.VendorSearchHandler;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vendors.VendorService;
-import org.eclipse.sw360.datahandler.db.VendorSearch;
-import org.apache.thrift.TException;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -35,12 +35,12 @@ import static org.eclipse.sw360.datahandler.common.SW360Assert.*;
 public class VendorHandler implements VendorService.Iface {
 
     private final VendorDatabaseHandler vendorDatabaseHandler;
-    private final VendorSearch vendorSearch;
+    private final VendorSearchHandler vendorSearchHandler;
 
     public VendorHandler() throws IOException {
         DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE);
         vendorDatabaseHandler = new VendorDatabaseHandler(databaseConnector);
-        vendorSearch = new VendorSearch(databaseConnector);     // Remove release id from component
+        vendorSearchHandler = new VendorSearchHandler(databaseConnector);     // Remove release id from component
     }
 
     @Override
@@ -72,12 +72,12 @@ public class VendorHandler implements VendorService.Iface {
 
     @Override
     public List<Vendor> searchVendors(String searchText) throws TException {
-        return vendorSearch.search(searchText);
+        return vendorSearchHandler.search(searchText);
     }
 
     @Override
     public Set<String> searchVendorIds(String searchText) throws TException {
-        return vendorSearch.searchIds(searchText);
+        return vendorSearchHandler.searchIds(searchText);
     }
 
 

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
@@ -105,21 +105,21 @@
                 <td>
                     <label for="project_version">Project Version</label>
                     <input type="text" class="searchbar" name="<portlet:namespace/><%=Project._Fields.VERSION%>"
-                           value="${version}" id="project_version" class="filterInput">
+                           value="<sw360:out value="${version}"/>" id="project_version" class="filterInput">
                 </td>
             </tr>
             <tr>
                 <td>
                     <label for="project_type">Project Type</label>
                     <input type="text" class="searchbar" name="<portlet:namespace/><%=Project._Fields.PROJECT_TYPE%>"
-                           value="${projectType}" id="project_type" class="filterInput">
+                           value="<sw360:out value="${projectType}"/>" id="project_type" class="filterInput">
                 </td>
             </tr>
             <tr>
                 <td>
                     <label for="project_responsible">Project Responsible (Email)</label>
                     <input type="text" class="searchbar" name="<portlet:namespace/><%=Project._Fields.PROJECT_RESPONSIBLE%>"
-                           value="${projectResponsible}" id="project_responsible" class="filterInput">
+                           value="<sw360:out value="${projectResponsible}"/>" id="project_responsible" class="filterInput">
                 </td>
             </tr>
             <tr>
@@ -130,9 +130,9 @@
                                 <core_rt:if test="${empty businessUnit}"> selected="selected"</core_rt:if>
                         ></option>
                         <core_rt:forEach items="${organizations}" var="org">
-                            <option value="${org.name}" class="textlabel stackedLabel"
+                            <option value="<sw360:out value="${org.name}"/>" class="textlabel stackedLabel"
                                     <core_rt:if test="${org.name == businessUnit}"> selected="selected"</core_rt:if>
-                            >${org.name}</option>
+                            ><sw360:out value="${org.name}"/></option>
                         </core_rt:forEach>
                     </select>
                 </td>
@@ -141,14 +141,14 @@
                 <td>
                     <label for="state">State</label>
                     <input type="text" class="searchbar" name="<portlet:namespace/><%=Project._Fields.STATE%>"
-                           value="${state}" id="state" class="filterInput">
+                           value="<sw360:out value="${state}"/>" id="state" class="filterInput">
                 </td>
             </tr>
             <tr>
                 <td>
                     <label for="tag">Tag</label>
                     <input type="text" class="searchbar" name="<portlet:namespace/><%=Project._Fields.TAG%>"
-                           value="${tag}" id="tag" class="filterInput">
+                           value="<sw360:out value="${tag}"/>" id="tag" class="filterInput">
                 </td>
             </tr>
 

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/searchReleases.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/searchReleases.jsp
@@ -78,7 +78,7 @@
         var firstRunForReleasesTable = true;
 
         Liferay.on('allPortletsReady', function() {
-                bindkeyPressToClick('searchrelease', 'searchbuttonrelease');}
+                bindkeyPressToClick('searchrelease', 'releaseSearchButton');}
         );
 
         function destroyReleaseDataTable() {

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -352,7 +352,12 @@ service ComponentService {
     /**
      * search components in database that match subQueryRestrictions
      **/
-    list<Component> refineSearch(1: string text, 2: map<string ,  set<string > > subQueryRestrictions);
+    list<Component> refineSearch(1: string text, 2: map<string, set<string>> subQueryRestrictions);
+
+    /**
+     * global search function to list releases which match the text argument
+     */
+    list<Release> searchReleases(1: string text);
 
     /**
      * get short summary of release by release name prefix

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -169,6 +169,11 @@ service ProjectService {
     // Search functions
 
     /**
+     * global search function to list projects which match the text argument
+     */
+    list<Project> search(1: string text);
+
+    /**
      * returns a list of projects which match `text` and the
      * `subQueryRestrictions` and are visible to the `user`
      */


### PR DESCRIPTION
- remove all special characters (sanitizeQueryInput)
- lucene search for linked releases or projects
- set focus to search button (enter) for linked releases
- advanced search attributes for projects should be sticky
- add sw360 out tag for project advanced attributes

closes eclipse/sw360#129