### PR TITLE
fix(licenses): Validate obligation list in LicenseDatabaseHandler

### DIFF
--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
@@ -686,7 +686,10 @@ public class LicenseDatabaseHandler {
 
         Map<String, Obligation> obligationIdMap = null;
         if (!obligationIdsToFetch.isEmpty()) {
-            obligationIdMap = ThriftUtils.getIdMap(getObligationsByIds(obligationIdsToFetch));
+            List<Obligation> obligations = getObligationsByIds(obligationIdsToFetch);
+            if (obligations != null && !obligations.isEmpty()) {
+                obligationIdMap = ThriftUtils.getIdMap(obligations);
+            }
         }
         if (obligationIdMap == null) {
             obligationIdMap = Collections.emptyMap();


### PR DESCRIPTION
- validates the obligation object before `ThriftUtils.getIdMap`

closes eclipse/sw360#287