### PR TITLE
chore(vulnerabilities): Improve handling of null values in lastUpdate

### DIFF
--- a/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityRepository.java
+++ b/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityRepository.java
@@ -36,7 +36,7 @@ public class VulnerabilityRepository extends DatabaseRepository<Vulnerability> {
 
     private static final String BY_LAST_UPDATE_VIEW =
             "function(doc) {" +
-                    "  if (doc.type == 'vulnerability' && doc.lastExternalUpdate != null) {" +
+                    "  if (doc.type == 'vulnerability') {" +
                     "    emit(doc.lastExternalUpdate, doc._id);" +
                     "  } " +
                     "}";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/vulnerabilities/VulnerabilitiesPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/vulnerabilities/VulnerabilitiesPortlet.java
@@ -147,7 +147,11 @@ public class VulnerabilitiesPortlet extends Sw360Portlet {
     }
 
     private boolean isFormattedTimeStamp(String potentialTimestamp) {
-        return potentialTimestamp.matches(YEAR_MONTH_DAY_REGEX);
+        if (isNullOrEmpty(potentialTimestamp)) {
+            return false;
+        } else {
+            return potentialTimestamp.matches(YEAR_MONTH_DAY_REGEX);
+        }
     }
 
     private void prepareDetailView(RenderRequest request, RenderResponse response) throws IOException, PortletException {

--- a/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/vulnerabilities/view.jsp
@@ -1,6 +1,6 @@
 <%--
   ~ Copyright (c) Bosch Software Innovations GmbH 2016.
-  ~ Copyright (c) Siemens AG 2016-2017. Part of the SW360 Portal Project.
+  ~ Copyright (c) Siemens AG 2016-2018. Part of the SW360 Portal Project.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
   ~
@@ -167,7 +167,7 @@
                          </core_rt:if>
                             "",
                     "3": "<sw360:out value='${vulnerability.publishDate}'/>",
-                    "4": "<sw360:out value='${vulnerability.lastExternalUpdate}'/>"
+                    "4": "<sw360:out value='${vulnerability.lastExternalUpdate}' default='not set'/>"
                 });
                 </core_rt:forEach>
 
@@ -190,7 +190,7 @@
                         {"title": "Publish date"},
                         {"title": "Last update"}
                     ],
-                    "order": [[4, 'desc'],[2, 'asc']],
+                    "order": [[4, 'desc'],[3, 'desc']],
                     "autoWidth": false
                 });
                 vulnerabilityTable.$('td').tooltip({"delay": 0, "track": true, "fade": 250});


### PR DESCRIPTION
In our specific vulnerability management system we don't have any information about last external update of the vulnerability. For SW360 the last external update value is necessary to list all vulnerabilities in the `vulnerability tab`. <br> <br>
This PR supports also vulnerabilities without any `lastExternalUpdate` information.

Signed-off-by: Thomas Maier <thomas.maier@evosoft.com>