### PR TITLE
fix(Attachments-UI):Restrict from duplicate attachment upload

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -400,9 +400,10 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         // Get actual document for members that should not change
         Component actual = componentRepository.get(component.getId());
         assertNotNull(actual, "Could not find component to update!");
-
         if (changeWouldResultInDuplicate(actual, component)) {
             return RequestStatus.DUPLICATE;
+        } else if (duplicateAttachmentExist(component)) {
+            return RequestStatus.DUPLICATE_ATTACHMENT;
         } else if (makePermission(actual, user).isActionAllowed(RequestedAction.WRITE)) {
             // Nested releases and attachments should not be updated by this method
             if (actual.isSetReleaseIds()) {
@@ -428,6 +429,14 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
         return isDuplicate(after);
     }
+
+    private boolean duplicateAttachmentExist(Component component) {
+    	if(component.attachments != null && !component.attachments.isEmpty()) {
+            return AttachmentConnector.isDuplicateAttachment(component.attachments);
+        }
+        return false;
+    }
+
 
     private void updateComponentInternal(Component updated, Component current, User user) {
         // Update the database with the component
@@ -621,6 +630,8 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
         if (actual.equals(release)) {
             return RequestStatus.SUCCESS;
+        } else if (duplicateAttachmentExist(release)) {
+            return RequestStatus.DUPLICATE_ATTACHMENT;
         } else if (changeWouldResultInDuplicate(actual, release)) {
             return RequestStatus.DUPLICATE;
         } else {
@@ -669,6 +680,13 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         }
 
         return isDuplicate(after);
+       }
+
+    private boolean duplicateAttachmentExist(Release release) {
+        if (release.attachments != null && !release.attachments.isEmpty()) {
+            return AttachmentConnector.isDuplicateAttachment(release.attachments);
+        }
+        return false;
     }
 
     private void deleteAttachmentUsagesOfUnlinkedReleases(Release updated, Release actual) throws SW360Exception {

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -194,7 +194,9 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
         if (changeWouldResultInDuplicate(actual, project)) {
             return RequestStatus.DUPLICATE;
-        } else if (!changePassesSanityCheck(project, actual)) {
+        } else if (duplicateAttachmentExist(project)) {
+            return RequestStatus.DUPLICATE_ATTACHMENT;
+        } else if (!changePassesSanityCheck(project, actual)){
             return RequestStatus.FAILED_SANITY_CHECK;
         } else if (makePermission(actual, user).isActionAllowed(RequestedAction.WRITE)) {
             copyImmutableFields(project,actual);
@@ -219,6 +221,13 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         }
 
         return isDuplicate(after);
+    }
+
+    private boolean duplicateAttachmentExist(Project project) {
+        if(project.attachments != null && !project.attachments.isEmpty()) {
+            return AttachmentConnector.isDuplicateAttachment(project.attachments);
+        }
+        return false;
     }
 
     private void deleteAttachmentUsagesOfUnlinkedReleases(Project updated, Project actual) throws SW360Exception {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
@@ -23,6 +23,7 @@ public class ErrorMessages {
     public static final String COMPONENT_DUPLICATE = "A component with the same name already exists.";
     public static final String RELEASE_NOT_ADDED = "Release could not be added.";
     public static final String RELEASE_DUPLICATE = "A release with the same name and version already exists.";
+    public static final String DUPLICATE_ATTACHMENT = "Multiple attachments with same name or content cannot be present in attachment list.";
     public static final String ERROR_GETTING_PROJECT = "Error fetching project from backend.";
     public static final String ERROR_GETTING_COMPONENT = "Error fetching component from backend.";
     public static final String ERROR_GETTING_LICENSE = "Error fetching license from backend.";
@@ -57,6 +58,7 @@ public class ErrorMessages {
             .add(COMPONENT_DUPLICATE)
             .add(RELEASE_NOT_ADDED)
             .add(RELEASE_DUPLICATE)
+            .add(DUPLICATE_ATTACHMENT)
             .add(LICENSE_USED_BY_RELEASE)
             .add(DOCUMENT_USED_BY_PROJECT_OR_RELEASE)
             .add(DOCUMENT_NOT_PROCESSED_SUCCESSFULLY)

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
@@ -275,6 +275,7 @@ abstract public class Sw360Portlet extends MVCPortlet {
             setSW360SessionError(request, ErrorMessages.UPDATE_FAILED_SANITY_CHECK);
             break;
         case DUPLICATE:
+        case DUPLICATE_ATTACHMENT:
             // just break to not throw an exception, error message has to be set by caller
             // because of type specific error messages
             break;

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -1050,8 +1050,11 @@ public class ComponentPortlet extends FossologyAwarePortlet {
                 user.setCommentMadeDuringModerationRequest(ModerationRequestCommentMsg);
                 RequestStatus requestStatus = client.updateComponent(component, user);
                 setSessionMessage(request, requestStatus, "Component", "update", component.getName());
-                if (RequestStatus.DUPLICATE.equals(requestStatus)) {
-                    setSW360SessionError(request, ErrorMessages.COMPONENT_DUPLICATE);
+                if (RequestStatus.DUPLICATE.equals(requestStatus) || RequestStatus.DUPLICATE_ATTACHMENT.equals(requestStatus)) {
+                    if(RequestStatus.DUPLICATE.equals(requestStatus))
+                        setSW360SessionError(request, ErrorMessages.COMPONENT_DUPLICATE);
+                    else
+                        setSW360SessionError(request, ErrorMessages.DUPLICATE_ATTACHMENT);
                     response.setRenderParameter(PAGENAME, PAGENAME_EDIT);
                     request.setAttribute(DOCUMENT_TYPE, SW360Constants.TYPE_COMPONENT);
                     request.setAttribute(DOCUMENT_ID, id);
@@ -1118,8 +1121,11 @@ public class ComponentPortlet extends FossologyAwarePortlet {
 
                     RequestStatus requestStatus = client.updateRelease(release, user);
                     setSessionMessage(request, requestStatus, "Release", "update", printName(release));
-                    if (RequestStatus.DUPLICATE.equals(requestStatus)) {
-                        setSW360SessionError(request, ErrorMessages.RELEASE_DUPLICATE);
+                    if (RequestStatus.DUPLICATE.equals(requestStatus) || RequestStatus.DUPLICATE_ATTACHMENT.equals(requestStatus)) {
+                        if(RequestStatus.DUPLICATE.equals(requestStatus))
+                            setSW360SessionError(request, ErrorMessages.RELEASE_DUPLICATE);
+                        else
+                            setSW360SessionError(request, ErrorMessages.DUPLICATE_ATTACHMENT);
                         response.setRenderParameter(PAGENAME, PAGENAME_EDIT_RELEASE);
                         request.setAttribute(DOCUMENT_TYPE, SW360Constants.TYPE_RELEASE);
                         response.setRenderParameter(COMPONENT_ID, id);

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -1183,8 +1183,11 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 user.setCommentMadeDuringModerationRequest(ModerationRequestCommentMsg);
                 requestStatus = client.updateProject(project, user);
                 setSessionMessage(request, requestStatus, "Project", "update", printName(project));
-                if (RequestStatus.DUPLICATE.equals(requestStatus)) {
-                    setSW360SessionError(request, ErrorMessages.PROJECT_DUPLICATE);
+                if (RequestStatus.DUPLICATE.equals(requestStatus) || RequestStatus.DUPLICATE_ATTACHMENT.equals(requestStatus)) {
+                    if(RequestStatus.DUPLICATE.equals(requestStatus))
+                        setSW360SessionError(request, ErrorMessages.PROJECT_DUPLICATE);
+                    else
+                        setSW360SessionError(request, ErrorMessages.DUPLICATE_ATTACHMENT);
                     response.setRenderParameter(PAGENAME, PAGENAME_EDIT);
                     request.setAttribute(DOCUMENT_TYPE, SW360Constants.TYPE_PROJECT);
                     request.setAttribute(DOCUMENT_ID, id);

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentConnector.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentConnector.java
@@ -126,4 +126,10 @@ public class AttachmentConnector extends AttachmentStreamConnector {
             }
         }
     }
+
+    public static boolean isDuplicateAttachment(Set<Attachment> attachments) {
+        boolean duplicateSha1 = attachments.parallelStream().collect(Collectors.groupingBy(Attachment::getSha1)).size() < attachments.size();
+        boolean duplicateFileName = attachments.parallelStream().collect(Collectors.groupingBy(Attachment::getFilename)).size() < attachments.size();
+        return (duplicateSha1 || duplicateFileName);
+    }
 }

--- a/libraries/lib-datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/sw360.thrift
@@ -26,6 +26,7 @@ enum RequestStatus {
     IN_USE=3,
     FAILED_SANITY_CHECK = 4,
     DUPLICATE = 5,
+    DUPLICATE_ATTACHMENT = 6,
 }
 
 enum RemoveModeratorRequestStatus {


### PR DESCRIPTION
#### Summary:
Restrict users from uploading multiple attachments with same file name.
#### Changes:
If user tries to upload multiple attachments with same file name , then during upload it will restrict the user from uploading  with warning message "Attachment with <i> filename</i> already exist"
#### Steps to test:
1.Try to upload an attachment with same file name and extension , listed on the attachment list.
#### Expected result: 
It should give an warning message "Attachment with  <i> filename</i> already exist"

closes #417 
