### PR TITLE
feat(licenses): allow to create unchecked licenses

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/LicenseSummary.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/LicenseSummary.java
@@ -39,6 +39,7 @@ public class LicenseSummary extends DocumentSummary<License> {
                 copy.setShortname(document.getId());
                 copyField(document, copy, _Fields.FULLNAME);
                 copyField(document, copy, _Fields.LICENSE_TYPE_DATABASE_ID);
+                copyField(document, copy, _Fields.CHECKED);
         }
 
         return copy;

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/detail.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/detail.jsp
@@ -54,9 +54,14 @@
 </portlet:actionURL>
 <core_rt:if test="${empty attributeNotFoundException}">
     <div id="header"></div>
-    <p class="pageHeader"><span
-            class="pageHeaderBigSpan">License: <sw360:out value="${licenseDetail.fullname}"/> (<sw360:out value="${licenseDetail.shortname}"/>)</span>
-        <core_rt:if test="${isUserAtLeastClearingAdmin == 'Yes'}">
+    <p class="pageHeader">
+        <span class="pageHeaderBigSpan">
+            <core_rt:if test="${licenseDetail.checked == false}">
+                <alert>UNCHECKED</alert>
+            </core_rt:if>
+            License: <sw360:out value="${licenseDetail.fullname}"/> (<sw360:out value="${licenseDetail.shortname}"/>)
+        </span>
+        <core_rt:if test="${isUserAtLeastClearingAdmin == 'Yes' || licenseDetail.checked == false}">
          <span class="pull-right">
              <input type="button" onclick="editLicense()" id="edit" value="Edit License Details and Text"
                     class="addButton">

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/edit.jsp
@@ -38,6 +38,7 @@
 </portlet:actionURL>
 
 <c:catch var="attributeNotFoundException">
+    <jsp:useBean id="isUserAtLeastClearingAdmin" class="java.lang.String" scope="request" />
     <jsp:useBean id="licenseDetail" type="org.eclipse.sw360.datahandler.thrift.licenses.License" scope="request" />
     <jsp:useBean id="licenseTypeChoice" class="java.util.ArrayList" scope="request" />
     <core_rt:set  var="addMode"  value="${empty licenseDetail.id}" />

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailSummary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/detailSummary.jspf
@@ -10,9 +10,17 @@
   ~ http://www.eclipse.org/legal/epl-v10.html
 --%>
 <table class="table info_table" id="licenseDetailOverview">
-  <thead><tr><th colspan="2">License Details: <sw360:out value="${licenseDetail.fullname}"/> (<sw360:out value="${licenseDetail.shortname}"/>)</th></tr></thead>
+  <thead><tr><th colspan="2">
+    License Details: <sw360:out value="${licenseDetail.fullname}"/> (<sw360:out value="${licenseDetail.shortname}"/>)
+    <core_rt:if test="${licenseDetail.checked != true}">
+      <alert>UNCHECKED</alert>
+    </core_rt:if>
+  </th></tr></thead>
   <tr><td>Fullname:</td><td><sw360:out value="${licenseDetail.fullname}"/></td></tr>
   <tr><td>Shortname:</td><td><sw360:out value="${licenseDetail.shortname}"/></td></tr>
+  <core_rt:if test="${licenseDetail.checked != true}">
+    <tr><td>Is checked:</td><td><b>false</b></td></tr>
+  </core_rt:if>
   <tr><td>Type:</td><td><sw360:out value="${licenseDetail.licenseType.licenseType}"/></td></tr>
   <%--need nested ifs for the yes no because the values can be undefined--%>
   <tr><td>GPL-2.0 compatibility:</td><td><sw360:DisplayEnum value="${licenseDetail.GPLv2Compat}"/></td></tr>

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/editDetailSummary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/editDetailSummary.jspf
@@ -76,7 +76,21 @@
       </label>
     </td>
 
-    <td width="33%"></td>
+    <td width="33%">
+      <label class="checkboxlabel" for="isChecked">
+        <input type="checkbox"
+               name="<portlet:namespace/><%=License._Fields.CHECKED%>"
+               value="true"
+               id="isChecked"
+               <core_rt:if test="${isUserAtLeastClearingAdmin == 'Yes' && licenseDetail.checked == true}">
+                 checked="checked"
+               </core_rt:if>
+               <core_rt:if test="${isUserAtLeastClearingAdmin != 'Yes' || (licenseDetail.id != null && licenseDetail.checked == true)}">
+                 disabled="disabled"
+               </core_rt:if> />
+        is checked
+      </label>
+    </td>
   </tr>
 
 </table>

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/view.jsp
@@ -20,9 +20,12 @@
 <portlet:defineObjects />
 <liferay-theme:defineObjects />
 
-<jsp:useBean id="isUserAtLeastClearingAdmin" class="java.lang.String" scope="request" />
-<jsp:useBean id="licenseList" type="java.util.List<org.eclipse.sw360.datahandler.thrift.licenses.License>"
-             scope="request"/>
+<c:catch var="attributeNotFoundException">
+    <jsp:useBean id="isUserAtLeastClearingAdmin" class="java.lang.String" scope="request" />
+    <jsp:useBean id="licenseList" type="java.util.List<org.eclipse.sw360.datahandler.thrift.licenses.License>"
+                 scope="request"/>
+</c:catch>
+<%@include file="/html/utils/includes/logError.jspf" %>
 
 <portlet:resourceURL var="exportLicensesURL">
     <portlet:param name="<%=PortalConstants.ACTION%>" value="<%=PortalConstants.EXPORT_TO_EXCEL%>"/>
@@ -42,9 +45,7 @@
     <span class="pull-right">
         <input type="button" class="addButton" onclick="window.location.href='<%=exportLicensesURL%>'"
                value="Export Licenses">
-        <core_rt:if test="${isUserAtLeastClearingAdmin == 'Yes'}">
-            <input type="button" class="addButton" onclick="window.location.href='<%=addLicenseURL%>'" value="Add License">
-        </core_rt:if>
+        <input type="button" class="addButton" onclick="window.location.href='<%=addLicenseURL%>'" value="Add License">
     </span>
 </p>
 
@@ -56,9 +57,10 @@
     <table id="licensesTable" cellpadding="0" cellspacing="0" border="0" class="display">
         <tfoot>
         <tr>
-            <th style="width:30%;"></th>
-            <th style="width:40%;"></th>
-            <th style="width:30%;"></th>
+            <th style="width: 25%;"></th>
+            <th style="width: 35%;"></th>
+            <th style="width: 20%;"></th>
+            <th style="width: 20%;"></th>
         </tr>
         </tfoot>
     </table>
@@ -92,7 +94,13 @@
                     <%-- "DT_RowId": '${license.id}',--%>
                     "0": "<sw360:DisplayLicenseLink licenseId="${license.id}"/>",
                     "1": '<sw360:out value="${license.fullname}"/>',
-                    "2": '<sw360:out value="${license.licenseType.licenseType}" default="--"/>'
+                    <core_rt:if test="${license.checked}">
+                    "2": '',
+                    </core_rt:if>
+                    <core_rt:if test="${not license.checked}">
+                    "2": 'UNCHECKED',
+                    </core_rt:if>
+                    "3": '<sw360:out value="${license.licenseType.licenseType}" default="--"/>'
                 });
             </core_rt:forEach>
 
@@ -121,6 +129,7 @@
                 "columns": [
                   { "title": "License Shortname" },
                   { "title": "License Fullname" },
+                  { "title": "Is checked?" },
                   { "title": "License Type" }
                   ],
                 "autoWidth": false

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/LicensePermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/LicensePermissions.java
@@ -41,8 +41,9 @@ public class LicensePermissions extends DocumentPermissions<License> {
     public boolean isActionAllowed(RequestedAction action) {
         switch (action) {
             case READ:
-                return true;
             case WRITE:
+                return true;
+            case CLEARING:
             case DELETE:
                 return PermissionUtils.isUserAtLeast(CLEARING_ADMIN, user);
             default:

--- a/libraries/lib-datahandler/src/main/thrift/licenses.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/licenses.thrift
@@ -105,6 +105,8 @@ struct License {
 	23: optional set<string> riskDatabaseIds,
     25: optional string text,
 
+    30: optional bool checked = true;
+
     90: optional DocumentState documentState,
 
 	200: optional map<RequestedAction, bool> permissions

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -454,7 +454,8 @@ class JacksonCustomizations {
                 "risksIterator",
                 "setRisks",
                 "setText",
-                "mainLicenseIdsIterator"
+                "mainLicenseIdsIterator",
+                "setChecked"
         })
         static abstract class LicenseMixin extends License {
             @Override

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -101,6 +101,7 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("fullName").description("The full name of the license"),
                                 fieldWithPath("shortName").description("The short name of the license, optional"),
                                 fieldWithPath("text").description("The license's original text"),
+                                fieldWithPath("checked").description("The information, whether the license is already checked, optional and defaults to true"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
     }


### PR DESCRIPTION
This allows everyone to create licenses, but the created licenses are marked as unchecked.

Since there is no owner concept on licenses, everyone is able to modify every unchecked license, and no moderation requests are generated.

closes #190