### PR TITLE
feat(attachment-usage): Restrict modification of the attachment usage

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -190,7 +190,6 @@ public class PortalConstants {
     public static final String VULNERABILITY = "vulnerability";
     public static final String VULNERABILITY_LIST = "vulnerabilityList";
     public static final String VULNERABILITY_RATINGS = "vulnerabilityRatings";
-    public static final String VULNERABILITY_RATINGS_EDITABLE = "vulnerabilityRatingsEditable";
     public static final String VULNERABILITY_ID = "vulnerabilityId";
     public static final String VULNERABILITY_IDS = "vulnerabilityIds";
     public static final String VULNERABILITY_RATING_VALUE = "vulnerabilityRatingValue";
@@ -395,6 +394,8 @@ public class PortalConstants {
     // CodeScoop integration
     public static final String CODESCOOP_URL;
     public static final String CODESCOOP_TOKEN;
+
+    public static final String WRITE_ACCESS_USER = "writeAccessUser";
 
     static {
         Properties props = CommonUtils.loadProperties(PortalConstants.class, PROPERTIES_FILE_PATH);

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -865,7 +865,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 putVulnerabilitiesInRequest(request, id, user);
                 putAttachmentUsagesInRequest(request, id);
                 request.setAttribute(
-                        VULNERABILITY_RATINGS_EDITABLE,
+                        WRITE_ACCESS_USER,
                         PermissionUtils.makePermission(project, user).isActionAllowed(RequestedAction.WRITE));
 
                 addProjectBreadcrumb(request, response, project);

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentUsages.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentUsages.jspf
@@ -63,7 +63,7 @@
     </core_rt:if>
     </tbody>
 </table>
-<core_rt:if test="${inProjectDetailsContext}">
+<core_rt:if test="${inProjectDetailsContext and writeAccessUser}">
 <span class="pull-right">
     <input type="button" class="addButton" id="saveAttachmentUsagesButton" value="Save Usages" class="addButton"/>
 </span>

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentUsagesRows.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentUsagesRows.jspf
@@ -86,7 +86,7 @@
                            name="<portlet:namespace/><%=PortalConstants.PROJECT_SELECTED_ATTACHMENT_USAGES%>"
                            value="${releaseLink.id}_<%=UsageData._Fields.LICENSE_INFO.getFieldName()%>_${attachment.attachmentContentId}"
                            id="${releaseLink.id}_<%=UsageData._Fields.LICENSE_INFO.getFieldName()%>_${attachment.attachmentContentId}"
-                           <core_rt:if test="${!licenseInfoAttachmentTypes.contains(attachment.attachmentType)}">disabled</core_rt:if>
+                           <core_rt:if test="${!licenseInfoAttachmentTypes.contains(attachment.attachmentType) or !writeAccessUser}">disabled</core_rt:if>
                            <core_rt:if test="${licInfoAttUsages.containsKey(attachment.attachmentContentId)}">checked="checked"</core_rt:if>
                            class="trackChange<core_rt:if test="${licInfoAttUsages.containsKey(attachment.attachmentContentId)}"> defaultChecked</core_rt:if>"
                     />
@@ -102,7 +102,7 @@
                            name="<portlet:namespace/><%=PortalConstants.PROJECT_SELECTED_ATTACHMENT_USAGES%>"
                            value="${releaseLink.id}_<%=UsageData._Fields.SOURCE_PACKAGE.getFieldName()%>_${attachment.attachmentContentId}"
                            id="${releaseLink.id}_<%=UsageData._Fields.SOURCE_PACKAGE.getFieldName()%>_${attachment.attachmentContentId}"
-                           <core_rt:if test="${!sourceCodeAttachmentTypes.contains(attachment.attachmentType)}">disabled</core_rt:if>
+                           <core_rt:if test="${!sourceCodeAttachmentTypes.contains(attachment.attachmentType) or !writeAccessUser}">disabled</core_rt:if>
                            <core_rt:if test="${sourceAttUsages.containsKey(attachment.attachmentContentId)}">checked="checked"</core_rt:if>
                            class="trackChange<core_rt:if test="${sourceAttUsages.containsKey(attachment.attachmentContentId)}"> defaultChecked</core_rt:if>"
                     />
@@ -120,6 +120,7 @@
                            id="${releaseLink.id}_<%=UsageData._Fields.MANUALLY_SET.getFieldName()%>_${attachment.attachmentContentId}"
                            <core_rt:if test="${manualAttUsages.containsKey(attachment.attachmentContentId)}">checked="checked"</core_rt:if>
                            class="trackChange<core_rt:if test="${manualAttUsages.containsKey(attachment.attachmentContentId)}"> defaultChecked</core_rt:if>" <core_rt:if test="${manualAttUsages.containsKey(attachment.attachmentContentId)}">checked="checked" class="defaultChecked"</core_rt:if>
+                           <core_rt:if test="${!writeAccessUser}">disabled</core_rt:if>
                     />
                     <input type="checkbox"
                            name="<portlet:namespace/><%=PortalConstants.PROJECT_SELECTED_ATTACHMENT_USAGES_SHADOWS%>"

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/vulnerabilities.jspf
@@ -25,9 +25,10 @@
 </portlet:resourceURL>
 <jsp:useBean id="vulnerabilityList" type="java.util.List<org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO>" scope="request"/>
 <jsp:useBean id="vulnerabilityRatings" type="java.util.Map<java.lang.String, org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityRatingForProject>" scope="request"/>
-<jsp:useBean id="vulnerabilityRatingsEditable" type="java.lang.Boolean" scope="request"/>
+<jsp:useBean id="writeAccessUser" type="java.lang.Boolean" scope="request"/>
 <jsp:useBean id="vulnerabilityCheckstatusTooltips" type="java.util.Map<java.lang.String, java.lang.String>" scope="request"/>
 <jsp:useBean id="vulnerabilityMatchedByHistogram" type="java.util.Map<java.lang.String, java.lang.Long>" scope="request"/>
+
 <jsp:useBean id="viewSize" type="java.lang.Integer" scope="request"/>
 
 <link rel="stylesheet" href="<%=request.getContextPath()%>/webjars/datatables.net-buttons-bs/css/buttons.bootstrap.min.css"/>
@@ -71,7 +72,7 @@
         <%@include file="/html/utils/includes/vulnerabilityModal.jspf" %>
     </form>
 </div>
-<core_rt:if test="${vulnerabilityRatingsEditable}">
+<core_rt:if test="${writeAccessUser}">
     <div>
         Change rating of selected vulnerabilities to
         <select class="toplabelledInput action change-vulnerability"
@@ -113,7 +114,7 @@
         Liferay.on('allPortletsReady', function() {
             createVulnerabilityTable();
 
-            <core_rt:if test="${vulnerabilityRatingsEditable}">
+            <core_rt:if test="${writeAccessUser}">
                 $('#apply-to-selected').on('click', function () {
                     batchChangeRating();
                 });
@@ -143,7 +144,7 @@
             </core_rt:if>
 
             vulnerabilityTable = $('#vulnerabilityTable').DataTable({
-                <core_rt:if test="${vulnerabilityRatingsEditable}">
+                <core_rt:if test="${writeAccessUser}">
                     dom: 'lfrtBip',
                     buttons: [
                         {
@@ -201,7 +202,7 @@
             });
         }
 
-        <core_rt:if test="${vulnerabilityRatingsEditable}">
+        <core_rt:if test="${writeAccessUser}">
             function batchChangeRating() {
                 var selectedRows = vulnerabilityTable.rows('.selected');
                 var selectedValue = $("#rating-change-for-selected").children("option:selected");


### PR DESCRIPTION
**Summary:**
Restrict users, without any WRITE access from modifying the attachment usage.

**Changes:**
"Save Usages" button is hidden and all the checkboxes are disabled for the users, without any WRITE access.

Closes: #426 

Signed-off-by: Smruti Sahoo <smruti.sahoo@siemens.com>