### PR TITLE
fix(rest): do not answer with 404 if resource list is empty

### DIFF
--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceListController.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceListController.java
@@ -12,6 +12,7 @@
 
 package org.eclipse.sw360.datahandler.resourcelists;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -23,8 +24,10 @@ public class ResourceListController<T> {
 
         int fromIndex = paginationOptions.getOffset();
         int toIndex = paginationOptions.getPageEndIndex();
-        if(fromIndex >= sortedResources.size()) {
-            throw new PaginationParameterException("The page size of " + fromIndex + " exceeds the list size of 'sortedResources.size()'");
+        if(fromIndex == 0 && sortedResources.size() == 0) {
+            return new PaginationResult<>(new ArrayList<>(), 0, paginationOptions);
+        } else if(fromIndex >= sortedResources.size()) {
+             throw new PaginationParameterException("The page size of " + fromIndex + " exceeds the list size of " + sortedResources.size() + ".");
         } else if (toIndex > sortedResources.size()) {
             toIndex = sortedResources.size();
         }


### PR DESCRIPTION
Currently, if there are no components, one gets 404 with every request. This simple PR fixes that and returns an empty response if one asks for (the first) elements of an empty list.