### PR TITLE
fix(projects): Enable phrase search for group and tag in projects

### DIFF
--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/LuceneAwareDatabaseConnector.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/LuceneAwareDatabaseConnector.java
@@ -194,6 +194,8 @@ public class LuceneAwareDatabaseConnector extends LuceneAwareCouchDbConnector {
                 return fieldName + ":\"" + (enumByString(input, ProjectState.class).toString()) + "\"";
             } else if (fieldName.equals("projectType")) {
                 return fieldName + ":\"" + (enumByString(input, ProjectType.class).toString()) + "\"";
+            } else if (fieldName.equals("businessUnit") || fieldName.equals("tag")) {
+                return fieldName + ":\"" + input + "\"";
             } else {
                 return fieldName + ":" + input;
             }


### PR DESCRIPTION
For advanced search with `group` or `tag` phrase searches should be used.

closes eclipse/sw360#337

Signed-off-by: Thomas Maier <thomas.maier@evosoft.com>