### PR TITLE
feat(duplicates): added support to prevent duplicate projects/components/releases

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2018. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2019. Part of the SW360 Portal Project.
  * With modifications by Bosch Software Innovations GmbH, 2016.
  *
  * SPDX-License-Identifier: EPL-1.0
@@ -11,12 +11,8 @@
  */
 package org.eclipse.sw360.datahandler.db;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Lists;
-import org.apache.log4j.Logger;
-import org.apache.thrift.TException;
+import com.google.common.collect.*;
+
 import org.eclipse.sw360.components.summary.SummaryType;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
@@ -40,6 +36,9 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.mail.MailConstants;
 import org.eclipse.sw360.mail.MailUtil;
+
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
 import org.ektorp.DocumentOperationResult;
 import org.ektorp.http.HttpClient;
 import org.jetbrains.annotations.NotNull;
@@ -59,7 +58,9 @@ import static org.eclipse.sw360.datahandler.common.SW360Assert.assertNotNull;
 import static org.eclipse.sw360.datahandler.common.SW360Assert.fail;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 import static org.eclipse.sw360.datahandler.thrift.ThriftUtils.copyFields;
-import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.*;
+import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.ensureEccInformationIsSet;
+import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.prepareComponents;
+import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.prepareReleases;
 
 /**
  * Class for accessing Component information from the database
@@ -400,7 +401,9 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         Component actual = componentRepository.get(component.getId());
         assertNotNull(actual, "Could not find component to update!");
 
-        if (makePermission(actual, user).isActionAllowed(RequestedAction.WRITE)) {
+        if (changeWouldResultInDuplicate(actual, component)) {
+            return RequestStatus.DUPLICATE;
+        } else if (makePermission(actual, user).isActionAllowed(RequestedAction.WRITE)) {
             // Nested releases and attachments should not be updated by this method
             if (actual.isSetReleaseIds()) {
                 component.setReleaseIds(actual.getReleaseIds());
@@ -415,6 +418,15 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         }
         return RequestStatus.SUCCESS;
 
+    }
+
+    private boolean changeWouldResultInDuplicate(Component before, Component after) {
+        if (before.getName().equals(after.getName())) {
+            // sth else was changed, not one of the duplication relevant properties
+            return false;
+        }
+
+        return isDuplicate(after);
     }
 
     private void updateComponentInternal(Component updated, Component current, User user) {
@@ -609,39 +621,54 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
         if (actual.equals(release)) {
             return RequestStatus.SUCCESS;
-        }
-        DocumentPermissions<Release> permissions = makePermission(actual, user);
-        boolean hasChangesInEccFields = hasChangesInEccFields(release, actual);
-
-        if ((hasChangesInEccFields && permissions.isActionAllowed(RequestedAction.WRITE_ECC)) ||
-                (!hasChangesInEccFields && permissions.isActionAllowed(RequestedAction.WRITE))) {
-
-            if (!hasChangesInEccFields && hasEmptyEccFields(release)) {
-                autosetEccFieldsForReleaseWithDownloadUrl(release);
-            }
-
-            copyFields(actual, release, immutableFields);
-
-            autosetReleaseClearingState(release, actual);
-            if (hasChangesInEccFields) {
-                autosetEccUpdaterInfo(release, user);
-            }
-            release.setAttachments( getAllAttachmentsToKeep(toSource(actual), actual.getAttachments(), release.getAttachments()) );
-            deleteAttachmentUsagesOfUnlinkedReleases(release, actual);
-            releaseRepository.update(release);
-            updateReleaseDependentFieldsForComponentId(release.getComponentId());
-            //clean up attachments in database
-            attachmentConnector.deleteAttachmentDifference(nullToEmptySet(actual.getAttachments()),nullToEmptySet(release.getAttachments()));
-            sendMailNotificationsForReleaseUpdate(release, user.getEmail());
+        } else if (changeWouldResultInDuplicate(actual, release)) {
+            return RequestStatus.DUPLICATE;
         } else {
-            if (hasChangesInEccFields) {
-                return releaseModerator.updateReleaseEccInfo(release, user);
+            DocumentPermissions<Release> permissions = makePermission(actual, user);
+            boolean hasChangesInEccFields = hasChangesInEccFields(release, actual);
+
+            if ((hasChangesInEccFields && permissions.isActionAllowed(RequestedAction.WRITE_ECC))
+                    || (!hasChangesInEccFields && permissions.isActionAllowed(RequestedAction.WRITE))) {
+
+                if (!hasChangesInEccFields && hasEmptyEccFields(release)) {
+                    autosetEccFieldsForReleaseWithDownloadUrl(release);
+                }
+
+                copyFields(actual, release, immutableFields);
+
+                autosetReleaseClearingState(release, actual);
+                if (hasChangesInEccFields) {
+                    autosetEccUpdaterInfo(release, user);
+                }
+                release.setAttachments(
+                        getAllAttachmentsToKeep(toSource(actual), actual.getAttachments(), release.getAttachments()));
+                deleteAttachmentUsagesOfUnlinkedReleases(release, actual);
+                releaseRepository.update(release);
+                updateReleaseDependentFieldsForComponentId(release.getComponentId());
+                // clean up attachments in database
+                attachmentConnector.deleteAttachmentDifference(nullToEmptySet(actual.getAttachments()),
+                        nullToEmptySet(release.getAttachments()));
+                sendMailNotificationsForReleaseUpdate(release, user.getEmail());
             } else {
-                return releaseModerator.updateRelease(release, user);
+                if (hasChangesInEccFields) {
+                    return releaseModerator.updateReleaseEccInfo(release, user);
+                } else {
+                    return releaseModerator.updateRelease(release, user);
+                }
             }
+
+            return RequestStatus.SUCCESS;
+        }
+    }
+
+    private boolean changeWouldResultInDuplicate(Release before, Release after) {
+        if (before.getName().equals(after.getName()) && ((before.getVersion() == null && after.getVersion() == null)
+                || (before.getVersion() != null && before.getVersion().equals(after.getVersion())))) {
+            // sth else was changed, not one of the duplication relevant properties
+            return false;
         }
 
-        return RequestStatus.SUCCESS;
+        return isDuplicate(after);
     }
 
     private void deleteAttachmentUsagesOfUnlinkedReleases(Release updated, Release actual) throws SW360Exception {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
@@ -18,11 +18,11 @@ import com.google.common.collect.ImmutableList;
 public class ErrorMessages {
 
     public static final String PROJECT_NOT_ADDED = "Project could not be added.";
-    public static final String PROJECT_DUPLICATE ="Project could not be added, since a project with the same name and version already exists.";
+    public static final String PROJECT_DUPLICATE = "A project with the same name and version already exists.";
     public static final String COMPONENT_NOT_ADDED = "Component could not be added.";
-    public static final String COMPONENT_DUPLICATE ="Component could not be added, since a component with the same name already exists.";
+    public static final String COMPONENT_DUPLICATE = "A component with the same name already exists.";
     public static final String RELEASE_NOT_ADDED = "Release could not be added.";
-    public static final String RELEASE_DUPLICATE ="Release could not be added, since a release with the same name and version already exists.";
+    public static final String RELEASE_DUPLICATE = "A release with the same name and version already exists.";
     public static final String ERROR_GETTING_PROJECT = "Error fetching project from backend.";
     public static final String ERROR_GETTING_COMPONENT = "Error fetching component from backend.";
     public static final String ERROR_GETTING_LICENSE = "Error fetching license from backend.";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2017, 2019. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
  * SPDX-License-Identifier: EPL-1.0
@@ -22,9 +22,7 @@ import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.util.bridges.mvc.MVCPortlet;
-import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
-import org.apache.thrift.TException;
+
 import org.eclipse.sw360.datahandler.thrift.*;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
@@ -38,12 +36,14 @@ import org.eclipse.sw360.portal.common.ErrorMessages;
 import org.eclipse.sw360.portal.common.PortalConstants;
 import org.eclipse.sw360.portal.users.UserCacheHolder;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
+
 import javax.portlet.*;
+
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
@@ -253,29 +253,33 @@ abstract public class Sw360Portlet extends MVCPortlet {
             name = " " + name;
         }
         switch (requestStatus) {
-            case SUCCESS:
-                statusMessage = type + name + " " + verb + "d successfully!";
-                SessionMessages.add(request, "request_processed", statusMessage);
-                break;
-            case SENT_TO_MODERATOR:
-                statusMessage = "Moderation request was sent to " + verb + " the " + type + name + "!";
-                SessionMessages.add(request, "request_processed", statusMessage);
-                break;
-            case FAILURE:
-                setSW360SessionError(request, ErrorMessages.DOCUMENT_NOT_PROCESSED_SUCCESSFULLY);
-                break;
-            case IN_USE:
-                if(type.equals("License")) {
-                    setSW360SessionError(request, ErrorMessages.LICENSE_USED_BY_RELEASE);
-                } else {
-                    setSW360SessionError(request, ErrorMessages.DOCUMENT_USED_BY_PROJECT_OR_RELEASE);
-                }
-                break;
-            case FAILED_SANITY_CHECK:
-                setSW360SessionError(request, ErrorMessages.UPDATE_FAILED_SANITY_CHECK);
-                break;
-            default:
-                throw new PortletException("Unknown request status");
+        case SUCCESS:
+            statusMessage = type + name + " " + verb + "d successfully!";
+            SessionMessages.add(request, "request_processed", statusMessage);
+            break;
+        case SENT_TO_MODERATOR:
+            statusMessage = "Moderation request was sent to " + verb + " the " + type + name + "!";
+            SessionMessages.add(request, "request_processed", statusMessage);
+            break;
+        case FAILURE:
+            setSW360SessionError(request, ErrorMessages.DOCUMENT_NOT_PROCESSED_SUCCESSFULLY);
+            break;
+        case IN_USE:
+            if (type.equals("License")) {
+                setSW360SessionError(request, ErrorMessages.LICENSE_USED_BY_RELEASE);
+            } else {
+                setSW360SessionError(request, ErrorMessages.DOCUMENT_USED_BY_PROJECT_OR_RELEASE);
+            }
+            break;
+        case FAILED_SANITY_CHECK:
+            setSW360SessionError(request, ErrorMessages.UPDATE_FAILED_SANITY_CHECK);
+            break;
+        case DUPLICATE:
+            // just break to not throw an exception, error message has to be set by caller
+            // because of type specific error messages
+            break;
+        default:
+            throw new PortletException("Unknown request status");
         }
     }
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2018. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2019. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
  * SPDX-License-Identifier: EPL-1.0
@@ -14,32 +14,19 @@ package org.eclipse.sw360.portal.portlets.projects;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.collect.*;
-import com.liferay.portal.kernel.json.JSONArray;
-import com.liferay.portal.kernel.json.JSONException;
-import com.liferay.portal.kernel.json.JSONFactoryUtil;
-import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.*;
 import com.liferay.portal.kernel.portlet.PortletResponseUtil;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.model.Organization;
 import com.liferay.portal.util.PortalUtil;
-import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
-import org.apache.thrift.TException;
-import org.apache.thrift.TSerializer;
-import org.apache.thrift.protocol.TSimpleJSONProtocol;
-import org.eclipse.sw360.datahandler.common.CommonUtils;
-import org.eclipse.sw360.datahandler.common.SW360Constants;
-import org.eclipse.sw360.datahandler.common.SW360Utils;
-import org.eclipse.sw360.datahandler.common.ThriftEnumUtils;
+
+import org.eclipse.sw360.datahandler.common.*;
 import org.eclipse.sw360.datahandler.common.WrappedException.WrappedTException;
 import org.eclipse.sw360.datahandler.couchdb.lucene.LuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.*;
 import org.eclipse.sw360.datahandler.thrift.attachments.*;
-import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
-import org.eclipse.sw360.datahandler.thrift.components.Release;
-import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStatusData;
-import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
+import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.cvesearch.CveSearchService;
 import org.eclipse.sw360.datahandler.thrift.cvesearch.VulnerabilityUpdateStatus;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.*;
@@ -57,20 +44,24 @@ import org.eclipse.sw360.portal.portlets.FossologyAwarePortlet;
 import org.eclipse.sw360.portal.users.LifeRayUserSession;
 import org.eclipse.sw360.portal.users.UserCacheHolder;
 import org.eclipse.sw360.portal.users.UserUtils;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
+import org.apache.thrift.TSerializer;
+import org.apache.thrift.protocol.TSimpleJSONProtocol;
 import org.jetbrains.annotations.NotNull;
 
 import javax.portlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URLConnection;
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Predicate;
+import java.util.function.*;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
@@ -1179,9 +1170,17 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 user.setCommentMadeDuringModerationRequest(ModerationRequestCommentMsg);
                 requestStatus = client.updateProject(project, user);
                 setSessionMessage(request, requestStatus, "Project", "update", printName(project));
-                cleanUploadHistory(user.getEmail(), id);
-                response.setRenderParameter(PAGENAME, PAGENAME_DETAIL);
-                response.setRenderParameter(PROJECT_ID, request.getParameter(PROJECT_ID));
+                if (RequestStatus.DUPLICATE.equals(requestStatus)) {
+                    setSW360SessionError(request, ErrorMessages.PROJECT_DUPLICATE);
+                    response.setRenderParameter(PAGENAME, PAGENAME_EDIT);
+                    request.setAttribute(DOCUMENT_TYPE, SW360Constants.TYPE_PROJECT);
+                    request.setAttribute(DOCUMENT_ID, id);
+                    prepareRequestForEditAfterDuplicateError(request, project, user);
+                } else {
+                    cleanUploadHistory(user.getEmail(), id);
+                    response.setRenderParameter(PAGENAME, PAGENAME_DETAIL);
+                    response.setRenderParameter(PROJECT_ID, request.getParameter(PROJECT_ID));
+                }
             } else {
                 // Add project
                 Project project = new Project();

--- a/libraries/lib-datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/sw360.thrift
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2014-2017, 2019. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
  * SPDX-License-Identifier: EPL-1.0
@@ -25,6 +25,7 @@ enum RequestStatus {
     FAILURE = 2,
     IN_USE=3,
     FAILED_SANITY_CHECK = 4,
+    DUPLICATE = 5,
 }
 
 enum RemoveModeratorRequestStatus {


### PR DESCRIPTION
* added detection of duplicates during edit of objects
  * therefor added new status "duplicate" in thrift layer for update methods

closes eclipse/sw360/#98

During testing it might be interesting which fields lost during the round trip. In generel, edit of projects, components and releases should be tested.