### PR TITLE
feat(UI:PageTitle): Show selected Project/Component Name in Browser Tab

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/html/components/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/edit.jsp
@@ -145,6 +145,7 @@
 </core_rt:if>
 
 <script>
+    document.title = "${component.name} - " + document.title;
     /* variables used in releaseTools.js ... */
     var releaseIdInURL = '<%=PortalConstants.RELEASE_ID%>',
         compIdInURL = '<%=PortalConstants.COMPONENT_ID%>',

--- a/frontend/sw360-portlet/src/main/webapp/html/components/editRelease.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/editRelease.jsp
@@ -169,6 +169,7 @@
 
 <script>
     require(['jquery', 'modules/sw360Validate', 'components/includes/vendors/searchVendor', 'modules/confirm', 'modules/autocomplete', 'modules/tabview', /* jquery-plugins */ 'jquery-ui' ], function($, sw360Validate, vendorsearch, confirm, autocomplete, tabview) {
+        document.title = "${component.name} - " + document.title;
 
         tabview.create('myTab');
 

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/detailOverview.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/detailOverview.jspf
@@ -41,3 +41,6 @@
         </div>
     </div>
 </div>
+<script>
+    document.title = "${component.name} - " + document.title;
+</script>

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/detailOverview.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/detailOverview.jspf
@@ -66,3 +66,6 @@
         </div>
     </div>
 </div>
+<script>
+    document.title = "${component.name} - " + document.title;
+</script>

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
@@ -145,6 +145,7 @@
 
 <script>
 require(['jquery', 'modules/sw360Validate', 'modules/confirm', 'modules/tabview' ], function($, sw360Validate, confirm, tabview) {
+    document.title = "${project.name} - " + document.title;
 
     tabview.create('myTab');
 

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/detailOverview.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/detailOverview.jspf
@@ -77,3 +77,6 @@
         </div>
     </div>
 </div>
+<script>
+    document.title = "${project.name} - " + document.title;
+</script>


### PR DESCRIPTION
#### Summary:
Show selected Project/Component Name in Browser Tab
#### Changes:
Added project or component name to page title.Now on selecting project or component the page title for Project will be "(ProjectName) : Projects - Liferay " and similarly on selecting of component the title will be ""(ComponentName) : Components - Liferay"
#### Steps to test:
1. Go to Projects tab and click on any of the project from the list.
2. Go to Components tab and select any of the existing component.
#### Expected result:
1.Selected Project or Component  name should be coming on page title.

Closes #140 