### PR TITLE
chore(projects): Change the file name of export spreadsheet

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/VendorPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/VendorPortlet.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.portal.portlets.admin;
 
 import com.google.common.collect.Sets;
 import com.liferay.portal.kernel.portlet.PortletResponseUtil;
+import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
@@ -72,8 +73,8 @@ public class VendorPortlet extends Sw360Portlet {
         try {
             VendorService.Iface client = thriftClients.makeVendorClient();
             List<Vendor> vendors = client.getAllVendors();
-
-            PortletResponseUtil.sendFile(request, response, "Vendors.xlsx", exporter.makeExcelExport(vendors), CONTENT_TYPE_OPENXML_SPREADSHEET);
+            String filename = String.format("vendors-%s.xlsx", SW360Utils.getCreatedOn());
+            PortletResponseUtil.sendFile(request, response, filename, exporter.makeExcelExport(vendors), CONTENT_TYPE_OPENXML_SPREADSHEET);
         } catch (IOException | TException e) {
             log.error("An error occurred while generating the Excel export", e);
             response.setProperty(ResourceResponse.HTTP_STATUS_CODE,

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -349,7 +349,8 @@ public class ComponentPortlet extends FossologyAwarePortlet {
             List<Component> components = getFilteredComponentList(request);
             ComponentExporter exporter = new ComponentExporter(thriftClients.makeComponentClient(), components, user,
                     extendedByReleases);
-            PortletResponseUtil.sendFile(request, response, "Components.xlsx", exporter.makeExcelExport(components),
+            String filename = String.format("components-%s.xlsx", SW360Utils.getCreatedOn());
+            PortletResponseUtil.sendFile(request, response, filename, exporter.makeExcelExport(components),
                     CONTENT_TYPE_OPENXML_SPREADSHEET);
         } catch (IOException | SW360Exception e) {
             log.error("An error occurred while generating the Excel export", e);


### PR DESCRIPTION
The file name of a spreadsheet for a specific project contains now:
- project (constant value)
- project name and version
- created on date

e.g.
**Filename (export spreadsheet in a view):** 
`projects-2018-06-14.xlsx` or `components-2018-06-14.xlsx`

**Filename (selected project):**
`project-MyTestProject-V1.2-2018-06-14.xlsx`

closes eclipse/sw360#223