### PR TITLE
fix(treetables): fix inconsistent indentation in treetables

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/css/jquery.treetable.theme.sw360.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/jquery.treetable.theme.sw360.css
@@ -10,7 +10,6 @@
 table.treetable span {
   background-position: center left;
   background-repeat: no-repeat;
-  padding: .2em 0 .2em 1.5em;
 }
 
 table.treetable span.file {


### PR DESCRIPTION
`<sw360:out>` tag adds a `<span>` around the text when it is necessary to abbreviate it. Padding such `span`s inside treetables leads to inconsistent and misleading indentation.

Removing the padding seems to have no drawbacks.