### PR TITLE
fix(ReleaseLink): Remove self link from LinkedReleases hierarchy

### DIFF
--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -273,8 +273,14 @@ public class ComponentHandler implements ComponentService.Iface {
         assertNotNull(release);
         assertId(release.getId());
         assertUser(user);
-
+        removeSelfLink(release);
         return handler.updateRelease(release, user, ThriftUtils.IMMUTABLE_OF_RELEASE);
+    }
+
+    private void removeSelfLink(Release release) {
+        if(release.releaseIdToRelationship != null && !release.releaseIdToRelationship.isEmpty()) {
+            release.releaseIdToRelationship.remove(release.id);
+        }
     }
 
     @Override


### PR DESCRIPTION
#### Summary: 
Self links should be forbidden at all
#### Changes: 
Added logic to remove the release from the LinkedReleases list ,if the parent and child release Id is same.
#### Steps to Test:
1. From the "Components" tab select any of the listed component.
2. Goto Release Overview and click on  Release Revision of any of the listed release.
3. Goto to Linked Releases tab of the selected Release and try to expand the Linked Releases Hierarchy and observe the structure. 
#### Expected result:
Self link should  not be present under same Release. 
Closes: #410 