### PR TITLE
chores(quick-deploy): add quick deploy for portlet

### DIFF
--- a/backend/svc/pom.xml
+++ b/backend/svc/pom.xml
@@ -79,6 +79,7 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-war-plugin</artifactId>
+              <version>2.2</version>
               <configuration>
                 <outputDirectory>${webapps.dir}</outputDirectory>
               </configuration>

--- a/frontend/sw360-portlet/pom.xml
+++ b/frontend/sw360-portlet/pom.xml
@@ -32,6 +32,8 @@
         <jquery.treetable.version>3.2.0</jquery.treetable.version>
         <jquery.validation.version>1.19.0</jquery.validation.version>
         <resumable.js.version>1.1.0</resumable.js.version>
+        <context.antiJARLocking>true</context.antiJARLocking>
+        <context.antiResourceLocking>true</context.antiResourceLocking>
     </properties>
 
     <artifactId>sw360-portlet</artifactId>
@@ -94,6 +96,20 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.2</version>
+                <configuration>
+                    <webResources>
+                        <resource>
+                            <directory>src/main/webapp/META-INF</directory>
+                            <filtering>true</filtering>
+                            <targetPath>META-INF</targetPath>
+                        </resource>
+                    </webResources>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -307,6 +323,13 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>develop</id>
+            <properties>
+                <context.antiJARLocking>false</context.antiJARLocking>
+                <context.antiResourceLocking>false</context.antiResourceLocking>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/frontend/sw360-portlet/src/main/webapp/META-INF/context.xml
+++ b/frontend/sw360-portlet/src/main/webapp/META-INF/context.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+  ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  -->
+<Context
+    antiJARLocking="${context.antiJARLocking}"
+    antiResourceLocking="${context.antiResourceLocking}"
+/>
+


### PR DESCRIPTION
This commit is an addition to the quick deploy PR sw360/sw360-chores#55

In order to prevent the Tomcat from creating a temp directory for the webapp
from which the webapp is service, the following context settings are
necessary:
  - antiJARLocking=false
  - antiResourceLocking=false

If the webapp provides no context file, liferay generates such a file with
both settings set to true.

This commit introduces an own context file which is filled based on properties.
These propterties are "true" by default but can be set to "false" by using
the maven profile "develop" on building.

Signed-off-by: Leo von Klenze <leo.vonklenze@scansation.de>