### PR TITLE
fix(user): Change user id field to optional

### DIFF
--- a/backend/src/src-attachments/src/test/java/org/eclipse/sw360/attachments/AttachmentHandlerTest.java
+++ b/backend/src/src-attachments/src/test/java/org/eclipse/sw360/attachments/AttachmentHandlerTest.java
@@ -83,13 +83,13 @@ public class AttachmentHandlerTest {
 
     @Test
     public void testVacuum_OnlyAdminCanRun() throws Exception {
-        final RequestSummary requestSummary = handler.vacuumAttachmentDB(new User("a", "a", "a").setUserGroup(UserGroup.USER), ImmutableSet.of("A1", "A2"));
+        final RequestSummary requestSummary = handler.vacuumAttachmentDB(new User("a", "a").setUserGroup(UserGroup.USER), ImmutableSet.of("A1", "A2"));
         assertThat(requestSummary.requestStatus, is(RequestStatus.FAILURE));
     }
 
     @Test
     public void testVacuum_AllIdsUsedIsNoop() throws Exception {
-        final RequestSummary requestSummary = handler.vacuumAttachmentDB(new User("a", "a", "a").setUserGroup(UserGroup.ADMIN), ImmutableSet.of("A1", "A2"));
+        final RequestSummary requestSummary = handler.vacuumAttachmentDB(new User("a", "a").setUserGroup(UserGroup.ADMIN), ImmutableSet.of("A1", "A2"));
         assertThat(requestSummary.requestStatus, is(RequestStatus.SUCCESS));
         assertThat(requestSummary.totalElements, is(2));
         assertThat(requestSummary.totalAffectedElements, is(0));
@@ -103,7 +103,7 @@ public class AttachmentHandlerTest {
 
     @Test
     public void testVacuum_UnusedIdIsDeleted() throws Exception {
-        final RequestSummary requestSummary = handler.vacuumAttachmentDB(new User("a", "a", "a").setUserGroup(UserGroup.ADMIN), ImmutableSet.of("A1"));
+        final RequestSummary requestSummary = handler.vacuumAttachmentDB(new User("a", "a").setUserGroup(UserGroup.ADMIN), ImmutableSet.of("A1"));
         assertThat(requestSummary.requestStatus, is(RequestStatus.SUCCESS));
         assertThat(requestSummary.totalElements, is(2));
         assertThat(requestSummary.totalAffectedElements, is(1));

--- a/libraries/lib-datahandler/src/main/thrift/users.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/users.thrift
@@ -43,7 +43,7 @@ enum RequestedAction {
 
 struct User {
 
-    1: required string id,
+    1: optional string id,
     2: optional string revision,
     3: optional string type = "user",
     4: required string email,

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/jgivens/WhenComputePermissions.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/jgivens/WhenComputePermissions.java
@@ -35,10 +35,8 @@ public class WhenComputePermissions  extends Stage<WhenComputePermissions> {
     @ProvidedScenarioState
     List<RequestedAction> allowedActions;
 
-    private static String DUMMY_ID = "DAU";
-
     public WhenComputePermissions the_highest_allowed_action_is_computed_for_user_$_with_user_group_$_and_department_$(@Quoted String userEmail, @TEnumToString UserGroup userGroup, @Quoted String userDept) {
-        final User user = new User(DUMMY_ID, userEmail, userDept).setUserGroup(userGroup);
+        final User user = new User(userEmail, userDept).setUserGroup(userGroup);
 
         final DocumentPermissions<Project> projectDocumentPermissions = PermissionUtils.makePermission(project, user);
 

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/jgivens/WhenComputeVisibility.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/jgivens/WhenComputeVisibility.java
@@ -31,22 +31,18 @@ public class WhenComputeVisibility extends Stage<WhenComputeVisibility> {
     @ProvidedScenarioState
     Boolean isVisible;
 
-
-    private static String DUMMY_ID = "DAU";
     private static String DUMMY_MAIL = "DAU@dau.com";
     private static String DUMMY_DEP = "definitleyTheWrongDepartment YO HO HO";
 
-
-
     public WhenComputeVisibility the_visibility_is_computed_for_department_$_and_user_group_$(@Quoted String department, @TEnumToString UserGroup userGroup) {
-        final User user = new User(DUMMY_ID, DUMMY_MAIL, department).setUserGroup(userGroup);
+        final User user = new User(DUMMY_MAIL, department).setUserGroup(userGroup);
 
         isVisible = ProjectPermissions.isVisible(user).test(project);
         return self();
     }
 
     public WhenComputeVisibility the_visibility_is_computed_for_the_wrong_department_and_the_user_$(@Quoted String mail) {
-        final User user = new User(DUMMY_ID, mail, DUMMY_DEP).setUserGroup(UserGroup.USER);
+        final User user = new User(mail, DUMMY_DEP).setUserGroup(UserGroup.USER);
 
         isVisible = ProjectPermissions.isVisible(user).test(project);
         return self();


### PR DESCRIPTION
- change the user id field to optional

Note: Only `email` and `department` is required for a `User` object.

closes eclipse/sw360#277

(requires new sw360 release version?)