### PR TITLE
fix(datahandler): Handle duplicate names in source code bundle generation

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/AttachmentPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/AttachmentPortletUtils.java
@@ -127,8 +127,7 @@ public class AttachmentPortletUtils extends AttachmentFrontendUtils {
         String filename;
         String contentType;
         if(attachments.size() == 1){
-            filename = downloadFileName
-                    .orElse(attachments.get(0).getFilename());
+            filename = attachments.get(0).getFilename();
             contentType = attachments.get(0).getContentType();
         } else {
             filename = downloadFileName

--- a/libraries/commonIO/src/main/java/org/eclipse/sw360/commonIO/AttachmentFrontendUtils.java
+++ b/libraries/commonIO/src/main/java/org/eclipse/sw360/commonIO/AttachmentFrontendUtils.java
@@ -53,7 +53,8 @@ public class AttachmentFrontendUtils {
         if(attachments == null || attachments.size() == 0){
             throw new SW360Exception("Tried to download empty set of Attachments");
         }else if(attachments.size() == 1){
-            return getConnector().getAttachmentStream(attachments.stream().findAny().get(), user, context);
+            // Temporary solutions, permission check needs to be implemented (getAttachmentStream)
+            return getConnector().unsafeGetAttachmentStream(attachments.iterator().next());
         } else {
             return getConnector().getAttachmentBundleStream(new HashSet<>(attachments), user, context);
         }

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2014-2016.
+ * Copyright Siemens AG, 2014-2018.
  * With modifications by Bosch Software Innovations GmbH, 2016
  * Part of the SW360 Portal Project.
  *
@@ -56,6 +56,7 @@ import static org.apache.log4j.LogManager.getLogger;
 public class CommonUtils {
 
     public static final String SYSTEM_CONFIGURATION_PATH = "/etc/sw360";
+    private static List<String> MULTIPLE_FILE_EXTENSIONS = Arrays.asList(".tar.gz", ".tar.bz2", ".tar.xz", ".tar.lz", ".tar.lzma");
 
     private CommonUtils() {
         // Utility class with only static functions
@@ -729,6 +730,19 @@ public class CommonUtils {
         return map.entrySet().stream()
                 .map(e -> ((Map.Entry<String, Set<Object>>) e).getValue())
                 .filter(s -> !s.isEmpty()).findAny();
+    }
+
+    public static String getExtensionFromFileName(String fileName) {
+        if (fileName == null) {
+            return null;
+        }
+        for (String multipleExtension : MULTIPLE_FILE_EXTENSIONS) {
+            if (fileName.toLowerCase().endsWith(multipleExtension)) {
+                int lastIndex = fileName.toLowerCase().lastIndexOf(multipleExtension);
+                return fileName.substring(lastIndex + 1);
+            }
+        }
+        return FilenameUtils.getExtension(fileName);
     }
 
 }

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/common/CommonUtilsTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/common/CommonUtilsTest.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import static org.eclipse.sw360.datahandler.common.CommonUtils.*;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -243,5 +244,14 @@ public class CommonUtilsTest {
         assertThat(getIntOrDefault("-25", 25), is(-25));
         assertThat(getIntOrDefault("25z", 6), is(6));
         assertThat(getIntOrDefault( null, 42), is(42));
+    }
+
+    @Test
+    public void testGetFileNameExtension() {
+        assertThat(getExtensionFromFileName("example.doc"), is("doc"));
+        assertThat(getExtensionFromFileName("source.TAR.gz"), is("TAR.gz"));
+        assertThat(getExtensionFromFileName("testfile.test.V1 12.jpg"), is("jpg"));
+        assertThat(getExtensionFromFileName("testfile-without-extension"), is(""));
+        assertNull(getExtensionFromFileName(null));
     }
 }

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentStreamConnectorTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentStreamConnectorTest.java
@@ -29,7 +29,10 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.ZipEntry;
 
 import static org.eclipse.sw360.datahandler.common.Duration.durationOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -190,6 +193,24 @@ public class AttachmentStreamConnectorTest {
         }
 
         verify(part1).close();
+    }
+
+    @Test
+    public void testPrintAcceptedZipEntryName() {
+        assertThat(attachmentStreamConnector.printAcceptedZipEntryName("source.zip", 0), is("source (0).zip"));
+        assertThat(attachmentStreamConnector.printAcceptedZipEntryName("source.JPG", 2), is("source (2).JPG"));
+        assertThat(attachmentStreamConnector.printAcceptedZipEntryName("source..v1.001.tar.xz", 3), is("source..v1.001 (3).tar.xz"));
+        assertThat(attachmentStreamConnector.printAcceptedZipEntryName("source", 4), is("source (4)"));
+    }
+
+    @Test
+    public void testGetDeduplicatedZipEntry() {
+        Map<String, Integer> fileNameUsageMap = new HashMap<>();
+        ZipEntry zipEntry =  attachmentStreamConnector.getDeduplicatedZipEntry("source.zip", fileNameUsageMap);
+        assertThat(zipEntry.getName(), is("source.zip"));
+        fileNameUsageMap.put("source.zip", 1);
+        ZipEntry zipEntry2 =  attachmentStreamConnector.getDeduplicatedZipEntry("source.zip", fileNameUsageMap);
+        assertThat(zipEntry2.getName(), is("source (1).zip"));
     }
 
 }


### PR DESCRIPTION
- handles duplicate attachment names in source code bundle generation zip
- switched to unsafeAttachmentDownload for single attachment selection / **WORKAROUND**
_(user select only one attachment in the source code bundle generation)_

Example of source code attachments with duplicate name:
- example.zip
- example (1).zip
- example (2).zip
- source.tar.gz
- source (1).tar.gz

closes eclipse/sw360#126