### PR TITLE
feat(wsimport): import sha1 values for releases as external id

### DIFF
--- a/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/domain/WsLibrary.java
+++ b/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/domain/WsLibrary.java
@@ -22,6 +22,7 @@ public class WsLibrary {
     private String type;
     private WsReference references;
     private WsLicense[] licenses;
+    private String sha1;
 
     public int getKeyId() {
         return keyId;
@@ -79,5 +80,12 @@ public class WsLibrary {
         this.licenses = licenses;
     }
 
+    public String getSha1() {
+        return sha1;
+    }
+
+    public void setSha1(String sha1) {
+        this.sha1 = sha1;
+    }
 }
 

--- a/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/entitytranslation/WsLibraryToSw360ReleaseTranslator.java
+++ b/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/entitytranslation/WsLibraryToSw360ReleaseTranslator.java
@@ -35,6 +35,7 @@ public class WsLibraryToSw360ReleaseTranslator implements EntityTranslator<WsLib
         sw360Release.setName(wsLibrary.getName());
         sw360Release.getExternalIds().put(TranslationConstants.WS_ID, Integer.toString(wsLibrary.getKeyId()));
         sw360Release.getExternalIds().put(FILENAME, wsLibrary.getFilename());
+        sw360Release.getExternalIds().put(SHA1, wsLibrary.getSha1());
 
         if (wsLibrary.getReferences() != null) {
                 sw360Release.setDownloadurl(wsLibrary.getReferences().getScmUrl());
@@ -49,7 +50,7 @@ public class WsLibraryToSw360ReleaseTranslator implements EntityTranslator<WsLib
         } else {
             sw360Release.setVersion(UNKNOWN);
         }
-
+        
         sw360Release.setClearingState(ClearingState.NEW_CLEARING);
 
         return sw360Release;

--- a/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/utility/TranslationConstants.java
+++ b/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/utility/TranslationConstants.java
@@ -25,6 +25,7 @@ public class TranslationConstants {
     public static final String IMPORTED_FROM_WHITESOURCE = "Imported from Whitesource";
     public static final String APPLICATION_JSON = "application/json";
     public static final String VERSION_SUFFIX_REGEX = "$*?-SNAPSHOT|$*?.RELEASE|$*?-RELEASE|$*?RELEASE|$*?.Final";
+    public static final String SHA1 = "sha1";
 
     public static final String REQUEST__GET_PROJECT_VITALS = "getProjectVitals";
     public static final String REQUEST__GET_PROJECT_LICENSES = "getProjectLicenses";


### PR DESCRIPTION
When using wsimport create external id with key "sha1" and copy there library's sha1 value from Whitesource as value