### PR TITLE
chore(thrift): update thrift version to 0.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,12 @@ sudo: required
 dist: trusty
 language: java
 jdk: openjdk8
+addons:
+  apt:
+    packages:
+      - docker-ce
+services:
+  - docker
 
 cache:
   apt: true
@@ -34,14 +40,23 @@ script: mvn --fail-at-end $MVN_ARGS
 
 matrix:
   include:
-    - env: MVN_ARGS="package"
-    - env: MVN_ARGS="validate"
+    - name: mvn package
+      env: MVN_ARGS="package"
+    - name: mvn validate
+      env: MVN_ARGS="validate"
       before_install:
-    - env: MVN_ARGS="dependency:analyze -DfailOnWarning"
+    - name: mvn dependency:analyze
+      env: MVN_ARGS="dependency:analyze -DfailOnWarning"
       install: mvn package -DskipTests
-    - before_install: true
+    - name: check for license headers
+      before_install: true
       install: true
       script: .travis/testForLicenseHeaders.sh
-      env: DESC="test for license headers"
+    # the following job sadly runs into timeout
+    # - name: test docker install file
+    #   before_install: true
+    #   install: true
+    #   script: scripts/compileWithDocker.sh
   allow_failures:
-    - env: MVN_ARGS="dependency:analyze -DfailOnWarning"
+    - name: mvn dependency:analyze
+

--- a/libraries/lib-datahandler/pom.xml
+++ b/libraries/lib-datahandler/pom.xml
@@ -32,6 +32,7 @@
                 <version>0.1.11</version>
                 <configuration>
                     <thriftExecutable>thrift</thriftExecutable>
+                    <generator>java</generator>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <java.version>1.8</java.version>
         <liferay.version>6.2.2</liferay.version>
         <ektorp.version>1.4.4</ektorp.version>
-        <thrift.version>0.9.3</thrift.version>
+        <thrift.version>0.11.0</thrift.version>
         <guava.version>21.0</guava.version>
         <spring.version>4.3.12.RELEASE</spring.version>
         <spring-boot.version>1.5.8.RELEASE</spring-boot.version>

--- a/scripts/install-thrift.sh
+++ b/scripts/install-thrift.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # -----------------------------------------------------------------------------
-# Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
+# Copyright Siemens AG, 2013-2016.
+# Copyright (c) Bosch Software Innovations GmbH 2019.
+# Part of the SW360 Portal Project.
 #
 # All rights reserved. This configuration file is provided to you under the
 # terms and conditions of the Eclipse Distribution License v1.0 which
@@ -16,42 +18,72 @@
 
 set -ex
 
+VERSION=0.11.0
+
 BASEDIR="/tmp"
-BUILDDIR="${BASEDIR}/thrift-0.9.3"
+BUILDDIR="${BASEDIR}/thrift-$VERSION"
+
+has() { type "$1" &> /dev/null; }
+
+SUDO_CMD=""
+if [ "$EUID" -ne 0 ]; then
+   if has "sudo" ; then
+       SUDO_CMD="sudo "
+   fi
+fi
 
 if [[ ! -d "$BUILDDIR" ]]; then
     echo "-[shell provisioning] Extracting thrift"
-    if [ -e /vagrant_shared/packages/thrift-0.9.3.tar.gz ]; then
-        tar -xzf /vagrant_shared/packages/thrift-0.9.3.tar.gz -C $BASEDIR
+    if [ -e "/vagrant_shared/packages/thrift-$VERSION.tar.gz" ]; then
+        tar -xzf "/vagrant_shared/packages/thrift-$VERSION.tar.gz" -C $BASEDIR
     else
-        apt-get update
-        apt-get install -y curl
+        if has "apt-get" ; then
+            $SUDO_CMD apt-get update
+            $SUDO_CMD apt-get install -y curl
+        elif has "apk" ; then
+            $SUDO_CMD apk --update add curl
+        else
+            echo "no supported package manager found"
+            exit 1
+        fi
 
-        TGZ="${BASEDIR}/thrift-0.9.3.tar.gz"
+        TGZ="${BASEDIR}/thrift-$VERSION.tar.gz"
 
-        curl -z $TGZ -o $TGZ http://ftp.fau.de/apache/thrift/0.9.3/thrift-0.9.3.tar.gz
+        curl -z $TGZ -o $TGZ http://archive.apache.org/dist/thrift/$VERSION/thrift-$VERSION.tar.gz
         tar -xzf $TGZ -C $BASEDIR
 
-        [[ "$1" != "--no-cleanup" ]] && rm "${BASEDIR}/thrift-0.9.3.tar.gz"
+        [[ "$1" != "--no-cleanup" ]] && rm "${BASEDIR}/thrift-$VERSION.tar.gz"
     fi
 fi
 
 cd "$BUILDDIR"
 if [[ ! -f "./compiler/cpp/thrift" ]]; then
     echo "-[shell provisioning] Installing dependencies of thrift"
-    apt-get update
-    apt-get install -y libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
+
+    if has "apt-get" ; then
+        $SUDO_CMD apt-get update
+        $SUDO_CMD apt-get install -y libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
+    elif has "apk" ; then
+        $SUDO_CMD apk --update add g++ make apache-ant libtool automake autoconf bison flex
+    else
+        echo "no supported package manager found"
+        exit 1
+    fi
 
     echo "-[shell provisioning] Building thrift"
     if [[ ! -f "./Makefile" ]]; then
-        ./configure --without-test --without-erlang --without-python --without-cpp --without-php --without-haskell --without-go
+        ./configure --with-java  \
+                    --without-cpp --without-qt4 --without-c_glib --without-csharp --without-erlang --without-perl --without-php \
+                    --without-php_extension --without-python --without-ruby --without-haskell --without-go --without-d \
+                    --without-haskell --without-php --without-ruby --without-python --without-erlang --without-perl \
+                    --without-c_sharp --without-d --without-php --without-go --without-lua --without-nodejs --without-cl
     fi
     make
 fi
 
 echo "-[shell provisioning] Installing thrift"
-make install
+$SUDO_CMD make install
 
-[[ "$1" != "--no-cleanup" ]] && rm -rf "$BUILDDIR"
-
-exit 0
+if [[ "$1" != "--no-cleanup" ]]; then
+    $SUDO_CMD rm -rf "$BUILDDIR"
+fi

--- a/sw360dev.Dockerfile
+++ b/sw360dev.Dockerfile
@@ -8,25 +8,17 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 
+# This can be used to compile SW360 via:
+# $ docker build -f sw360dev.Dockerfile -t sw360/sw360dev --rm=true --force-rm=true .
+# $ docker run -i -v $(pwd):/sw360portal -w /sw360portal --net=host sw360/sw360dev su-exec $(id -u):$(id -g) mvn package -DskipTests
+
 FROM maven:3.5.0-jdk-8-alpine
 MAINTAINER Maximilian Huber <maximilian.huber@tngtech.com>
 
+ADD scripts/install-thrift.sh /install-thrift.sh
 RUN set -x \
  &&  apk --update add su-exec git \
-     wget g++ make apache-ant libtool automake autoconf bison flex \
- && rm -rf /var/cache/apk/* \
- && cd /tmp \
- && wget -q 'https://github.com/apache/thrift/archive/0.9.3.tar.gz' -O thrift.tar.gz \
- && tar xzf thrift.tar.gz && rm thrift.tar.gz && cd thrift* \
- && ./bootstrap.sh \
- && ./configure --prefix=/usr \
-        --with-java  \
-        --without-cpp --without-qt4 --without-c_glib --without-csharp --without-erlang --without-perl --without-php \
-        --without-php_extension --without-python --without-ruby --without-haskell --without-go --without-d \
-        --without-haskell --without-php --without-ruby --without-python --without-erlang --without-perl \
-        --without-c_sharp --without-d --without-php --without-go --without-lua --without-nodejs \
- && make \
- && make install \
- && rm -rf /tmp/thrift*
+ && /install-thrift.sh \
+ && rm -rf /var/cache/apk/*
 
 CMD /bin/bash


### PR DESCRIPTION
It would also possible to update to thrift 0.12.0, but the corresponding libthrift is not yet available on maven central.

This also implies that one needs to update the thrift compiler on the build host to version 0.11.0, this can be done via the script `scripts/install-thrift.sh` (e.g. on ubuntu).