### PR TITLE
fix(vul-scheduler): fixed an issue where vulnerabilities were stored in the wrong db

### DIFF
--- a/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasink/VulnerabilityConnector.java
+++ b/backend/src/src-cvesearch/src/main/java/org/eclipse/sw360/cvesearch/datasink/VulnerabilityConnector.java
@@ -12,17 +12,16 @@
 package org.eclipse.sw360.cvesearch.datasink;
 
 import com.google.common.base.Strings;
+
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.db.*;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
-import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.cvesearch.UpdateType;
 import org.eclipse.sw360.datahandler.thrift.cvesearch.VulnerabilityUpdateStatus;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
-import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.ReleaseVulnerabilityRelation;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
 import org.eclipse.sw360.vulnerabilities.common.VulnerabilityMapper;
@@ -43,7 +42,7 @@ public class VulnerabilityConnector {
     public VulnerabilityConnector() throws IOException{
         DatabaseConnector db = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE);
 
-        vulnerabilityDatabaseHandler = new VulnerabilityDatabaseHandler(db);
+        vulnerabilityDatabaseHandler = new VulnerabilityDatabaseHandler();
         projectDatabaseHandler = new ProjectDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE, DatabaseSettings.COUCH_DB_ATTACHMENTS);
         vendorRepository = new VendorRepository(db);
         releaseRepository = new ReleaseRepository(db, vendorRepository);

--- a/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/VulnerabilityHandler.java
+++ b/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/VulnerabilityHandler.java
@@ -16,9 +16,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
-import org.apache.thrift.TException;
+
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.db.ComponentDatabaseHandler;
 import org.eclipse.sw360.datahandler.db.ProjectDatabaseHandler;
@@ -34,10 +32,13 @@ import org.eclipse.sw360.datahandler.thrift.vulnerabilities.*;
 import org.eclipse.sw360.vulnerabilities.common.VulnerabilityMapper;
 import org.eclipse.sw360.vulnerabilities.db.VulnerabilityDatabaseHandler;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
+
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.log4j.Logger.getLogger;
@@ -57,7 +58,7 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
     private final ProjectDatabaseHandler projectDatabaseHandler;
 
     public VulnerabilityHandler() throws IOException, SW360Exception {
-        dbHandler = new VulnerabilityDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_VM);
+        dbHandler = new VulnerabilityDatabaseHandler();
         compHandler = new ComponentDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE, DatabaseSettings.COUCH_DB_ATTACHMENTS);
         projectDatabaseHandler = new ProjectDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE, DatabaseSettings.COUCH_DB_ATTACHMENTS);
     }

--- a/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityDatabaseHandler.java
+++ b/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityDatabaseHandler.java
@@ -11,20 +11,21 @@
 package org.eclipse.sw360.vulnerabilities.db;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
-import org.apache.thrift.TBase;
+
+import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.ReleaseVulnerabilityRelation;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityWithReleaseRelations;
 import org.eclipse.sw360.vulnerabilities.common.VulnerabilityMapper;
-import org.ektorp.http.HttpClient;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.apache.thrift.TBase;
 
 import java.net.MalformedURLException;
 import java.util.*;
-import java.util.function.Supplier;
 
 /**
  * Class for accessing the CouchDB database
@@ -35,22 +36,13 @@ public class VulnerabilityDatabaseHandler {
 
     private static final Logger log = Logger.getLogger(VulnerabilityDatabaseHandler.class);
 
-    /**
-     * Connection to the couchDB database
-     */
-    private final DatabaseConnector db;
     private final VulnerabilityRepository vulRepo;
     private final VulnerabilityRelationRepository relationRepo;
 
-    public VulnerabilityDatabaseHandler(Supplier<HttpClient> httpClient, String dbName) throws MalformedURLException {
-        // Create the connector
-        db = new DatabaseConnector(httpClient, dbName);
-        vulRepo = new VulnerabilityRepository(db);
-        relationRepo = new VulnerabilityRelationRepository(db);
-    }
+    public VulnerabilityDatabaseHandler() throws MalformedURLException {
+        DatabaseConnector db = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(),
+                DatabaseSettings.COUCH_DB_VM);
 
-    public VulnerabilityDatabaseHandler(DatabaseConnector db) throws MalformedURLException {
-        this.db = db;
         vulRepo = new VulnerabilityRepository(db);
         relationRepo = new VulnerabilityRelationRepository(db);
     }


### PR DESCRIPTION
* fixed the storage db of the cve search which stored vuls and their relations in the standard db while the thrift service tried to read them from the vm db

fixes eclipse/sw360/#401

Signed-off-by: Andreas Klett <andreas.klett@scansation.de>

Testing: On a clean installation one should be able to schedule the cve search (Admin -> Schedule) and after a successful run there should be vulnerabilities in the application that are visible at the releases or on the Vulnerabilities page.
The bad thing: I guess the start time for the scheduler is only changeable via code. So maybe one want to change org.eclipse.sw360.schedule.timer.Scheduler.getNextSyncDate(int, int) before deploying the branch (careful: the time entered is GMT).