### PR TITLE
fix(licenseinfo): Exclude old commons-lang3 dependencies

### DIFF
--- a/backend/src/src-licenseinfo/pom.xml
+++ b/backend/src/src-licenseinfo/pom.xml
@@ -45,16 +45,28 @@
             <groupId>org.spdx</groupId>
             <artifactId>spdx-tools</artifactId>
             <version>2.1.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
-              <groupId>org.apache.velocity</groupId>
-              <artifactId>velocity-engine-core</artifactId>
-              <version>2.0</version>
+            <groupId>org.apache.velocity</groupId>
+            <artifactId>velocity-engine-core</artifactId>
+            <version>2.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
-              <groupId>org.apache.velocity.tools</groupId>
-              <artifactId>velocity-tools-generic</artifactId>
-              <version>3.0</version>
+            <groupId>org.apache.velocity.tools</groupId>
+            <artifactId>velocity-tools-generic</artifactId>
+            <version>3.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>

--- a/backend/src/src-licenses/pom.xml
+++ b/backend/src/src-licenses/pom.xml
@@ -18,6 +18,12 @@
             <groupId>org.spdx</groupId>
             <artifactId>spdx-tools</artifactId>
             <version>2.1.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- fix velocity dependencies problem

`
NoSuchMethodError: org.apache.commons.lang3.StringEscapeUtils.escapeXml
`

Signed-off-by: Thomas Maier <thomas.maier@evosoft.com>