### PR TITLE
feat(rest): Add externalId endpoint (projects) to REST API

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -453,6 +453,10 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return repository.getCountByProjectId(id);
     }
 
+    public Set<Project> searchByExternalIds(Map<String, Set<String>> externalIds, User user) {
+        return repository.searchByExternalIds(externalIds, user);
+    }
+
     public Set<Project> getAccessibleProjects(User user) {
         return repository.getAccessibleProjects(user);
     }

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
@@ -132,6 +132,15 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
                     "  }" +
                     "}";
 
+    private static final String BY_EXTERNAL_IDS =
+            "function(doc) {" +
+                    "  if (doc.type == 'project') {" +
+                    "    for (var externalId in doc.externalIds) {" +
+                    "       emit( [externalId, doc.externalIds[externalId]] , doc._id);" +
+                    "    }" +
+                    "  }" +
+                    "}";
+
     public ProjectRepository(DatabaseConnector db) {
         super(Project.class, db, new ProjectSummary());
         initStandardDesignDocument();
@@ -218,6 +227,12 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
         // Filter BU to first three blocks
         String bu = getBUFromOrganisation(organisation);
         return queryByPrefix("buprojects", bu);
+    }
+
+    @View(name = "byexternalids", map = BY_EXTERNAL_IDS)
+    public Set<Project> searchByExternalIds(Map<String, Set<String>> externalIds, User user) {
+        Set<String> searchIds = queryForIdsAsComplexValues("byexternalids", externalIds);
+        return filterAccessibleProjectsByIds(user, searchIds);
     }
 
     public List<Project> getBUProjectsSummary(String organisation) {

--- a/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -156,6 +156,14 @@ public class ProjectHandler implements ProjectService.Iface {
         return handler.getCountByProjectId(id);
     }
 
+    @Override
+    public Set<Project> searchByExternalIds(Map<String, Set<String>> externalIds, User user) throws TException {
+        assertNotNull(externalIds);
+        assertUser(user);
+
+        return handler.searchByExternalIds(externalIds, user);
+    }
+
     ////////////////////////////
     // ADD INDIVIDUAL OBJECTS //
     ////////////////////////////

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseRepository.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2014-2018. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -13,10 +13,7 @@ package org.eclipse.sw360.datahandler.couchdb;
 import org.ektorp.*;
 import org.ektorp.support.CouchDbRepositorySupport;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -99,11 +96,22 @@ public class DatabaseRepository<T> extends CouchDbRepositorySupport<T> {
         return queryForIds(query);
     }
 
+    public Set<String> queryForIdsAsComplexValues(String queryName, Map<String, Set<String>> keys) {
+        Set<ComplexKey> complexKeys = keys.entrySet().stream()
+                .map(DatabaseRepository::createComplexKeys)
+                .flatMap(Collection::stream).collect(Collectors.toSet());
+        ViewQuery query = createQuery(queryName).keys(complexKeys);
+        return queryForIds(query);
+    }
+
+    private static Set<ComplexKey> createComplexKeys(Map.Entry<String, Set<String>> key) {
+        return key.getValue().stream().map(v -> ComplexKey.of(key.getKey(), v)).collect(Collectors.toSet());
+    }
+
     public Set<String> queryForIdsAsValue(String queryName, Set<String> keys) {
         ViewQuery query = createQuery(queryName).keys(keys);
         return queryForIdsAsValue(query);
     }
-
 
     public Set<String> queryForIds(String queryName, String startKey, String endKey) {
         ViewQuery query = createQuery(queryName).startKey(startKey).endKey(endKey);

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -309,4 +309,10 @@ service ProjectService {
      * get the count value of projects which have `id` in linkedProjects
      */
     i32 getCountByProjectId(1: string id);
+
+    /**
+     * get a set of projects based on the external id
+     * external ids can have multiple values to one key
+     */
+    set<Project> searchByExternalIds(1: map<string, set<string>> externalIds, 2: User user);
 }

--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -69,6 +69,22 @@ include::{snippets}/should_document_get_projects_by_type/http-response.adoc[]
 include::{snippets}/should_document_get_projects_by_type/links.adoc[]
 
 
+[[resources-project-get-project-by-externalids]]
+==== Listing by external ids
+
+A `GET` request will get all projects corresponding to external ids +
+The request parameter supports MultiValueMap (allows to add duplicate keys with different values)
+
+===== Response structure
+include::{snippets}/should_document_get_projects_by_external-ids/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_projects_by_external-ids/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_projects_by_external-ids/http-response.adoc[]
+
+
 [[resources-project-attachment-info-get]]
 ==== Listing attachment info
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -33,6 +33,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -105,6 +106,11 @@ public class Sw360ProjectService {
             final Project project = getProjectForUserById(projectId, sw360User);
             return project.getReleaseIdToUsage().keySet();
         }
+    }
+
+    public Set<Project> searchByExternalIds(Map<String, Set<String>> externalIds, User sw360User) throws TException {
+        final ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        return sw360ProjectClient.searchByExternalIds(externalIds, sw360User);
     }
 
     private ProjectService.Iface getThriftProjectClient() throws TTransportException {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -72,6 +72,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
 
     private Project project;
     private Attachment attachment;
+    private Map<String, Set<String>> externalIds;
 
     @Before
     public void before() throws TException {
@@ -88,6 +89,10 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         Map<String, ProjectReleaseRelationship> linkedReleases = new HashMap<>();
         Map<String, ProjectRelationship> linkedProjects = new HashMap<>();
         ProjectReleaseRelationship projectReleaseRelationship = new ProjectReleaseRelationship(CONTAINED, MAINLINE);
+
+        externalIds = new HashMap<>();
+        externalIds.put("portal-id", new HashSet<>(Arrays.asList("13319-XX3")));
+        externalIds.put("project-ext", new HashSet<>(Arrays.asList("515432", "7657")));
 
         List<Project> projectList = new ArrayList<>();
         List<Project> projectListByName = new ArrayList<>();
@@ -135,7 +140,10 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         project2.setPreevaluationDeadline("2018-07-17");
         project2.setSystemTestStart("2017-01-01");
         project2.setSystemTestEnd("2018-03-01");
-        project2.setExternalIds(Collections.singletonMap("mainline-id-project", "7657"));
+        Map<String, String> projExtKeys = new HashMap();
+        projExtKeys.put("mainline-id-project", "7657");
+        projExtKeys.put("portal-id", "13319-XX3");
+        project2.setExternalIds(projExtKeys);
         linkedReleases = new HashMap<>();
         linkedReleases.put("5578999", projectReleaseRelationship);
         project2.setReleaseIdToUsage(linkedReleases);
@@ -145,6 +153,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         Set<String> releaseIdsTransitive = new HashSet<>(Arrays.asList("3765276512", "5578999"));
 
         given(this.projectServiceMock.getProjectsForUser(anyObject())).willReturn(projectList);
+        given(this.projectServiceMock.searchByExternalIds(eq(externalIds), anyObject())).willReturn((new HashSet<>(projectList)));
         given(this.projectServiceMock.getProjectForUserById(eq(project.getId()), anyObject())).willReturn(project);
         given(this.projectServiceMock.searchProjectByName(eq(project.getName()), anyObject())).willReturn(projectListByName);
         given(this.projectServiceMock.getReleaseIds(eq(project.getId()), anyObject(), eq("false"))).willReturn(releaseIds);
@@ -282,6 +291,24 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                         responseFields(
                                 fieldWithPath("_embedded.sw360:projects[]name").description("The name of the project"),
                                 fieldWithPath("_embedded.sw360:projects[]version").description("The project version"),
+                                fieldWithPath("_embedded.sw360:projects[]projectType").description("The project type, possible values are: " + Arrays.asList(ProjectType.values())),
+                                fieldWithPath("_embedded.sw360:projects").description("An array of <<resources-projects, Projects resources>>"),
+                                fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
+                        )));
+    }
+
+    @Test
+    public void should_document_get_projects_by_externalIds() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/projects/searchByExternalIds?project-ext=515432&project-ext=7657&portal-id=13319-XX3")
+                .contentType(MediaTypes.HAL_JSON)
+                .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        responseFields(
+                                fieldWithPath("_embedded.sw360:projects[]name").description("The name of the project"),
+                                fieldWithPath("_embedded.sw360:projects[]version").description("The project version"),
+                                fieldWithPath("_embedded.sw360:projects[]externalIds").description("External Ids of the project"),
                                 fieldWithPath("_embedded.sw360:projects[]projectType").description("The project type, possible values are: " + Arrays.asList(ProjectType.values())),
                                 fieldWithPath("_embedded.sw360:projects").description("An array of <<resources-projects, Projects resources>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")


### PR DESCRIPTION
- new REST API endpoint to list projects based on external ids
- added documentation (project page)

closes eclipse/sw360#247

Signed-off-by: Thomas Maier <thomas.maier@evosoft.com>