### PR TITLE
feat(rest): Allow to search only by externalId-Key (without specific value)

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
@@ -166,7 +166,8 @@ public class ComponentRepository extends SummaryAwareRepository<Component> {
     }
 
     public Set<Component> searchByExternalIds(Map<String, Set<String>> externalIds) {
-        Set<String> ids = queryForIdsAsComplexValues("byExternalIds", externalIds);
-        return new HashSet<>(get(ids));
+        RepositoryUtils repositoryUtils = new RepositoryUtils();
+        Set<String> searchIds = repositoryUtils.searchByExternalIds(this, "byExternalIds", externalIds);
+        return new HashSet<>(get(searchIds));
     }
 }

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectRepository.java
@@ -237,7 +237,8 @@ public class ProjectRepository extends SummaryAwareRepository<Project> {
 
     @View(name = "byexternalids", map = BY_EXTERNAL_IDS)
     public Set<Project> searchByExternalIds(Map<String, Set<String>> externalIds, User user) {
-        Set<String> searchIds = queryForIdsAsComplexValues("byexternalids", externalIds);
+        RepositoryUtils repositoryUtils = new RepositoryUtils();
+        Set<String> searchIds = repositoryUtils.searchByExternalIds(this, "byexternalids", externalIds);
         return filterAccessibleProjectsByIds(user, searchIds);
     }
 

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
@@ -14,7 +14,6 @@ import org.eclipse.sw360.components.summary.ReleaseSummary;
 import org.eclipse.sw360.components.summary.SummaryType;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.couchdb.SummaryAwareRepository;
-import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.ektorp.ViewQuery;
@@ -139,7 +138,8 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
     }
 
     public Set<Release> searchByExternalIds(Map<String, Set<String>> externalIds) {
-        Set<String> ids = queryForIdsAsComplexValues("byExternalIds", externalIds);
-        return new HashSet<>(get(ids));
+        RepositoryUtils repositoryUtils = new RepositoryUtils();
+        Set<String> searchIds = repositoryUtils.searchByExternalIds(this, "byExternalIds", externalIds);
+        return new HashSet<>(get(searchIds));
     }
 }

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/RepositoryUtils.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/RepositoryUtils.java
@@ -17,13 +17,13 @@ import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.ektorp.DocumentOperationResult;
 
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 /**
  * @author johannes.najjar@tngtech.com
  */
 public class RepositoryUtils {
+
     //This works with any repository
     public static RequestSummary doBulk(Collection<?> objects, User user, DatabaseRepository<?> repository){
 
@@ -40,5 +40,23 @@ public class RepositoryUtils {
             requestSummary.setRequestStatus(RequestStatus.FAILURE);
         }
         return requestSummary;
+    }
+
+    public Set<String> searchByExternalIds(DatabaseRepository<?> repository, String queryName, Map<String, Set<String>> externalIds) {
+        Set<String> searchIds = new HashSet<>();
+        for (Iterator<Map.Entry<String, Set<String>>> it = externalIds.entrySet().iterator(); it.hasNext(); ) {
+            Map.Entry<String, Set<String>> externalId = it.next();
+            Set<String> externalValues = externalId.getValue();
+            if (externalValues.isEmpty() || (externalValues.size() == 1 && externalValues.iterator().next().isEmpty())) {
+                searchIds.addAll(repository.queryForIdsOnlyComplexKey(queryName, externalId.getKey()));
+                it.remove();
+            }
+        }
+
+        if (!externalIds.isEmpty()) {
+            searchIds.addAll(repository.queryForIdsAsComplexValues(queryName, externalIds));
+        }
+
+        return searchIds;
     }
 }

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseRepository.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseRepository.java
@@ -104,6 +104,22 @@ public class DatabaseRepository<T> extends CouchDbRepositorySupport<T> {
         return queryForIds(query);
     }
 
+    public Set<String> queryForIdsOnlyComplexKey(String queryName, String key) {
+        return queryForIdsOnlyComplexKeys(queryName, Collections.singleton(key));
+    }
+
+    public Set<String> queryForIdsOnlyComplexKeys(String queryName, Set<String> keys) {
+        Set<String> queryResult = new HashSet<>();
+        for (String key : keys) {
+            // If there is no value for the key just search for the key occurrence
+            // \ufff0 is used to ignore all other complex keys
+            ComplexKey startKeys = ComplexKey.of(key);
+            ComplexKey endKeys = ComplexKey.of(key, "\ufff0");
+            queryResult.addAll(queryForIds(queryName, startKeys, endKeys));
+        }
+        return queryResult;
+    }
+
     private static Set<ComplexKey> createComplexKeys(Map.Entry<String, Set<String>> key) {
         return key.getValue().stream().map(v -> ComplexKey.of(key.getKey(), v)).collect(Collectors.toSet());
     }
@@ -114,6 +130,11 @@ public class DatabaseRepository<T> extends CouchDbRepositorySupport<T> {
     }
 
     public Set<String> queryForIds(String queryName, String startKey, String endKey) {
+        ViewQuery query = createQuery(queryName).startKey(startKey).endKey(endKey);
+        return queryForIds(query);
+    }
+
+    public Set<String> queryForIds(String queryName, ComplexKey startKey, ComplexKey endKey) {
         ViewQuery query = createQuery(queryName).startKey(startKey).endKey(endKey);
         return queryForIds(query);
     }

--- a/rest/resource-server/src/docs/asciidoc/components.adoc
+++ b/rest/resource-server/src/docs/asciidoc/components.adoc
@@ -104,6 +104,23 @@ include::{snippets}/should_document_get_component/http-response.adoc[]
 include::{snippets}/should_document_get_component/links.adoc[]
 
 
+[[resources-components-get-by-externalids]]
+==== Listing by external ids
+
+A `GET` request will get all components corresponding to external ids +
+The request parameter supports MultiValueMap (allows to add duplicate keys with different values) +
+It's possible to search for components only by the external id key by leaving the value.
+
+===== Response structure
+include::{snippets}/should_document_get_components_by_external-ids/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_components_by_external-ids/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_components_by_external-ids/http-response.adoc[]
+
+
 [[resources-component-attachment-info-get]]
 ==== Listing attachment info
 

--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -73,7 +73,8 @@ include::{snippets}/should_document_get_projects_by_type/links.adoc[]
 ==== Listing by external ids
 
 A `GET` request will get all projects corresponding to external ids +
-The request parameter supports MultiValueMap (allows to add duplicate keys with different values)
+The request parameter supports MultiValueMap (allows to add duplicate keys with different values) +
+It's possible to search for projects only by the external id key by leaving the value.
 
 ===== Response structure
 include::{snippets}/should_document_get_projects_by_external-ids/response-fields.adoc[]
@@ -186,3 +187,18 @@ include::{snippets}/should_document_get_project_releases_ecc_information/http-re
 
 ===== Links
 include::{snippets}/should_document_get_project_releases_ecc_information/links.adoc[]
+
+
+[[resources-projects-create]]
+==== Creating a project
+
+A `POST` request is used to create a project
+
+===== Request structure
+include::{snippets}/should_document_create_project/request-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_create_project/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_create_project/http-response.adoc[]

--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -53,7 +53,8 @@ include::{snippets}/should_document_get_releases_with_fields/links.adoc[]
 ==== Listing by external ids
 
 A `GET` request will get all releases corresponding to external ids +
-The request parameter supports MultiValueMap (allows to add duplicate keys with different values)
+The request parameter supports MultiValueMap (allows to add duplicate keys with different values) +
+It's possible to search for releases only by the external id key by leaving the value.
 
 ===== Response structure
 include::{snippets}/should_document_get_releases_by_external-ids/response-fields.adoc[]
@@ -109,6 +110,21 @@ include::{snippets}/should_document_get_release/http-response.adoc[]
 
 ===== Links
 include::{snippets}/should_document_get_release/links.adoc[]
+
+
+[[resources-releases-create]]
+==== Creating a release
+
+A `POST` request is used to create a release
+
+===== Request structure
+include::{snippets}/should_document_create_release/request-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_create_release/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_create_release/http-response.adoc[]
 
 
 [[resources-release-update]]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -492,6 +492,7 @@ class JacksonCustomizations {
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonIgnoreProperties({
+                "id",
                 "revision",
                 "type",
                 "externalId",
@@ -521,6 +522,8 @@ class JacksonCustomizations {
                 "referencesSize",
                 "setPriorityToolTip",
                 "setCveReferences",
+                "assignedExtComponentIdsIterator",
+                "vendorAdvisoriesIterator",
                 "setIntReleaseId",
                 "cveReferencesSize",
                 "setDescription",
@@ -555,6 +558,7 @@ class JacksonCustomizations {
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonIgnoreProperties({
+                "id",
                 "revision",
                 "type",
                 "publishDate",
@@ -612,6 +616,8 @@ class JacksonCustomizations {
                 "setExtendedDescription",
                 "vulnerableConfigurationSize",
                 "assignedExtComponentIdsSize",
+                "assignedExtComponentIdsIterator",
+                "vendorAdvisoriesIterator",
                 "vendorAdvisoriesSize",
                 "setVendorAdvisories",
                 "cveFurtherMetaDataPerSourceSize",

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -24,6 +24,7 @@ import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
+import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
 import org.eclipse.sw360.rest.resourceserver.attachment.AttachmentController;
 import org.eclipse.sw360.rest.resourceserver.component.ComponentController;
 import org.eclipse.sw360.rest.resourceserver.license.LicenseController;
@@ -436,6 +437,12 @@ public class RestControllerHelper<T> {
         return embeddedUser;
     }
 
+    public Vendor convertToEmbeddedVendor(Vendor vendor) {
+        Vendor embeddedVendor = convertToEmbeddedVendor(vendor.getFullname());
+        embeddedVendor.setId(vendor.getId());
+        return embeddedVendor;
+    }
+
     public Vendor convertToEmbeddedVendor(String fullName) {
         Vendor embeddedVendor = new Vendor();
         embeddedVendor.setFullname(fullName);
@@ -454,6 +461,13 @@ public class RestControllerHelper<T> {
         attachment.setCheckedComment(null);
         attachment.setCheckStatus(null);
         return attachment;
+    }
+
+    public Vulnerability convertToEmbeddedVulnerability(Vulnerability vulnerability) {
+        Vulnerability embeddedVulnerability = new Vulnerability(vulnerability.getExternalId());
+        embeddedVulnerability.setId(vulnerability.getId());
+        embeddedVulnerability.setTitle(vulnerability.getTitle());
+        return embeddedVulnerability;
     }
 
     /**

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
@@ -52,13 +52,12 @@ public class VendorController implements ResourceProcessor<RepositoryLinksResour
         List<Vendor> vendors = vendorService.getVendors();
 
         List<Resource<Vendor>> vendorResources = new ArrayList<>();
-        for (Vendor vendor : vendors) {
-            Vendor embeddedVendor = restControllerHelper.convertToEmbeddedVendor(vendor.getFullname());
-            Resource<Vendor> vendorResource = new Resource<>(embeddedVendor);
-            vendorResources.add(vendorResource);
-        }
-        Resources<Resource<Vendor>> resources = new Resources<>(vendorResources);
+        vendors.forEach(v -> {
+            Vendor embeddedVendor = restControllerHelper.convertToEmbeddedVendor(v);
+            vendorResources.add(new Resource<>(embeddedVendor));
+        });
 
+        Resources<Resource<Vendor>> resources = new Resources<>(vendorResources);
         return new ResponseEntity<>(resources, HttpStatus.OK);
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -27,7 +27,6 @@ import org.springframework.hateoas.ResourceProcessor;
 import org.springframework.hateoas.Resources;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -52,17 +51,15 @@ public class VulnerabilityController implements ResourceProcessor<RepositoryLink
     public ResponseEntity<Resources<Resource<Vulnerability>>> getVulnerabilities() {
         User user = restControllerHelper.getSw360UserFromAuthentication();
         List<Vulnerability> vulnerabilities = vulnerabilityService.getVulnerabilities(user);
-
         List<Resource<Vulnerability>> vulnerabilityResources = new ArrayList<>();
-        for (Vulnerability vulnerability : vulnerabilities) {
-            vulnerability.setCwe(null);
-            vulnerability.setId(null);
-            vulnerability.setExternalId(null);
-            Resource<Vulnerability> vulnerabilityResource = new Resource<>(vulnerability);
-            vulnerabilityResources.add(vulnerabilityResource);
-        }
-        Resources<Resource<Vulnerability>> resources = new Resources<>(vulnerabilityResources);
 
+        vulnerabilities.forEach(v -> {
+            Vulnerability embeddedVulnerability = restControllerHelper.convertToEmbeddedVulnerability(v);
+            vulnerabilityResources.add(new Resource<>(embeddedVulnerability));
+
+        });
+
+        Resources<Resource<Vulnerability>> resources = new Resources<>(vulnerabilityResources);
         return new ResponseEntity<>(resources, HttpStatus.OK);
     }
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -35,6 +35,7 @@ import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static org.eclipse.sw360.datahandler.thrift.MainlineState.MAINLINE;
@@ -42,10 +43,11 @@ import static org.eclipse.sw360.datahandler.thrift.ReleaseRelationship.CONTAINED
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -173,8 +175,27 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.projectServiceMock.searchProjectByName(eq(project.getName()), anyObject())).willReturn(projectListByName);
         given(this.projectServiceMock.getReleaseIds(eq(project.getId()), anyObject(), eq("false"))).willReturn(releaseIds);
         given(this.projectServiceMock.getReleaseIds(eq(project.getId()), anyObject(), eq("true"))).willReturn(releaseIdsTransitive);
-        given(this.projectServiceMock.convertToEmbeddedWithExternalIds(eq(project))).willReturn(project);
-        given(this.projectServiceMock.convertToEmbeddedWithExternalIds(eq(project2))).willReturn(project2);
+        given(this.projectServiceMock.convertToEmbeddedWithExternalIds(eq(project))).willReturn(
+                new Project("Emerald Web")
+                        .setVersion("1.0.2")
+                        .setId("376576")
+                        .setDescription("Emerald Web provides a suite of components for Critical Infrastructures.")
+                        .setExternalIds(Collections.singletonMap("mainline-id-project", "515432"))
+                        .setProjectType(ProjectType.PRODUCT));
+        given(this.projectServiceMock.convertToEmbeddedWithExternalIds(eq(project2))).willReturn(
+                new Project("Orange Web")
+                        .setVersion("2.0.1")
+                        .setId("376570")
+                        .setDescription("Orange Web provides a suite of components for documentation.")
+                        .setExternalIds(projExtKeys)
+                        .setProjectType(ProjectType.PRODUCT));
+        when(this.projectServiceMock.createProject(anyObject(), anyObject())).then(invocation ->
+                new Project("Test Project")
+                        .setId("1234567890")
+                        .setDescription("This is the description of my Test Project")
+                        .setProjectType(ProjectType.PRODUCT)
+                        .setVersion("1.0")
+                        .setCreatedOn(new SimpleDateFormat("yyyy-MM-dd").format(new Date())));
 
         Release release = new Release();
         release.setId("3765276512");
@@ -415,5 +436,37 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                 .accept("application/*"))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document());
+    }
+
+    @Test
+    public void should_document_create_project() throws Exception {
+        Map<String, String> project = new HashMap<>();
+        project.put("name", "Test Project");
+        project.put("version", "1.0");
+        project.put("description", "This is the description of my Test Project");
+        project.put("projectType", ProjectType.PRODUCT.toString());
+
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        this.mockMvc.perform(post("/api/projects")
+                .contentType(MediaTypes.HAL_JSON)
+                .content(this.objectMapper.writeValueAsString(project))
+                .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isCreated())
+                .andDo(this.documentationHandler.document(
+                        requestFields(
+                                fieldWithPath("name").description("The name of the project"),
+                                fieldWithPath("description").description("The project description"),
+                                fieldWithPath("version").description("The version of the new project"),
+                                fieldWithPath("projectType").description("The project type, possible values are: " + Arrays.asList(ProjectType.values()))
+                        ),
+                        responseFields(
+                                fieldWithPath("name").description("The name of the project"),
+                                fieldWithPath("version").description("The project version"),
+                                fieldWithPath("createdOn").description("The date the project was created"),
+                                fieldWithPath("description").description("The project description"),
+                                fieldWithPath("projectType").description("The project type, possible values are: " + Arrays.asList(ProjectType.values())),
+                                fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
+                                fieldWithPath("_embedded.createdBy").description("The user who created this project")
+                        )));
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/VulnerabilitySpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/VulnerabilitySpecTest.java
@@ -109,7 +109,7 @@ public class VulnerabilitySpecTest extends TestRestDocsSpecBase {
                         ),
                         responseFields(
                                 fieldWithPath("_embedded.sw360:vulnerabilities[]title").description("The title of the vulnerability"),
-                                fieldWithPath("_embedded.sw360:vulnerabilities[]description").description("The vulnerability description"),
+                                fieldWithPath("_embedded.sw360:vulnerabilities[]externalId").description("The external Id of the vulnerability"),
                                 fieldWithPath("_embedded.sw360:vulnerabilities").description("An array of <<resources-vulnerabilities, Vulnerabilities resources>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
@@ -127,7 +127,6 @@ public class VulnerabilitySpecTest extends TestRestDocsSpecBase {
                                 linkWithRel("self").description("The <<resources-vulnerabilities, Vulnerabilities resource>>")
                         ),
                         responseFields(
-                                fieldWithPath("id").description("The id of the vulnerability"),
                                 fieldWithPath("title").description("The title of the vulnerability"),
                                 fieldWithPath("description").description("The vulnerability description"),
                                 fieldWithPath("externalId").description("The external Id"),


### PR DESCRIPTION
- allows to search for externalId keys without values like (.../searchByExternalIds?external-id-key or .../searchByExternalIds?external-id-key=)
- added some tests for missing API docs (create project, create release, externalIds for components...)
- some small bugfixes regarding vulnerability/vendor ids (URL selflink was null)

closes #361 

Signed-off-by: Thomas Maier <thomas.maier@evosoft.com>