### PR TITLE
refactor(velocity): update to new version

### DIFF
--- a/backend/src/src-licenseinfo/pom.xml
+++ b/backend/src/src-licenseinfo/pom.xml
@@ -11,6 +11,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- We need at least 3.8.1 since it is a dependency from velocity -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.8.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -35,14 +47,14 @@
             <version>2.1.0</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
-            <version>1.7</version>
+              <groupId>org.apache.velocity</groupId>
+              <artifactId>velocity-engine-core</artifactId>
+              <version>2.0</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity-tools</artifactId>
-            <version>2.0</version>
+              <groupId>org.apache.velocity.tools</groupId>
+              <artifactId>velocity-tools-generic</artifactId>
+              <version>3.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
@@ -58,6 +70,18 @@
             <groupId>net.sf.saxon</groupId>
             <artifactId>saxon-dom</artifactId>
             <version>8.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+            <version>2.1.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jaxen</groupId>
+            <artifactId>jaxen</artifactId>
+            <version>1.1.6</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <parent>

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -17,25 +17,24 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import org.apache.log4j.Logger;
-import org.apache.thrift.TException;
-import org.eclipse.sw360.datahandler.db.AttachmentDatabaseHandler;
+
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.common.WrappedException.WrappedTException;
+import org.eclipse.sw360.datahandler.db.AttachmentDatabaseHandler;
 import org.eclipse.sw360.datahandler.db.ComponentDatabaseHandler;
-import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
-import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
-import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
-import org.eclipse.sw360.datahandler.thrift.components.Component;
-import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.*;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.licenseinfo.outputGenerators.*;
 import org.eclipse.sw360.licenseinfo.parsers.*;
 import org.eclipse.sw360.licenseinfo.util.LicenseNameWithTextUtils;
+
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
 
 import java.net.MalformedURLException;
 import java.util.*;
@@ -46,8 +45,8 @@ import java.util.stream.Collectors;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
 import static org.eclipse.sw360.datahandler.common.SW360Assert.assertNotNull;
 import static org.eclipse.sw360.datahandler.common.WrappedException.wrapTException;
-import static org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatVariant.REPORT;
 import static org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatVariant.DISCLOSURE;
+import static org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatVariant.REPORT;
 
 /**
  * Implementation of the Thrift service
@@ -380,7 +379,12 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
 
         parsingResults.forEach(result -> {
             if( component != null) {
-                result.setComponentType(toString(component.getComponentType()));
+                if (component.getComponentType() != null) {
+                    result.setComponentType(toString(component.getComponentType()));
+                } else {
+                    LOGGER.warn("Component with [" + component.getId() + ": " + component.getName() + "] has no type!");
+                    result.setComponentType("");
+                }
             } else {
                 // just being extra defensive
                 result.setComponentType("Unknown component.");

--- a/backend/src/src-licenseinfo/src/main/resources/textLicenseInfoFile.vm
+++ b/backend/src/src-licenseinfo/src/main/resources/textLicenseInfoFile.vm
@@ -14,6 +14,8 @@ Open Source Software Contained in this Product/Device:
 #foreach($releaseName in $licenseInfoResults.keySet()) #set($errorResults=[])
 * $releaseName #foreach($errorResult in $licenseInfoErrorResults.get($releaseName))
 (ERROR when reading license information from file $errorResult.licenseInfo.filenames[0]: $errorResult.message) #end
+## The following empty line is needed to ensure that every release gets a new line
+
 #end
 
 

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Bosch Software Innovations GmbH, 2016.
- * With modifications by Siemens AG, 2018.
+ * With modifications by Siemens AG, 2018-2019.
  * Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
@@ -11,10 +11,13 @@
  * http://www.eclipse.org/legal/epl-v10.html
  */
 package org.eclipse.sw360.licenseinfo.outputGenerators;
-import org.eclipse.sw360.datahandler.thrift.projects.Project;
+
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.*;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+
 import org.dom4j.Document;
 import org.dom4j.Element;
+import org.dom4j.Node;
 import org.dom4j.Text;
 import org.dom4j.io.SAXReader;
 import org.junit.BeforeClass;
@@ -263,14 +266,18 @@ public class XhtmlGeneratorTest {
 
         for (Iterator iter = list.iterator(); iter.hasNext(); ) {
             Element element = (Element) iter.next();
-            for (Object liObject : element.content()) {
-                Element liElement = (Element) liObject;
-                String licenseEntryId = liElement.attribute("id").getValue();
-                String licenseTextId = licenseEntryId.replace("licenseEntry","licenseText");
-                List licenseTexts = document.selectNodes("//*[local-name()='pre'][@id='" + licenseTextId + "']/text()");
-                Object licenseText = licenseTexts.stream().map(l -> ((Text) l).getStringValue()).reduce("", (BinaryOperator<String>)(l1, l2)-> (String) (l1+l2));
-                result.append(((String) licenseText).trim());
-                result.append("\n");
+            for (Node liObject : element.content()) {
+                if (liObject.getNodeType() == Node.ELEMENT_NODE) {
+                    Element liElement = (Element) liObject;
+                    String licenseEntryId = liElement.attribute("id").getValue();
+                    String licenseTextId = licenseEntryId.replace("licenseEntry", "licenseText");
+                    List licenseTexts = document
+                            .selectNodes("//*[local-name()='pre'][@id='" + licenseTextId + "']/text()");
+                    Object licenseText = licenseTexts.stream().map(l -> ((Text) l).getStringValue()).reduce("",
+                            (BinaryOperator<String>) (l1, l2) -> (String) (l1 + l2));
+                    result.append(((String) licenseText).trim());
+                    result.append("\n");
+                }
             }
         }
 

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentSelectTable.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentSelectTable.jspf
@@ -306,7 +306,7 @@
                         });
 
                         loadedCallback();
-                    }).error(function(xhr, type, error) {
+                    }).fail(function(xhr, type, error) {
                         data.loaded = false;
                         renderErrorMessage($linkedProjectsInfoTable, node, data.ttId, error);
                         loadedCallback(error);
@@ -422,7 +422,7 @@
                                 }
                             });
                         }
-                    }).error(function(error) {
+                    }).fail(function(error) {
                         $('#infobar').removeClass('backgroundWarning').addClass('backgroundAlert').html($('<span>', {
                             text: "Cannot load previous selection: " + error.statusText + ' (' + error.status + ')'
                         }));


### PR DESCRIPTION
* the new version of tools does not contain dom4j as dependency anymore. As we use it in the tests it is now directly declared with scope test
* the template for text license info files was modified to ensure that every release is on its own line
* deprecated and removed jquery api was fixed (error replaced by fail)

Closes #128

Signed-off-by: Leo von Klenze <leo.vonklenze@scansation.de>