### PR TITLE
feat(rest): Update REST Attachment endpoints and documentation

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentContentRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentContentRepository.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
+import org.eclipse.sw360.datahandler.couchdb.DatabaseRepository;
+import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.RequestSummary;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.ektorp.DocumentOperationResult;
+import org.ektorp.ViewQuery;
+import org.ektorp.support.View;
+import org.ektorp.support.Views;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * CRUD access for the Attachment class
+ *
+ * @author cedric.bodet@tngtech.com
+ * @author Johannes.Najjar@tngtech.com
+ * @author daniele.fognini@tngtech.com
+ */
+@Views({
+        @View(name = "all", map = "function(doc) { if (doc.type == 'attachment') emit(null, doc._id) }"),
+        @View(name = "onlyRemotes", map = "function(doc) { if(doc.type == 'attachment' && doc.onlyRemote) { emit(null, doc) } }")
+})
+public class AttachmentContentRepository extends DatabaseRepository<AttachmentContent> {
+
+    public AttachmentContentRepository(DatabaseConnector db) {
+        super(AttachmentContent.class, db);
+
+        initStandardDesignDocument();
+    }
+
+    public List<AttachmentContent> getOnlyRemoteAttachments() {
+        ViewQuery query = createQuery("onlyRemotes");
+        query.includeDocs(false);
+        return queryView(query);
+    }
+
+    public RequestSummary vacuumAttachmentDB(User user, final Set<String> usedIds) {
+        final RequestSummary requestSummary = new RequestSummary();
+        if (!PermissionUtils.isAdmin(user))
+            return requestSummary.setRequestStatus(RequestStatus.FAILURE);
+
+        final List<AttachmentContent> allAttachmentContents = getAll();
+        final Set<AttachmentContent> unusedAttachmentContents = allAttachmentContents.stream()
+                .filter(input -> !usedIds.contains(input.getId()))
+                .collect(Collectors.toSet());
+
+        requestSummary.setTotalElements(allAttachmentContents.size());
+        requestSummary.setTotalAffectedElements(unusedAttachmentContents.size());
+
+        final List<DocumentOperationResult> documentOperationResults = deleteBulk(unusedAttachmentContents);
+        if (documentOperationResults.isEmpty()) {
+            requestSummary.setRequestStatus(RequestStatus.SUCCESS);
+        }else{
+            requestSummary.setRequestStatus(RequestStatus.FAILURE);
+        }
+        return requestSummary;
+    }
+}

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentOwnerRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentOwnerRepository.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Siemens AG, 2018. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
+import org.eclipse.sw360.datahandler.couchdb.DatabaseRepository;
+import org.eclipse.sw360.datahandler.thrift.Source;
+import org.ektorp.ViewQuery;
+import org.ektorp.support.View;
+import org.ektorp.support.Views;
+
+import java.util.List;
+import java.util.Set;
+
+@Views({
+        @View(name = "attachmentOwner",
+                map = "function(doc) { if (doc.type == 'project' || doc.type == 'component' || doc.type == 'release') { " +
+                        "for(var i in doc.attachments) { " +
+                            "var source;" +
+                            "if (doc.type == 'project') {source = {projectId: doc._id}}" +
+                            "if (doc.type == 'component') {source = {componentId: doc._id}}" +
+                            "if (doc.type == 'release') {source = {releaseId: doc._id}}" +
+                        "emit(doc.attachments[i].attachmentContentId, source); } } }")
+})
+
+public class AttachmentOwnerRepository extends DatabaseRepository<Source> {
+
+    public AttachmentOwnerRepository(DatabaseConnector db) {
+        super(Source.class, db);
+        initStandardDesignDocument();
+    }
+
+    public List<Source> getOwnersByIds(Set<String> ids) {
+        ViewQuery viewQuery = createQuery("attachmentOwner").includeDocs(false).keys(ids);
+        return queryView(viewQuery);
+    }
+}

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2018. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -8,69 +8,43 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-
 package org.eclipse.sw360.datahandler.db;
 
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseRepository;
-import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
-import org.eclipse.sw360.datahandler.thrift.RequestStatus;
-import org.eclipse.sw360.datahandler.thrift.RequestSummary;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
-import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.ektorp.DocumentOperationResult;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.ektorp.ViewQuery;
 import org.ektorp.support.View;
 import org.ektorp.support.Views;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-/**
- * CRUD access for the Attachment class
- *
- * @author cedric.bodet@tngtech.com
- * @author Johannes.Najjar@tngtech.com
- * @author daniele.fognini@tngtech.com
- */
 @Views({
-        @View(name = "all", map = "function(doc) { if (doc.type == 'attachment') emit(null, doc._id) }"),
-        @View(name = "onlyRemotes", map = "function(doc) { if(doc.type == 'attachment' && doc.onlyRemote) { emit(null, doc) } }")
+        @View(name = "byid",
+                map = "function(doc) { if (doc.type == 'project' || doc.type == 'component' || doc.type == 'release') { " +
+                        "for(var i in doc.attachments) { " +
+                        "emit(doc.attachments[i].attachmentContentId, doc.attachments[i]); } } }"),
+        @View(name = "bysha1",
+                map = "function(doc) { if (doc.type == 'project' || doc.type == 'component' || doc.type == 'release') { " +
+                        "for(var i in doc.attachments) { " +
+                        "emit(doc.attachments[i].sha1, doc.attachments[i]); } } }")
 })
-public class AttachmentRepository extends DatabaseRepository<AttachmentContent> {
+
+public class AttachmentRepository extends DatabaseRepository<Attachment> {
 
     public AttachmentRepository(DatabaseConnector db) {
-        super(AttachmentContent.class, db);
-
+        super(Attachment.class, db);
         initStandardDesignDocument();
     }
 
-    public List<AttachmentContent> getOnlyRemoteAttachments() {
-        ViewQuery query = createQuery("onlyRemotes");
-        query.includeDocs(false);
-        return queryView(query);
+    public List<Attachment> getAttachmentsByIds(Set<String> ids) {
+        ViewQuery viewQuery = createQuery("byid").includeDocs(false).keys(ids);
+        return queryView(viewQuery);
     }
 
-    public RequestSummary vacuumAttachmentDB(User user, final Set<String> usedIds) {
-        final RequestSummary requestSummary = new RequestSummary();
-        if (!PermissionUtils.isAdmin(user))
-            return requestSummary.setRequestStatus(RequestStatus.FAILURE);
-
-        final List<AttachmentContent> allAttachmentContents = getAll();
-        final Set<AttachmentContent> unusedAttachmentContents = allAttachmentContents.stream()
-                .filter(input -> !usedIds.contains(input.getId()))
-                .collect(Collectors.toSet());
-
-        requestSummary.setTotalElements(allAttachmentContents.size());
-        requestSummary.setTotalAffectedElements(unusedAttachmentContents.size());
-
-        final List<DocumentOperationResult> documentOperationResults = deleteBulk(unusedAttachmentContents);
-        if (documentOperationResults.isEmpty()) {
-            requestSummary.setRequestStatus(RequestStatus.SUCCESS);
-        }else{
-            requestSummary.setRequestStatus(RequestStatus.FAILURE);
-        }
-        return requestSummary;
+    public List<Attachment> getAttachmentsBySha1s(Set<String> sha1s) {
+        ViewQuery viewQuery = createQuery("bysha1").includeDocs(false).keys(sha1s);
+        return queryView(viewQuery);
     }
 }

--- a/backend/src/src-attachments/src/main/java/org/eclipse/sw360/attachments/AttachmentHandler.java
+++ b/backend/src/src-attachments/src/main/java/org/eclipse/sw360/attachments/AttachmentHandler.java
@@ -18,10 +18,7 @@ import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.Source;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentService;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage;
-import org.eclipse.sw360.datahandler.thrift.attachments.UsageData;
+import org.eclipse.sw360.datahandler.thrift.attachments.*;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 
 import java.net.MalformedURLException;
@@ -42,9 +39,7 @@ import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.validateAttach
  */
 public class AttachmentHandler implements AttachmentService.Iface {
 
-    private static final Logger log = Logger.getLogger(AttachmentHandler.class);
     private final AttachmentDatabaseHandler handler;
-
 
     public AttachmentHandler() throws MalformedURLException {
         handler = new AttachmentDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE, DatabaseSettings.COUCH_DB_ATTACHMENTS);
@@ -167,12 +162,7 @@ public class AttachmentHandler implements AttachmentService.Iface {
 
     @Override
     public List<AttachmentUsage> getAttachmentUsages(Source owner, String attachmentContentId, UsageData filter) throws TException {
-        assertNotNull(owner);
-        assertTrue(owner.isSet());
-        assertNotNull(attachmentContentId);
-        assertNotEmpty(attachmentContentId);
-
-        return handler.getAttachmentUsages(owner, attachmentContentId, filter);
+        return getAttachmentsUsages(owner, Collections.singleton(attachmentContentId), filter);
     }
 
     @Override
@@ -220,4 +210,21 @@ public class AttachmentHandler implements AttachmentService.Iface {
         assertNotNull(attachments);
         return handler.getAttachmentUsageCount(attachments, filter);
     }
+
+    @Override
+    public List<Attachment> getAttachmentsByIds(Set<String> ids) throws TException {
+        assertNotEmpty(ids);
+        return handler.getAttachmentsByIds(ids);
+    }
+    @Override
+    public List<Attachment> getAttachmentsBySha1s(Set<String> sha1s) throws TException {
+        assertNotEmpty(sha1s);
+        return handler.getAttachmentsBySha1s(sha1s);
+    }
+    @Override
+    public List<Source> getAttachmentOwnersByIds(Set<String> ids) throws TException {
+        assertNotEmpty(ids);
+        return handler.getAttachmentOwnersByIds(ids);
+    }
+
 }

--- a/backend/utils/src/main/java/org/eclipse/sw360/attachments/db/RemoteAttachmentDownloader.java
+++ b/backend/utils/src/main/java/org/eclipse/sw360/attachments/db/RemoteAttachmentDownloader.java
@@ -15,7 +15,7 @@ import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.common.Duration;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
-import org.eclipse.sw360.datahandler.db.AttachmentRepository;
+import org.eclipse.sw360.datahandler.db.AttachmentContentRepository;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.apache.log4j.Logger;
@@ -48,9 +48,9 @@ public class RemoteAttachmentDownloader {
 
     public static int retrieveRemoteAttachments(Supplier<HttpClient> httpClient, String dbAttachments, Duration downloadTimeout) throws MalformedURLException {
         AttachmentConnector attachmentConnector = new AttachmentConnector(httpClient, dbAttachments, downloadTimeout);
-        AttachmentRepository attachmentRepository = new AttachmentRepository(new DatabaseConnector(httpClient, dbAttachments));
+        AttachmentContentRepository attachmentContentRepository = new AttachmentContentRepository(new DatabaseConnector(httpClient, dbAttachments));
 
-        List<AttachmentContent> remoteAttachments = attachmentRepository.getOnlyRemoteAttachments();
+        List<AttachmentContent> remoteAttachments = attachmentContentRepository.getOnlyRemoteAttachments();
         log.info(format("we have %d remote attachments to retrieve", remoteAttachments.size()));
 
         int count = 0;

--- a/backend/utils/src/test/java/org/eclipse/sw360/attachments/db/RemoteAttachmentDownloaderTest.java
+++ b/backend/utils/src/test/java/org/eclipse/sw360/attachments/db/RemoteAttachmentDownloaderTest.java
@@ -15,7 +15,7 @@ import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.common.Duration;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
-import org.eclipse.sw360.datahandler.db.AttachmentRepository;
+import org.eclipse.sw360.datahandler.db.AttachmentContentRepository;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.Visibility;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
@@ -58,7 +58,7 @@ public class RemoteAttachmentDownloaderTest {
     private static final String dbName = DatabaseSettings.COUCH_DB_ATTACHMENTS;
 
     private AttachmentConnector attachmentConnector;
-    private AttachmentRepository repository;
+    private AttachmentContentRepository repository;
 
     private List<String> garbage;
     private Duration downloadTimeout = Duration.durationOf(5, TimeUnit.SECONDS);
@@ -75,7 +75,7 @@ public class RemoteAttachmentDownloaderTest {
     public void setUp() throws Exception {
         DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), dbName);
         attachmentConnector = new AttachmentConnector(DatabaseSettings.getConfiguredHttpClient(), dbName, downloadTimeout);
-        repository = new AttachmentRepository(databaseConnector);
+        repository = new AttachmentContentRepository(databaseConnector);
 
         garbage = new ArrayList<>();
     }

--- a/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/component-friendly-url-routes.xml
+++ b/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/component-friendly-url-routes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
   ~
@@ -36,5 +36,38 @@
         <pattern>/add</pattern>
         <implicit-parameter name="p_p_id">components_WAR_sw360portlet</implicit-parameter>
         <implicit-parameter name="pagename">edit</implicit-parameter>
+    </route>
+    <route>
+        <pattern>/release/{id}/{releaseId}/attachment/{contextId}/{attachmentId}</pattern>
+        <generated-parameter name="attachmentId">{attachmentId}</generated-parameter>
+        <generated-parameter name="componentid">{id}</generated-parameter>
+        <generated-parameter name="releaseId">{id}</generated-parameter>
+        <generated-parameter name="context_id">{contextId}</generated-parameter>
+        <implicit-parameter name="pagename">detailRelease</implicit-parameter>
+        <implicit-parameter name="context_type">release</implicit-parameter>
+        <implicit-parameter name="action">AttachmentDownload</implicit-parameter>
+        <implicit-parameter name="p_p_id">components_WAR_sw360portlet</implicit-parameter>
+        <implicit-parameter name="p_p_lifecycle">2</implicit-parameter>
+        <implicit-parameter name="p_p_state">normal</implicit-parameter>
+        <implicit-parameter name="p_p_mode">view</implicit-parameter>
+        <implicit-parameter name="p_p_cacheability">cacheLevelPage</implicit-parameter>
+        <implicit-parameter name="p_p_col_id">column-1</implicit-parameter>
+        <implicit-parameter name="p_p_col_count">1</implicit-parameter>
+    </route>
+    <route>
+        <pattern>/{id}/attachment/{contextId}/{attachmentId}</pattern>
+        <generated-parameter name="attachmentId">{attachmentId}</generated-parameter>
+        <generated-parameter name="componentid">{id}</generated-parameter>
+        <generated-parameter name="context_id">{contextId}</generated-parameter>
+        <implicit-parameter name="pagename">detail</implicit-parameter>
+        <implicit-parameter name="context_type">component</implicit-parameter>
+        <implicit-parameter name="action">AttachmentDownload</implicit-parameter>
+        <implicit-parameter name="p_p_id">components_WAR_sw360portlet</implicit-parameter>
+        <implicit-parameter name="p_p_lifecycle">2</implicit-parameter>
+        <implicit-parameter name="p_p_state">normal</implicit-parameter>
+        <implicit-parameter name="p_p_mode">view</implicit-parameter>
+        <implicit-parameter name="p_p_cacheability">cacheLevelPage</implicit-parameter>
+        <implicit-parameter name="p_p_col_id">column-1</implicit-parameter>
+        <implicit-parameter name="p_p_col_count">1</implicit-parameter>
     </route>
 </routes>

--- a/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/project-friendly-url-routes.xml
+++ b/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/project-friendly-url-routes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
   ~
@@ -23,5 +23,21 @@
         <pattern>/add</pattern>
         <implicit-parameter name="p_p_id">projects_WAR_sw360portlet</implicit-parameter>
         <implicit-parameter name="pagename">edit</implicit-parameter>
+    </route>
+    <route>
+        <pattern>/{id}/attachment/{contextId}/{attachmentId}</pattern>
+        <generated-parameter name="attachmentId">{attachmentId}</generated-parameter>
+        <generated-parameter name="projectid">{id}</generated-parameter>
+        <generated-parameter name="context_id">{contextId}</generated-parameter>
+        <implicit-parameter name="pagename">detail</implicit-parameter>
+        <implicit-parameter name="context_type">project</implicit-parameter>
+        <implicit-parameter name="action">AttachmentDownload</implicit-parameter>
+        <implicit-parameter name="p_p_id">projects_WAR_sw360portlet</implicit-parameter>
+        <implicit-parameter name="p_p_lifecycle">2</implicit-parameter>
+        <implicit-parameter name="p_p_state">normal</implicit-parameter>
+        <implicit-parameter name="p_p_mode">view</implicit-parameter>
+        <implicit-parameter name="p_p_cacheability">cacheLevelPage</implicit-parameter>
+        <implicit-parameter name="p_p_col_id">column-1</implicit-parameter>
+        <implicit-parameter name="p_p_col_count">1</implicit-parameter>
     </route>
 </routes>

--- a/libraries/importers/component-importer/src/test/java/org/eclipse/sw360/importer/ComponentAndAttachmentAwareDBTest.java
+++ b/libraries/importers/component-importer/src/test/java/org/eclipse/sw360/importer/ComponentAndAttachmentAwareDBTest.java
@@ -13,7 +13,7 @@ package org.eclipse.sw360.importer;
 
 import com.google.common.collect.FluentIterable;
 import org.eclipse.sw360.attachments.AttachmentHandler;
-import org.eclipse.sw360.datahandler.db.AttachmentRepository;
+import org.eclipse.sw360.datahandler.db.AttachmentContentRepository;
 import org.eclipse.sw360.components.ComponentHandler;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.common.ImportCSV;
@@ -49,7 +49,7 @@ public class ComponentAndAttachmentAwareDBTest {
     protected ComponentService.Iface componentClient;
     protected VendorService.Iface vendorClient;
     protected AttachmentService.Iface attachmentClient;
-    protected AttachmentRepository attachmentRepository;
+    protected AttachmentContentRepository attachmentContentRepository;
     protected User user;
 
     protected  static  DatabaseConnector getDBConnector(String couchDbDatabase) throws MalformedURLException {
@@ -57,8 +57,8 @@ public class ComponentAndAttachmentAwareDBTest {
     }
 
 
-    protected static AttachmentRepository getAttachmentRepository() throws MalformedURLException {
-        return new AttachmentRepository(getDBConnector(DatabaseSettings.COUCH_DB_ATTACHMENTS));
+    protected static AttachmentContentRepository getAttachmentContentRepository() throws MalformedURLException {
+        return new AttachmentContentRepository(getDBConnector(DatabaseSettings.COUCH_DB_ATTACHMENTS));
     }
 
     protected static FluentIterable<ComponentCSVRecord> getCompCSVRecordsFromTestFile(String fileName) throws IOException {
@@ -110,7 +110,7 @@ public class ComponentAndAttachmentAwareDBTest {
         componentClient = thriftClients.makeComponentClient();
         vendorClient = thriftClients.makeVendorClient();
         attachmentClient = thriftClients.makeAttachmentClient();
-        attachmentRepository = getAttachmentRepository();
+        attachmentContentRepository = getAttachmentContentRepository();
         user = getAdminUser(getClass());
 
 

--- a/libraries/importers/component-importer/src/test/java/org/eclipse/sw360/importer/ComponentImportUtilsTest.java
+++ b/libraries/importers/component-importer/src/test/java/org/eclipse/sw360/importer/ComponentImportUtilsTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.sw360.importer;
 
 import com.google.common.collect.FluentIterable;
-import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
@@ -76,10 +75,10 @@ public class ComponentImportUtilsTest extends ComponentAndAttachmentAwareDBTest 
         final AttachmentContent overwriter = new AttachmentContent().setId(OVERRIDING_ID).setOnlyRemote(true).setRemoteUrl(REMOTE_URL).setType(TYPE_ATTACHMENT);
         final AttachmentContent addition = new AttachmentContent().setId(ADDITIONAL_ID).setOnlyRemote(true).setRemoteUrl(REMOTE_URL).setType(TYPE_ATTACHMENT);
 
-        attachmentRepository.add(overwriter);
-        attachmentRepository.add(addition);
+        attachmentContentRepository.add(overwriter);
+        attachmentContentRepository.add(addition);
 
-        assertThat(attachmentRepository.getAll(), Matchers.hasSize(3));
+        assertThat(attachmentContentRepository.getAll(), Matchers.hasSize(3));
         FluentIterable<ComponentAttachmentCSVRecord> compAttachmentCSVRecords = getCompAttachmentCSVRecordsFromTestFile(attachmentsFilename);
 
         ComponentImportUtils.writeAttachmentsToDatabase(compAttachmentCSVRecords,user,componentClient,attachmentClient);
@@ -92,7 +91,7 @@ public class ComponentImportUtilsTest extends ComponentAndAttachmentAwareDBTest 
             assertThat(((SW360Exception)e).getWhy(), is("Cannot find "+ attachmentContentId + " in database."));
         }
 
-        assertThat(attachmentRepository.getAll(), Matchers.hasSize(2) );
+        assertThat(attachmentContentRepository.getAll(), Matchers.hasSize(2) );
         final AttachmentContent attachmentContent = attachmentClient.getAttachmentContent(getCreatedAttachmentContentId());
 
         assertThat(attachmentContent, is(overwriter));
@@ -135,10 +134,10 @@ public class ComponentImportUtilsTest extends ComponentAndAttachmentAwareDBTest 
 
         assertThat(componentClient.getComponentSummary(user), hasSize(0));
         assertThat(componentClient.getReleaseSummary(user), hasSize(0));
-        assertThat(attachmentRepository.getAll(), Matchers.hasSize(0) );
+        assertThat(attachmentContentRepository.getAll(), Matchers.hasSize(0) );
 
         ComponentImportUtils.writeToDatabase(compCSVRecords, componentClient, vendorClient, attachmentClient, user);
-        assertThat(attachmentRepository.getAll(), Matchers.hasSize(1) );
+        assertThat(attachmentContentRepository.getAll(), Matchers.hasSize(1) );
         List<Component> componentSummaryAfterFirst = componentClient.getComponentSummary(user);
         List<Release> releaseSummaryAfterFirst = componentClient.getReleaseSummary(user);
 
@@ -146,7 +145,7 @@ public class ComponentImportUtilsTest extends ComponentAndAttachmentAwareDBTest 
 
         ComponentImportUtils.writeToDatabase(compCSVRecords, componentClient, vendorClient, attachmentClient, user);
         assertExpectedComponentsInDb();
-        assertThat(attachmentRepository.getAll(), Matchers.hasSize(1) );
+        assertThat(attachmentContentRepository.getAll(), Matchers.hasSize(1) );
         assertThat(componentClient.getComponentSummary(user), is(componentSummaryAfterFirst));
         assertThat(componentClient.getReleaseSummary(user), is(releaseSummaryAfterFirst));
 

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseNestedMixIn.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseNestedMixIn.java
@@ -23,9 +23,7 @@ import static org.eclipse.sw360.datahandler.common.SW360Constants.KEY_REV;
  *
  * @author cedric.bodet@tngtech.com
  */
-@JsonPropertyOrder({KEY_ID, KEY_REV})
-// Always put _id and _rev upfront. Not required, but serialized objects then look nicer.
-@JsonIgnoreProperties({"optionals", "_attachments"})
+@JsonIgnoreProperties({KEY_ID, KEY_REV})
 @SuppressWarnings("unused")
 public class DatabaseNestedMixIn {
 

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
@@ -49,7 +49,6 @@ public class ThriftUtils {
     private static final Logger log = Logger.getLogger(ThriftUtils.class);
 
     public static final List<Class<?>> THRIFT_CLASSES = ImmutableList.<Class<?>>builder()
-            .add(Attachment.class) // Attachment service
             .add(AttachmentContent.class) // Attachment service
             .add(AttachmentUsage.class) // Attachment service
             .add(Component.class).add(Release.class) // Component service
@@ -65,6 +64,7 @@ public class ThriftUtils {
             .build();
 
     public static final List<Class<?>> THRIFT_NESTED_CLASSES = ImmutableList.<Class<?>>builder()
+            .add(Attachment.class) // Attachment service
             .add(Source.class)
             .add(UsageData.class)
             .add(LicenseInfoUsage.class)

--- a/libraries/lib-datahandler/src/main/thrift/attachments.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/attachments.thrift
@@ -269,4 +269,19 @@ service AttachmentService {
      * is used for the filter.
      */
     list<AttachmentUsage> getUsedAttachments(1: Source usedBy, 2: UsageData filter);
+
+    /**
+     * Returns attachments based on its attachmentContentId value
+     */
+    list<Attachment> getAttachmentsByIds(1: set<string> ids);
+
+    /**
+     * Returns attachments based on its sha1 value
+     */
+    list<Attachment> getAttachmentsBySha1s(1: set<string> sha1s);
+
+    /**
+     * Returns the sources/owners (project, component, release) of the attachment by attachmentContentId
+     */
+    list<Source> getAttachmentOwnersByIds(1: set<string> ids)
 }

--- a/rest/authorization-server/pom.xml
+++ b/rest/authorization-server/pom.xml
@@ -152,6 +152,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-war-plugin</artifactId>
+                        <version>2.2</version>
                         <configuration>
                             <outputDirectory>${webapps.dir}</outputDirectory>
                         </configuration>

--- a/rest/resource-server/pom.xml
+++ b/rest/resource-server/pom.xml
@@ -272,6 +272,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-war-plugin</artifactId>
+                        <version>2.2</version>
                         <configuration>
                             <outputDirectory>${webapps.dir}</outputDirectory>
                         </configuration>

--- a/rest/resource-server/src/docs/asciidoc/api-guide.adoc
+++ b/rest/resource-server/src/docs/asciidoc/api-guide.adoc
@@ -42,11 +42,11 @@ use of HTTP verbs.
 | `PUT`
 | Used to update an existing resource (complete update)
 
-// | `PATCH`
-// | Used to update an existing resource (partial updates)
+| `PATCH`
+| Used to update an existing resource (partial updates)
 
-// | `DELETE`
-// | Used to delete an existing resource
+| `DELETE`
+| Used to delete an existing resource
 |===
 
 [[overview-http-status-codes]]
@@ -222,11 +222,15 @@ You can configure the sw360 Granted Authority by changing the properties file (s
 Token response elements
 |===
 | Name | Configuration | Default Value
-
+| `API Client Id`
+| rest.security.client.id
+| trusted-sw360-client
+| `API Client Secret Key`
+| rest.security.client.secret
+| sw360-secret
 | `Token Validity`
 | rest.access.token.validity.seconds
 | 3600 (seconds)
-
 | `Write Access`
 | rest.write.access.usergroup
 | SW360_ADMIN

--- a/rest/resource-server/src/docs/asciidoc/attachments.adoc
+++ b/rest/resource-server/src/docs/asciidoc/attachments.adoc
@@ -10,47 +10,22 @@
 [[resources-attachments]]
 === Attachments
 
-The Attachments resource is used to create and list attachments.
+The Attachments resource is used to list attachment information.
 
 
-[[resources-attachment-get]]
-==== Get a single attachment
+[[resources-attachment-information-get]]
+==== Get attachment info
 
-A `GET` request will get a single attachment.
+A `GET` request will get attachment information.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_attachment/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_attachment/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_attachment/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_attachment/links.adoc[]
-
-
-////
-[[resources-attachments-create]]
-==== Creating a attachment
-
-A `POST` request is used to create a attachment
-
-===== Request structure
-
-include::{snippets}/should_document_create_attachment/request-fields.adoc[]
-
-===== Example request
-
-include::{snippets}/should_document_create_attachment/curl-request.adoc[]
-
-===== Example response
-
-include::{snippets}/should_document_create_attachment/http-response.adoc[]
-////
-

--- a/rest/resource-server/src/docs/asciidoc/components.adoc
+++ b/rest/resource-server/src/docs/asciidoc/components.adoc
@@ -19,19 +19,15 @@ The Components resource is used to create and list components.
 A `GET` request will list all of the service's components.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_components/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_components/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_components/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_components/links.adoc[]
 
 [[resources-components-list-with-fields]]
@@ -40,20 +36,17 @@ include::{snippets}/should_document_get_components/links.adoc[]
 A `GET` request will list all of the service's components. The `fields` parameter defines which component object properties should be contained in the response.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_components_with_fields/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_components_with_fields/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_components_with_fields/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_components_with_fields/links.adoc[]
+
 
 [[resources-components-list-by-name]]
 ==== Listing by name
@@ -62,20 +55,17 @@ A `GET` request will list all of the service's components by component name. +
 Please set the request parameter `&name=<NAME>`.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_components_by_name/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_components_by_name/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_components_by_name/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_components_by_name/links.adoc[]
+
 
 [[resources-components-list-by-type]]
 ==== Listing by type
@@ -84,20 +74,17 @@ A `GET` request will list all of the service's components by component type. +
 Component types = `{INTERNAL, OSS, COTS, FREESOFTWARE, INNER_SOURCE, SERVICE}`
 
 ===== Response structure
-
 include::{snippets}/should_document_get_components_by_type/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_components_by_type/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_components_by_type/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_components_by_type/links.adoc[]
+
 
 [[resources-component-get]]
 ==== Get a single component
@@ -105,20 +92,45 @@ include::{snippets}/should_document_get_components_by_type/links.adoc[]
 A `GET` request will get a single component.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_component/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_component/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_component/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_component/links.adoc[]
+
+
+[[resources-component-attachment-info-get]]
+==== Listing attachment info
+
+A `GET` request will get all attachment information of a component.
+
+===== Response structure
+include::{snippets}/should_document_get_component_attachment_info/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_component_attachment_info/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_component_attachment_info/http-response.adoc[]
+
+
+[[resources-component-attachment-get]]
+==== Download attachment
+
+A `GET` request will allow you to download an attachment of a component. +
+Please set the Accept-Header `application/*`. Only this Accept-Header is supported.
+
+===== Example request
+include::{snippets}/should_document_get_component_attachment/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_component_attachment/http-response.adoc[]
+
 
 [[resources-components-create]]
 ==== Creating a component
@@ -126,13 +138,43 @@ include::{snippets}/should_document_get_component/links.adoc[]
 A `POST` request is used to create a component
 
 ===== Request structure
-
 include::{snippets}/should_document_create_component/request-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_create_component/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_create_component/http-response.adoc[]
+
+
+[[resources-components-update]]
+==== Update a component
+
+A `PATCH` request is used to update an existing component
+
+===== Response structure
+include::{snippets}/should_document_update_component/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_update_component/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_update_component/http-response.adoc[]
+
+===== Links
+include::{snippets}/should_document_update_component/links.adoc[]
+
+
+[[resources-components-delete]]
+==== Delete a component
+
+A `DELETE` request is used to delete an existing component
+
+===== Response structure
+include::{snippets}/should_document_delete_components/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_delete_components/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_delete_components/http-response.adoc[]

--- a/rest/resource-server/src/docs/asciidoc/licenses.adoc
+++ b/rest/resource-server/src/docs/asciidoc/licenses.adoc
@@ -19,20 +19,17 @@ The Licenses resource is used to create and list licenses.
 A `GET` request will list all of the service's licenses.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_licenses/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_licenses/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_licenses/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_licenses/links.adoc[]
+
 
 [[resources-license-get]]
 ==== Get a single license
@@ -40,38 +37,13 @@ include::{snippets}/should_document_get_licenses/links.adoc[]
 A `GET` request will get a single license.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_license/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_license/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_license/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_license/links.adoc[]
-
-
-////
-[[resources-licenses-create]]
-==== Creating a license
-
-A `POST` request is used to create a license
-
-===== Request structure
-
-include::{snippets}/should_document_create_license/request-fields.adoc[]
-
-===== Example request
-
-include::{snippets}/should_document_create_license/curl-request.adoc[]
-
-===== Example response
-
-include::{snippets}/should_document_create_license/http-response.adoc[]
-////
-

--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -19,20 +19,17 @@ The Projects resource is used to create and list projects.
 A `GET` request will list all of the service's projects.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_projects/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_projects/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_projects/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_projects/links.adoc[]
+
 
 [[resources-projects-list-by-name]]
 ==== Listing by name
@@ -41,20 +38,17 @@ A `GET` request will list all of the service's projects by project name. +
 Please set the request parameter `&name=<NAME>`.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_projects_by_name/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_projects_by_name/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_projects_by_name/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_projects_by_name/links.adoc[]
+
 
 [[resources-projects-list-by-type]]
 ==== Listing by type
@@ -63,20 +57,44 @@ A `GET` request will list all of the service's projects by project type. +
 Project types = `{CUSTOMER, INTERNAL, PRODUCT, SERVICE, INNER_SOURCE}`
 
 ===== Response structure
-
 include::{snippets}/should_document_get_projects_by_type/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_projects_by_type/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_projects_by_type/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_projects_by_type/links.adoc[]
+
+
+[[resources-project-attachment-info-get]]
+==== Listing attachment info
+
+A `GET` request will get all attachment information of a project.
+
+===== Response structure
+include::{snippets}/should_document_get_project_attachment_info/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_project_attachment_info/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_project_attachment_info/http-response.adoc[]
+
+
+[[resources-project-attachment-get]]
+==== Download attachment
+
+A `GET` request will allow you to download an attachment of a project. +
+Please set the Accept-Header `application/*`. Only this Accept-Header is supported.
+
+===== Example request
+include::{snippets}/should_document_get_project_attachment/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_project_attachment/http-response.adoc[]
 
 
 [[resources-project-get]]
@@ -85,20 +103,17 @@ include::{snippets}/should_document_get_projects_by_type/links.adoc[]
 A `GET` request will get a single project.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_project/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_project/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_project/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_project/links.adoc[]
+
 
 [[resources-project-get-project-releases]]
 ==== Listing releases
@@ -107,20 +122,17 @@ A `GET` request will get releases of a single project. +
 Only linked releases without any releases of sub-projects `&transitive=false`.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_project_releases/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_project_releases/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_project_releases/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_project_releases/links.adoc[]
+
 
 [[resources-project-get-project-releases-transitive]]
 ==== Listing releases (transitive)
@@ -129,20 +141,17 @@ A `GET` request will get all releases of a single project (transitive). +
 Please set the request parameter `&transitive=true`.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_project_releases_transitive/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_project_releases_transitive/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_project_releases_transitive/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_project_releases_transitive/links.adoc[]
+
 
 [[resources-project-get-project-releases-ecc-information]]
 ==== Listing releases with ECC
@@ -151,36 +160,13 @@ A `GET` request will get all releases with ECC information of a single project.
 This works also with the transitive request parameter (&transitive=true)
 
 ===== Response structure
-
 include::{snippets}/should_document_get_project_releases_ecc_information/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_project_releases_ecc_information/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_project_releases_ecc_information/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_project_releases_ecc_information/links.adoc[]
-
-////
-[[resources-projects-create]]
-==== Creating a project
-
-A `POST` request is used to create a project
-
-===== Request structure
-
-include::{snippets}/should_document_create_project/request-fields.adoc[]
-
-===== Example request
-
-include::{snippets}/should_document_create_project/curl-request.adoc[]
-
-===== Example response
-
-include::{snippets}/should_document_create_project/http-response.adoc[]
-////

--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -19,20 +19,45 @@ The Releases resource is used to create and list releases.
 A `GET` request will list all of the service's releases.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_releases/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_releases/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_releases/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_releases/links.adoc[]
+
+
+[[resources-release-attachment-info-get]]
+==== Listing attachment info
+
+A `GET` request will get all attachment information of a release.
+
+===== Response structure
+include::{snippets}/should_document_get_release_attachment_info/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_release_attachment_info/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_release_attachment_info/http-response.adoc[]
+
+
+[[resources-release-attachment-get]]
+==== Download attachment
+
+A `GET` request will allow you to download an attachment of a release. +
+Please set the Accept-Header `application/*`. Only this Accept-Header is supported.
+
+===== Example request
+include::{snippets}/should_document_get_release_attachment/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_release_attachment/http-response.adoc[]
+
 
 [[resources-release-get]]
 ==== Get a single release
@@ -40,38 +65,46 @@ include::{snippets}/should_document_get_releases/links.adoc[]
 A `GET` request will get a single release.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_release/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_release/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_release/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_release/links.adoc[]
 
 
-////
-[[resources-releases-create]]
-==== Creating a release
+[[resources-release-update]]
+==== Update a release
 
-A `POST` request is used to create a release
+A `PATCH` request is used to update an existing release
 
-===== Request structure
-
-include::{snippets}/should_document_create_release/request-fields.adoc[]
+===== Response structure
+include::{snippets}/should_update_release/response-fields.adoc[]
 
 ===== Example request
-
-include::{snippets}/should_document_create_release/curl-request.adoc[]
+include::{snippets}/should_update_release/curl-request.adoc[]
 
 ===== Example response
+include::{snippets}/should_update_release/http-response.adoc[]
 
-include::{snippets}/should_document_create_release/http-response.adoc[]
-////
+===== Links
+include::{snippets}/should_update_release/links.adoc[]
 
+
+[[resources-release-delete]]
+==== Delete a release
+
+A `DELETE` request is used to delete an existing release
+
+===== Response structure
+include::{snippets}/should_document_delete_releases/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_delete_releases/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_delete_releases/http-response.adoc[]

--- a/rest/resource-server/src/docs/asciidoc/users.adoc
+++ b/rest/resource-server/src/docs/asciidoc/users.adoc
@@ -19,20 +19,17 @@ The Users resource is used to get and list users.
 A `GET` request will list all of the service's users.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_users/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_users/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_users/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_users/links.adoc[]
+
 
 [[resources-user-get]]
 ==== Get a single user
@@ -40,19 +37,15 @@ include::{snippets}/should_document_get_users/links.adoc[]
 A `GET` request will get a single user.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_user/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_user/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_user/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_user/links.adoc[]
 
 

--- a/rest/resource-server/src/docs/asciidoc/vendors.adoc
+++ b/rest/resource-server/src/docs/asciidoc/vendors.adoc
@@ -19,20 +19,17 @@ The Vendors resource is used to create and list vendors.
 A `GET` request will list all of the service's vendors.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_vendors/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_vendors/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_vendors/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_vendors/links.adoc[]
+
 
 [[resources-vendor-get]]
 ==== Get a single vendor
@@ -40,38 +37,13 @@ include::{snippets}/should_document_get_vendors/links.adoc[]
 A `GET` request will get a single vendor.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_vendor/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_vendor/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_vendor/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_vendor/links.adoc[]
-
-
-////
-[[resources-vendors-create]]
-==== Creating a vendor
-
-A `POST` request is used to create a vendor
-
-===== Request structure
-
-include::{snippets}/should_document_create_vendor/request-fields.adoc[]
-
-===== Example request
-
-include::{snippets}/should_document_create_vendor/curl-request.adoc[]
-
-===== Example response
-
-include::{snippets}/should_document_create_vendor/http-response.adoc[]
-////
-

--- a/rest/resource-server/src/docs/asciidoc/vulnerabilities.adoc
+++ b/rest/resource-server/src/docs/asciidoc/vulnerabilities.adoc
@@ -19,20 +19,17 @@ The Vulnerabilities resource is used to create and list vulnerabilities.
 A `GET` request will list all of the service's vulnerabilities.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_vulnerabilities/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_vulnerabilities/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_vulnerabilities/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_vulnerabilities/links.adoc[]
+
 
 [[resources-vulnerabilitie-get]]
 ==== Get a single vulnerability
@@ -40,17 +37,13 @@ include::{snippets}/should_document_get_vulnerabilities/links.adoc[]
 A `GET` request will get a single vulnerability.
 
 ===== Response structure
-
 include::{snippets}/should_document_get_vulnerability/response-fields.adoc[]
 
 ===== Example request
-
 include::{snippets}/should_document_get_vulnerability/curl-request.adoc[]
 
 ===== Example response
-
 include::{snippets}/should_document_get_vulnerability/http-response.adoc[]
 
 ===== Links
-
 include::{snippets}/should_document_get_vulnerability/links.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/AttachmentInfo.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/AttachmentInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -11,14 +11,32 @@
 
 package org.eclipse.sw360.rest.resourceserver.attachment;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
+import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
-import org.eclipse.sw360.datahandler.thrift.components.Release;
 
 @Data
-@AllArgsConstructor
 public class AttachmentInfo {
     private Attachment attachment;
-    private Release release;
+    private Source owner;
+
+    public AttachmentInfo(Attachment attachment) {
+        this.attachment = attachment;
+    }
+
+    public Attachment getAttachment() {
+        return attachment;
+    }
+
+    public void setAttachment(Attachment attachment) {
+        this.attachment = attachment;
+    }
+
+    public Source getOwner() {
+        return owner;
+    }
+
+    public void setOwner(Source owner) {
+        this.owner = owner;
+    }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -296,6 +296,7 @@ class JacksonCustomizations {
         @JsonIgnoreProperties({
                 "id",
                 "revision",
+                "attachments",
                 "permissions",
                 "createdBy",
                 "moderators",
@@ -315,6 +316,7 @@ class JacksonCustomizations {
                 "setDownloadurl",
                 "setPermissions",
                 "externalIdsSize",
+                "attachmentsIterator",
                 "attachmentsSize",
                 "setMainlineState",
                 "setClearingState",

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -254,11 +254,6 @@ public class RestControllerHelper {
                 this.addEmbeddedModerators(halRelease, moderators);
                 release.setModerators(null);
             }
-            if (release.getAttachments() != null) {
-                Set<Attachment> attachments = release.getAttachments();
-                this.addEmbeddedAttachments(halRelease, attachments);
-                release.setAttachments(null);
-            }
             if (release.getVendor() != null) {
                 Vendor vendor = release.getVendor();
                 HalResource<Vendor> vendorHalResource = this.addEmbeddedVendor(vendor.getFullname());
@@ -302,7 +297,7 @@ public class RestControllerHelper {
         }
     }
 
-    private void addEmbeddedProject(HalResource halResource, Project project) {
+    public void addEmbeddedProject(HalResource halResource, Project project) {
         Project embeddedProject = convertToEmbeddedProject(project);
         HalResource<Project> halProject = new HalResource<>(embeddedProject);
         Link projectLink = linkTo(ProjectController.class)
@@ -338,6 +333,15 @@ public class RestControllerHelper {
         embeddedProject.setVersion(project.getVersion());
         embeddedProject.setType(null);
         return embeddedProject;
+    }
+
+    public void addEmbeddedComponent(HalResource halResource, Component component) {
+        Component embeddedComponent = convertToEmbeddedComponent(component);
+        HalResource<Component> halComponent = new HalResource<>(embeddedComponent);
+        Link componentLink = linkTo(ComponentController.class)
+                .slash("api" + ComponentController.COMPONENTS_URL + "/" + component.getId()).withSelfRel();
+        halComponent.add(componentLink);
+        halResource.addEmbeddedResource("sw360:components", halComponent);
     }
 
     public Component convertToEmbeddedComponent(Component component) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -26,6 +26,7 @@ import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.attachment.AttachmentInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/AttachmentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/AttachmentSpecTest.java
@@ -9,6 +9,7 @@
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
 import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
@@ -18,6 +19,7 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.attachment.AttachmentInfo;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
+import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,6 +59,9 @@ public class AttachmentSpecTest extends TestRestDocsSpecBase {
     @MockBean
     private Sw360AttachmentService attachmentServiceMock;
 
+    @MockBean
+    private Sw360ReleaseService releaseServiceMock;
+
     private Attachment attachment;
 
     @Before
@@ -91,9 +96,13 @@ public class AttachmentSpecTest extends TestRestDocsSpecBase {
         release.setComponentId("678dstzd8");
         release.setClearingState(ClearingState.APPROVED);
 
-        AttachmentInfo attachmentInfo = new AttachmentInfo(attachment, release);
+        AttachmentInfo attachmentInfo = new AttachmentInfo(attachment);
+        Source owner = new Source();
+        owner.setReleaseId(release.getId());
+        attachmentInfo.setOwner(owner);
 
-        given(this.attachmentServiceMock.getAttachmentByIdForUser(eq(attachment.getAttachmentContentId()), anyObject())).willReturn(attachmentInfo);
+        given(this.attachmentServiceMock.getAttachmentById(eq(attachment.getAttachmentContentId()))).willReturn(attachmentInfo);
+        given(this.releaseServiceMock.getReleaseForUserById(eq(release.getId()), anyObject())).willReturn(release);
 
         User user = new User();
         user.setId("123456789");
@@ -113,7 +122,7 @@ public class AttachmentSpecTest extends TestRestDocsSpecBase {
                 .andDo(this.documentationHandler.document(
                         links(
                                 linkWithRel("self").description("The <<resources-projects,Projects resource>>"),
-                                linkWithRel("sw360:release").description("The release this attachment belongs to"),
+                                linkWithRel("sw360:downloadLink").description("The download link (URL) of the resource"),
                                 linkWithRel("curies").description("Curies are used for online documentation")
                         ),
                         responseFields(

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -13,11 +13,14 @@ package org.eclipse.sw360.rest.resourceserver.restdocs;
 import com.google.common.collect.ImmutableSet;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
+import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.component.Sw360ComponentService;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.junit.Before;
@@ -26,6 +29,8 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.Resources;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.*;
@@ -38,12 +43,10 @@ import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.li
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ComponentSpecTest extends TestRestDocsSpecBase {
@@ -60,13 +63,27 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
     @MockBean
     private Sw360ComponentService componentServiceMock;
 
+    @MockBean
+    private Sw360AttachmentService attachmentServiceMock;
+
     private Component angularComponent;
+
+    private Attachment attachment;
 
     @Before
     public void before() throws TException {
+        Set<Attachment> attachmentList = new HashSet<>();
+        List<Resource<Attachment>> attachmentResources = new ArrayList<>();
+        attachment = new Attachment("1231231254", "spring-core-4.3.4.RELEASE.jar");
+        attachment.setSha1("da373e491d3863477568896089ee9457bc316783");
+        attachmentList.add(attachment);
+        attachmentResources.add(new Resource<>(attachment));
+
+        given(this.attachmentServiceMock.getAttachmentContent(anyObject())).willReturn(new AttachmentContent().setId("1231231254").setFilename("spring-core-4.3.4.RELEASE.jar").setContentType("binary"));
+        given(this.attachmentServiceMock.getResourcesFromList(anyObject())).willReturn(new Resources<>(attachmentResources));
+
         List<Component> componentList = new ArrayList<>();
         List<Component> componentListByName = new ArrayList<>();
-
         angularComponent = new Component();
         angularComponent.setId("17653524");
         angularComponent.setName("Angular");
@@ -83,6 +100,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
         angularComponent.setCategories(ImmutableSet.of("java", "javascript", "sql"));
         angularComponent.setLanguages(ImmutableSet.of("EN", "DE"));
         angularComponent.setOperatingSystems(ImmutableSet.of("Windows", "Linux"));
+        angularComponent.setAttachments(attachmentList);
         componentList.add(angularComponent);
         componentListByName.add(angularComponent);
 
@@ -158,9 +176,9 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
         mockMvc.perform(get("/api/components")
                 .header("Authorization", "Bearer " + accessToken)
-                .param("page","0")
+                .param("page", "0")
                 .param("page_entries", "5")
-                .param("sort","name,desc")
+                .param("sort", "name,desc")
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
@@ -193,9 +211,9 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
         mockMvc.perform(get("/api/components")
                 .header("Authorization", "Bearer " + accessToken)
                 .param("fields", "ownerGroup,ownerCountry")
-                .param("page","0")
+                .param("page", "0")
                 .param("page_entries", "5")
-                .param("sort","name,desc")
+                .param("sort", "name,desc")
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
@@ -301,9 +319,9 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
         mockMvc.perform(get("/api/components?type=" + angularComponent.getComponentType())
                 .header("Authorization", "Bearer " + accessToken)
-                .param("page","0")
+                .param("page", "0")
                 .param("page_entries", "5")
-                .param("sort","name,desc")
+                .param("sort", "name,desc")
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
@@ -336,9 +354,9 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
         mockMvc.perform(get("/api/components?name=" + angularComponent.getName())
                 .header("Authorization", "Bearer " + accessToken)
-                .param("page","0")
+                .param("page", "0")
                 .param("page_entries", "5")
-                .param("sort","name,desc")
+                .param("sort", "name,desc")
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
@@ -414,5 +432,31 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("[].resourceId").description("id of the deleted resource"),
                                 fieldWithPath("[].status").description("status of the delete operation")
                         )));
+    }
+
+    @Test
+    public void should_document_get_component_attachment_info() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/components/" + angularComponent.getId() + "/attachments")
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        responseFields(
+                                fieldWithPath("_embedded.sw360:attachments").description("An array of <<resources-attachment, Attachments resources>>"),
+                                fieldWithPath("_embedded.sw360:attachments[]filename").description("The attachment filename"),
+                                fieldWithPath("_embedded.sw360:attachments[]sha1").description("The attachment sha1 value"),
+                                fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
+                        )));
+    }
+
+    @Test
+    public void should_document_get_component_attachment() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/components/" + angularComponent.getId() + "/attachments/" + attachment.getAttachmentContentId())
+                .header("Authorization", "Bearer " + accessToken)
+                .accept("application/*"))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document());
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -10,6 +10,8 @@ package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
 import org.eclipse.sw360.datahandler.thrift.components.ECCStatus;
 import org.eclipse.sw360.datahandler.thrift.components.EccInformation;
@@ -19,6 +21,7 @@ import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectType;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
+import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
@@ -28,6 +31,9 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.Resources;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.*;
@@ -62,10 +68,23 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
     @MockBean
     private Sw360ReleaseService releaseServiceMock;
 
+    @MockBean
+    private Sw360AttachmentService attachmentServiceMock;
+
     private Project project;
+    private Attachment attachment;
 
     @Before
     public void before() throws TException {
+        Set<Attachment> attachmentList = new HashSet<>();
+        List<Resource<Attachment>> attachmentResources = new ArrayList<>();
+        attachment = new Attachment("1231231254", "spring-core-4.3.4.RELEASE.jar");
+        attachment.setSha1("da373e491d3863477568896089ee9457bc316783");
+        attachmentList.add(attachment);
+        attachmentResources.add(new Resource<>(attachment));
+
+        given(this.attachmentServiceMock.getAttachmentContent(anyObject())).willReturn(new AttachmentContent().setId("1231231254").setFilename("spring-core-4.3.4.RELEASE.jar").setContentType("binary"));
+        given(this.attachmentServiceMock.getResourcesFromList(anyObject())).willReturn(new Resources<>(attachmentResources));
 
         Map<String, ProjectReleaseRelationship> linkedReleases = new HashMap<>();
         Map<String, ProjectRelationship> linkedProjects = new HashMap<>();
@@ -98,6 +117,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         project.setLinkedProjects(linkedProjects);
         projectList.add(project);
         projectListByName.add(project);
+        project.setAttachments(attachmentList);
 
         Project project2 = new Project();
         project2.setId("376570");
@@ -321,5 +341,31 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("_embedded.sw360:releases[].eccInformation.eccStatus").description("The ECC information status value"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
+    }
+
+    @Test
+    public void should_document_get_project_attachment_info() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/projects/" + project.getId() + "/attachments")
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        responseFields(
+                                fieldWithPath("_embedded.sw360:attachments").description("An array of <<resources-attachment, Attachments resources>>"),
+                                fieldWithPath("_embedded.sw360:attachments[]filename").description("The attachment filename"),
+                                fieldWithPath("_embedded.sw360:attachments[]sha1").description("The attachment sha1 value"),
+                                fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
+                        )));
+    }
+
+    @Test
+    public void should_document_get_project_attachment() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/projects/" + project.getId() + "/attachments/" + attachment.getAttachmentContentId())
+                .header("Authorization", "Bearer " + accessToken)
+                .accept("application/*"))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document());
     }
 }


### PR DESCRIPTION
- added attachments endpoints to projects, components and releases
- added REST API documentation for these new endpoints
- added REST API documentation to download attachment over REST (+tests)
- created attachment backend services to search for id, sha1 and get attachment sources (link to project, component or release)
- changed REST API attachment implementation to get attachment information (speed up)
- in addition I added some other useful stuff to the REST API documentation
- set version for maven-war-plugin (avoid build warnings)

Signed-off-by: Thomas Maier <thomas.maier@evosoft.com>

closes eclipse/sw360#327