### PR TITLE
fix(projects): fix assertion exception when requesting attachment uses with empty ids set

### DIFF
--- a/backend/src/src-attachments/src/main/java/org/eclipse/sw360/attachments/AttachmentHandler.java
+++ b/backend/src/src-attachments/src/main/java/org/eclipse/sw360/attachments/AttachmentHandler.java
@@ -11,7 +11,6 @@
 package org.eclipse.sw360.attachments;
 
 import com.google.common.collect.ImmutableSet;
-import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.db.AttachmentDatabaseHandler;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
@@ -170,8 +169,9 @@ public class AttachmentHandler implements AttachmentService.Iface {
         assertNotNull(owner);
         assertTrue(owner.isSet());
         assertNotNull(attachmentContentIds);
-        assertNotEmpty(attachmentContentIds);
-
+        if (attachmentContentIds.isEmpty()) {
+            return Collections.emptyList();
+        }
         return handler.getAttachmentUsages(owner, attachmentContentIds, filter);
     }
 

--- a/backend/src/src-attachments/src/test/java/org/eclipse/sw360/attachments/AttachmentHandlerTest.java
+++ b/backend/src/src-attachments/src/test/java/org/eclipse/sw360/attachments/AttachmentHandlerTest.java
@@ -210,6 +210,8 @@ public class AttachmentHandlerTest {
 
         Assert.assertThat(handler.getAttachmentsUsages(Source.releaseId("r1"), ImmutableSet.of("a11", "a12"), null),
                 Matchers.containsInAnyOrder(usage1, usage2, usage4, usage5));
+        Assert.assertThat(handler.getAttachmentsUsages(Source.releaseId("r1"), Collections.emptySet(), null),
+                Matchers.empty());
     }
 
     @Test


### PR DESCRIPTION
fix assertion exception when requesting attachment uses with empty ids set

closes eclipse/sw360#346