### PR TITLE
fix(wsimport): remove projects from components that are created

### DIFF
--- a/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/domain/WsProjectVitalInformation.java
+++ b/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/domain/WsProjectVitalInformation.java
@@ -20,6 +20,7 @@ public class WsProjectVitalInformation {
     private String token;
     private String creationDate;
     private String lastUpdatedDate;
+    private String pluginName;
 
     public int getId() {
         return id;
@@ -59,5 +60,13 @@ public class WsProjectVitalInformation {
 
     public void setLastUpdatedDate(String lastUpdatedDate) {
         this.lastUpdatedDate = lastUpdatedDate;
+    }
+
+    public String getPluginName() {
+        return pluginName;
+    }
+
+    public void setPluginName(String pluginName) {
+        this.pluginName = pluginName;
     }
 }

--- a/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/entitytranslation/WsLicenseToSw360LicenseTranslator.java
+++ b/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/entitytranslation/WsLicenseToSw360LicenseTranslator.java
@@ -27,8 +27,8 @@ public class WsLicenseToSw360LicenseTranslator implements EntityTranslator<WsLic
 
     @Override
     public License apply(WsLicense wsLicense) {
-        String license = wsLicense.getName().replaceFirst(SUSPECTED, "");
-        String licenseWithDashes = license.replaceAll("\\s+","-").trim();
+        String license = wsLicense.getName().replaceFirst(SUSPECTED, "").trim();
+        String licenseWithDashes = license.replaceAll("[\\s+/]","-");
 
         License sw360License = new License();
         sw360License.setId(licenseWithDashes);

--- a/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/rest/WsImportService.java
+++ b/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/rest/WsImportService.java
@@ -19,12 +19,17 @@ import org.eclipse.sw360.wsimport.utility.WsTokenType;
 
 import java.io.IOException;
 
+import static org.eclipse.sw360.wsimport.utility.TranslationConstants.REQUEST__GET_PROJECT_VITALS;
+import static org.eclipse.sw360.wsimport.utility.TranslationConstants.REQUEST__GET_PROJECT_LICENSES;
+import static org.eclipse.sw360.wsimport.utility.TranslationConstants.REQUEST__GET_ORGANIZATION_PROJECT_VITALS;
+
+
 /**
  * @author ksoranko@verifa.io
  */
-public class WsImportProjectService {
+public class WsImportService {
 
-    private static final Logger LOGGER = Logger.getLogger(WsImportProjectService.class);
+    private static final Logger LOGGER = Logger.getLogger(WsImportService.class);
     private static final WsRestClient restClient = new WsRestClient();
     private static final Gson gson = new Gson();
 
@@ -32,9 +37,9 @@ public class WsImportProjectService {
         String projectVitalString;
         WsProjectVitalInformation projectVitalInformation = null;
         try {
-            projectVitalString = restClient.getData("getProjectVitals", projectToken, WsTokenType.PROJECT, tokenCredentials);
+            projectVitalString = restClient.getData(REQUEST__GET_PROJECT_VITALS, projectToken, WsTokenType.PROJECT, tokenCredentials);
         } catch (IOException ioe) {
-            LOGGER.error(ioe);
+            LOGGER.error("Exception with " + REQUEST__GET_PROJECT_VITALS + " request to " + tokenCredentials.getServerUrl() + ", with message:" + ioe);
             return null;
         }
         WsProjectVitals wsProjectVitals = gson.fromJson(projectVitalString, WsProjectVitals.class);
@@ -49,6 +54,7 @@ public class WsImportProjectService {
                     projectVitalInformation.getToken(),
                     projectVitalInformation.getCreationDate());
         } else {
+            LOGGER.error("WsProjectVitalInformation is empty...");
             return null;
         }
     }
@@ -56,18 +62,36 @@ public class WsImportProjectService {
     public WsLibrary[] getProjectLicenses(String projectToken, TokenCredentials tokenCredentials) throws JsonSyntaxException {
         String projectLibsString = null;
         try {
-            projectLibsString = restClient.getData("getProjectLicenses", projectToken, WsTokenType.PROJECT, tokenCredentials);
+            projectLibsString = restClient.getData(REQUEST__GET_PROJECT_LICENSES, projectToken, WsTokenType.PROJECT, tokenCredentials);
         } catch (IOException ioe) {
-            LOGGER.error(ioe);
+            LOGGER.error("Exception with " + REQUEST__GET_PROJECT_LICENSES + " request to " + tokenCredentials.getServerUrl() + ", with message:" + ioe);
             return null;
         }
         WsProjectLibs wsProjectLibs = gson.fromJson(projectLibsString, WsProjectLibs.class);
         if (wsProjectLibs != null) {
             return wsProjectLibs.getLibraries();
         } else {
+            LOGGER.error("WsProjectLibs is empty...");
             return null;
         }
 
+    }
+
+    public  WsProjectVitalInformation[] getOrganizationalProjectVitals(TokenCredentials tokenCredentials) throws JsonSyntaxException {
+        String projectVitalString;
+        try {
+            projectVitalString = restClient.getData(REQUEST__GET_ORGANIZATION_PROJECT_VITALS, tokenCredentials.getToken(), WsTokenType.ORGANIZATION, tokenCredentials);
+        } catch (IOException ioe) {
+            LOGGER.error("Exception with " + REQUEST__GET_ORGANIZATION_PROJECT_VITALS + " request to " + tokenCredentials.getServerUrl() + ", with message:" + ioe);
+            return null;
+        }
+        WsProjectVitals wsProjectVitals = gson.fromJson(projectVitalString, WsProjectVitals.class);
+        if (wsProjectVitals.getProjectVitals() != null) {
+            return wsProjectVitals.getProjectVitals();
+        } else {
+            LOGGER.error("WsProjectVitals is empty...");
+            return null;
+        }
     }
 
 }

--- a/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/rest/WsRestClient.java
+++ b/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/rest/WsRestClient.java
@@ -64,7 +64,6 @@ public class WsRestClient {
         String input = generateRequestBody(requestString, tokenCredentials.getUserKey(), type, token);
         HttpClient httpClient = getConfiguredHttpClient();
         HttpResponse response = getWsConnection(input, httpClient, tokenCredentials.getServerUrl());
-        String result = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
-        return result;
+        return IOUtils.toString(response.getEntity().getContent(), "UTF-8");
     }
 }

--- a/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/service/WsImportHandler.java
+++ b/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/service/WsImportHandler.java
@@ -14,7 +14,7 @@ package org.eclipse.sw360.wsimport.service;
 import com.google.gson.JsonSyntaxException;
 import org.apache.log4j.Logger;
 import org.eclipse.sw360.wsimport.domain.WsProject;
-import org.eclipse.sw360.wsimport.rest.WsImportProjectService;
+import org.eclipse.sw360.wsimport.rest.WsImportService;
 import org.eclipse.sw360.wsimport.thrift.ThriftUploader;
 import org.eclipse.sw360.wsimport.utility.TranslationConstants;
 import org.apache.thrift.TException;
@@ -39,7 +39,7 @@ public class WsImportHandler implements ProjectImportService.Iface {
     public synchronized ImportStatus importData(List<String> projectTokens, User user, TokenCredentials tokenCredentials) throws TException, JsonSyntaxException {
         List<WsProject> toImport = projectTokens
                 .stream()
-                .map(t -> new WsImportProjectService().getWsProject(t, tokenCredentials))
+                .map(t -> new WsImportService().getWsProject(t, tokenCredentials))
                 .collect(Collectors.toList());
 
         return new ThriftUploader().importWsProjects(toImport, user, tokenCredentials);

--- a/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/utility/TranslationConstants.java
+++ b/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/utility/TranslationConstants.java
@@ -26,6 +26,10 @@ public class TranslationConstants {
     public static final String APPLICATION_JSON = "application/json";
     public static final String VERSION_SUFFIX_REGEX = "$*?-SNAPSHOT|$*?.RELEASE|$*?-RELEASE|$*?RELEASE|$*?.Final";
 
+    public static final String REQUEST__GET_PROJECT_VITALS = "getProjectVitals";
+    public static final String REQUEST__GET_PROJECT_LICENSES = "getProjectLicenses";
+    public static final String REQUEST__GET_ORGANIZATION_PROJECT_VITALS = "getOrganizationProjectVitals";
+
     private TranslationConstants(){
         //Utility class with only static members
     }


### PR DESCRIPTION
At the moment Whitesource sees for example maven project submodules as components in other submodules so this PR goes through the project list and ensures that projects are not created as components in sw360. Also includes small code refactoring.

Signed-off-by: Kalle Soranko <ksoranko@verifa.io>