### PR TITLE
fix(rest): Trying to sort components by an unsupported property causes NPE

### DIFF
--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceComparatorGenerator.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceComparatorGenerator.java
@@ -73,7 +73,10 @@ public class ResourceComparatorGenerator {
     private Comparator<Component> componentComparator(List<Component._Fields> fields) {
         Comparator<Component> comparator = Comparator.comparing(x -> true);
         for (Component._Fields field:fields) {
-            comparator = comparator.thenComparing(componentMap.get(field));
+            Comparator<Component> fieldComparator = componentMap.get(field);
+            if(fieldComparator != null) {
+                comparator = comparator.thenComparing(fieldComparator);
+            }
         }
         comparator = comparator.thenComparing(defaultComponentComparator());
         return comparator;


### PR DESCRIPTION
Currently the following request will throw an NPE:
`GET /components?page=0&sort=ownerCountry`

This PR will fix this bug.