### PR TITLE
fix(auth): fix screen name auth problem

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/UserRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/UserRepository.java
@@ -34,7 +34,7 @@ import java.util.Set;
         @View(name = "all",
                 map = "function(doc) { if (doc.type == 'user') emit(null, doc._id) }"),
         @View(name = "byExternalId",
-                map = "function(doc) { if (doc.type == 'user') emit(doc.externalid, doc._id) }"),
+                map = "function(doc) { if (doc.type == 'user') emit(doc.externalid.toLowerCase(), doc._id) }"),
         @View(name = "byApiToken",
                 map = "function(doc) { if (doc.type == 'user') " +
                         "  for (var i in doc.restApiTokens) {" +
@@ -66,7 +66,7 @@ public class UserRepository extends SummaryAwareRepository<User> {
     }
 
     public User getByExternalId(String externalId) {
-        final Set<String> userIds = queryForIdsAsValue("byExternalId", externalId);
+        final Set<String> userIds = queryForIdsAsValue("byExternalId", externalId.toLowerCase());
         return getUserFromIds(userIds);
     }
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -94,7 +94,7 @@ public class RestControllerHelper<T> {
     public User getSw360UserFromAuthentication() {
         try {
             String userId = (String) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-            return userService.getUserByEmail(userId);
+            return userService.getUserByEmailOrExternalId(userId);
         } catch (RuntimeException e) {
             throw new AuthenticationServiceException("Could not load user from authentication.");
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/user/Sw360UserService.java
@@ -46,6 +46,15 @@ public class Sw360UserService {
         }
     }
 
+    public User getUserByEmailOrExternalId(String userIdentifier) {
+        try {
+            UserService.Iface sw360UserClient = getThriftUserClient();
+            return sw360UserClient.getByEmailOrExternalId(userIdentifier, userIdentifier);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public User getUser(String id) {
         try {
             UserService.Iface sw360UserClient = getThriftUserClient();

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
@@ -77,7 +77,7 @@ public class ComponentTest extends TestIntegrationBase {
         user.setEmail("admin@sw360.org");
         user.setFullname("John Doe");
 
-        given(this.userServiceMock.getUserByEmail("admin@sw360.org")).willReturn(user);
+        given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(user);
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ProjectTest.java
@@ -59,7 +59,7 @@ public class ProjectTest extends TestIntegrationBase {
         user.setEmail("admin@sw360.org");
         user.setFullname("John Doe");
 
-        given(this.userServiceMock.getUserByEmail("admin@sw360.org")).willReturn(user);
+        given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(user);
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
@@ -78,7 +78,7 @@ public class ReleaseTest extends TestIntegrationBase {
         user.setEmail("admin@sw360.org");
         user.setFullname("John Doe");
 
-        given(this.userServiceMock.getUserByEmail("admin@sw360.org")).willReturn(user);
+        given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(user);
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/AttachmentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/AttachmentSpecTest.java
@@ -109,7 +109,7 @@ public class AttachmentSpecTest extends TestRestDocsSpecBase {
         user.setEmail("admin@sw360.org");
         user.setFullname("John Doe");
 
-        given(this.userServiceMock.getUserByEmail("admin@sw360.org")).willReturn(user);
+        given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(user);
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -153,10 +153,10 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                         .setExternalIds(Collections.singletonMap("component-id-key", "c77321"))
         );
 
+        given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(
+                new User("admin@sw360.org", "sw360").setId("123456789"));
         given(this.userServiceMock.getUserByEmail("admin@sw360.org")).willReturn(
                 new User("admin@sw360.org", "sw360").setId("123456789"));
-        given(this.userServiceMock.getUserByEmail("jane@sw360.org")).willReturn(
-                new User("jane@sw360.org", "sw360").setId("209582812"));
         given(this.userServiceMock.getUserByEmail("john@sw360.org")).willReturn(
                 new User("john@sw360.org", "sw360").setId("74427996"));
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -232,6 +232,8 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         given(this.releaseServiceMock.getReleaseForUserById(eq(release.getId()), anyObject())).willReturn(release);
         given(this.releaseServiceMock.getReleaseForUserById(eq(release2.getId()), anyObject())).willReturn(release2);
 
+        given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(
+                new User("admin@sw360.org", "sw360").setId("123456789"));
         given(this.userServiceMock.getUserByEmail("admin@sw360.org")).willReturn(
                 new User("admin@sw360.org", "sw360").setId("123456789"));
         given(this.userServiceMock.getUserByEmail("jane@sw360.org")).willReturn(

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/VulnerabilitySpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/VulnerabilitySpecTest.java
@@ -90,7 +90,7 @@ public class VulnerabilitySpecTest extends TestRestDocsSpecBase {
         user.setEmail("admin@sw360.org");
         user.setFullname("John Doe");
 
-        given(this.userServiceMock.getUserByEmail("admin@sw360.org")).willReturn(user);
+        given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(user);
 
         given(this.vulnerabilityServiceMock.getVulnerabilities(anyObject())).willReturn(vulnerabilityList);
         given(this.vulnerabilityServiceMock.getVulnerabilityByExternalId(eq(vulnerability.getExternalId()), anyObject())).willReturn(vulnerability);


### PR DESCRIPTION
This PR adds the possibility to use the rest auth server using the screen name (or ldap name) instead of the email address. This is necessary e.g. if someone configured SW360 to use the screen name as login.

To test that one could use an existing instance, change the login to "login via screen name"  and try to use rest-auth. Instead of the email address one then needs to pass the screen name in the request.