### PR TITLE
chore(thrift): build thrift with `--without-java` flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ cache:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y couchdb
-  - sudo ./scripts/install-thrift.sh --no-cleanup
   - sudo service couchdb restart
+  - ./scripts/install-thrift.sh --no-cleanup
 install: mvn dependency:resolve || true
 
 env: MVN_ARGS="package"

--- a/scripts/compileWithDocker.sh
+++ b/scripts/compileWithDocker.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright (c) Bosch Software Innovations GmbH 2019.
+# Part of the SW360 Portal Project.
+#
+# SPDX-License-Identifier: EPL-1.0
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+tempdir=$(mktemp -d)
+mkdir -p "$tempdir/scripts"
+cp "$DIR/scripts/install-thrift.sh" "$tempdir/scripts"
+pushd $tempdir
+docker build \
+    -f "$DIR/sw360dev.Dockerfile" \
+    -t sw360/sw360dev \
+    --rm=true --force-rm=true \
+    $tempdir
+popd
+rm -r $tempdir
+
+docker run -i \
+    -v "$DIR":/sw360portal \
+    -w /sw360portal \
+    --net=host \
+    sw360/sw360dev \
+    su-exec $(id -u):$(id -g) \
+    mvn package -DskipTests

--- a/scripts/install-thrift.sh
+++ b/scripts/install-thrift.sh
@@ -16,7 +16,7 @@
 # initial author: birgit.heydenreich@tngtech.com
 # -----------------------------------------------------------------------------
 
-set -ex
+set -e
 
 VERSION=0.11.0
 
@@ -25,12 +25,24 @@ BUILDDIR="${BASEDIR}/thrift-$VERSION"
 
 has() { type "$1" &> /dev/null; }
 
+if has "thrift"; then
+    if thrift --version | grep -q "$VERSION"; then
+        echo "thrift is already installed at $(which thrift)"
+        exit 0
+    else
+        echo "thrift is already installed but does not have the correct version: $VERSION"
+        exit 1
+    fi
+fi
+
 SUDO_CMD=""
 if [ "$EUID" -ne 0 ]; then
    if has "sudo" ; then
        SUDO_CMD="sudo "
    fi
 fi
+
+set -x
 
 if [[ ! -d "$BUILDDIR" ]]; then
     echo "-[shell provisioning] Extracting thrift"
@@ -72,11 +84,11 @@ if [[ ! -f "./compiler/cpp/thrift" ]]; then
 
     echo "-[shell provisioning] Building thrift"
     if [[ ! -f "./Makefile" ]]; then
-        ./configure --with-java  \
-                    --without-cpp --without-qt4 --without-c_glib --without-csharp --without-erlang --without-perl --without-php \
-                    --without-php_extension --without-python --without-ruby --without-haskell --without-go --without-d \
-                    --without-haskell --without-php --without-ruby --without-python --without-erlang --without-perl \
-                    --without-c_sharp --without-d --without-php --without-go --without-lua --without-nodejs --without-cl
+        ./configure --without-java --without-cpp --without-qt4 --without-c_glib --without-csharp --without-erlang \
+                    --without-perl --without-php --without-php_extension --without-python --without-ruby \
+                    --without-haskell --without-go --without-d --without-haskell --without-php --without-ruby \
+                    --without-python --without-erlang --without-perl --without-c_sharp --without-d --without-php \
+                    --without-go --without-lua --without-nodejs --without-cl
     fi
     make
 fi


### PR DESCRIPTION
This minor change. We do not need to build with the `--with-java` flag, since we get the java libraries from maven. We only need the core compiler.
If this java is not disabled, the thrift build step tries to download a jar dependency while compiling.

##

This can be tested by running 
```
$ mvn clean
$ scripts/compileWithDocker.sh
```
and is also used by travis, so travis also tests the changes here.