### PR TITLE
fix(component): Do not update component properties if they are not in request

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortletUtils.java
@@ -128,11 +128,10 @@ public abstract class ComponentPortletUtils {
         for (Component._Fields field : extractFieldsForComponentUpdate(requestParams, component)) {
             setFieldValue(request, component, field);
         }
-        if (!requestParams.contains("updateOnlyRequested")) {
-            component.setAttachments(PortletUtils.updateAttachmentsFromRequest(request, component.getAttachments()));
-            component.setRoles(PortletUtils.getCustomMapFromRequest(request));
-            component.setExternalIds(PortletUtils.getExternalIdMapFromRequest(request));
-        }
+
+        component.setAttachments(PortletUtils.updateAttachmentsFromRequest(request, component.getAttachments()));
+        component.setRoles(PortletUtils.getCustomMapFromRequest(request));
+        component.setExternalIds(PortletUtils.getExternalIdMapFromRequest(request));
     }
 
     private static List<Component._Fields> extractFieldsForComponentUpdate(List<String> requestParams, Component component) {


### PR DESCRIPTION
@mcjaeger 
I found a bug at editing a component:

* assume a component with two releases
* in the releases, you have some values for aggregation, such as programming languages
* on the component record, the values for the releases show up there in the "release aggregated data" section
* if you then edit the component at a plain attribute, such as "homepage" and save, then the release aggregated data is lost 7 empty.


Here is solution - we can update component properties if they are in request. If not, we will not setup empty data from request to component entity before save.