### PR TITLE
fix(license): fix problem in editing licenses

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/licenses/LicensesPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/licenses/LicensesPortlet.java
@@ -264,8 +264,7 @@ public class LicensesPortlet extends Sw360Portlet {
             }
         }
 
-        license = updateLicenseFromRequest(license, request);
-        return license;
+        return updateLicenseFromRequest(license, request);
     }
 
     private boolean checkLicenseExists(License license, User user, LicenseService.Iface client) {

--- a/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/editDetailSummary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/licenses/includes/editDetailSummary.jspf
@@ -86,7 +86,7 @@
                  checked="checked"
                </core_rt:if>
                <core_rt:if test="${isUserAtLeastClearingAdmin != 'Yes' || (licenseDetail.id != null && licenseDetail.checked == true)}">
-                 disabled="disabled"
+                 readonly="readonly"
                </core_rt:if> />
         is checked
       </label>


### PR DESCRIPTION
currently it is not possible to modify and update licenses via the UI, due to
the problem that the `disabled` checked-flag is not send back to the server in
the post request. Changing it to `readonly` fixes the problem.