### PR TITLE
fix(licenseInfo): remove the hidden license text input field from license info generation page

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentSelectTable.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentSelectTable.jspf
@@ -349,11 +349,6 @@
                         $('<td>', {
                             colspan: 4
                         }).append(
-                            $('<input/>', {
-                                type:     'hidden',
-                                name:     portletNamespace + attachmentContentId + '_text',
-                                value:    license.text
-                            }),
                             $('<span/>', {
                                 'class': 'license-text sw360-ellipsis',
                                 title: license.text ? license.text : '',


### PR DESCRIPTION
Sending license texts in the request to generate license info file is unnecessary. In some cases, it makes the request body so large that the tomcat refuses to serve it and the user receives HTTP 502 from the reverse proxy server.