### PR TITLE
fix(attachment): Multiple attachment upload stall issue

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/AttachmentPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/AttachmentPortletUtils.java
@@ -62,7 +62,6 @@ public class AttachmentPortletUtils extends AttachmentFrontendUtils {
     }
 
     public AttachmentPortletUtils(ThriftClients thriftClients) {
-        super(thriftClients);
         projectClient = thriftClients.makeProjectClient();
         componentClient = thriftClients.makeComponentClient();
     }
@@ -109,7 +108,7 @@ public class AttachmentPortletUtils extends AttachmentFrontendUtils {
         List<AttachmentContent> attachments = new ArrayList<>();
         try {
             for(String id : ids){
-                attachments.add(client.getAttachmentContent(id));
+                attachments.add(attchmntClient.get().getAttachmentContent(id));
             }
 
             serveAttachmentBundle(attachments, request, response, downloadFileName);
@@ -233,7 +232,7 @@ public class AttachmentPortletUtils extends AttachmentFrontendUtils {
         AttachmentContent attachment = null;
         if (resumableUpload.hasAttachmentId()) {
             try {
-                attachment = client.getAttachmentContent(resumableUpload.getAttachmentId());
+                attachment = attchmntClient.get().getAttachmentContent(resumableUpload.getAttachmentId());
             } catch (TException e) {
                 log.error("Error retrieving attachment", e);
             }
@@ -248,7 +247,7 @@ public class AttachmentPortletUtils extends AttachmentFrontendUtils {
                 .setFilename(filename);
 
         try {
-            attachmentContent = client.makeAttachmentContent(attachmentContent);
+            attachmentContent = attchmntClient.get().makeAttachmentContent(attachmentContent);
         } catch (TException e) {
             log.error("Error creating attachment", e);
             attachmentContent = null;
@@ -269,7 +268,7 @@ public class AttachmentPortletUtils extends AttachmentFrontendUtils {
     public RequestStatus cancelUpload(ResourceRequest request) {
         String attachmentId = request.getParameter(PortalConstants.ATTACHMENT_ID);
         try {
-            return client.deleteAttachmentContent(attachmentId);
+            return attchmntClient.get().deleteAttachmentContent(attachmentId);
         } catch (TException e) {
             log.error("Error deleting attachment from backend", e);
             return RequestStatus.FAILURE;

--- a/libraries/commonIO/src/main/java/org/eclipse/sw360/commonIO/AttachmentFrontendUtils.java
+++ b/libraries/commonIO/src/main/java/org/eclipse/sw360/commonIO/AttachmentFrontendUtils.java
@@ -34,18 +34,17 @@ import java.util.concurrent.TimeUnit;
 public class AttachmentFrontendUtils {
 
     private static final Logger log = Logger.getLogger(AttachmentFrontendUtils.class);
-    protected final AttachmentService.Iface client;
 
     private AttachmentStreamConnector connector;
     // TODO add Config class and DI
     private final Duration downloadTimeout = Duration.durationOf(30, TimeUnit.SECONDS);
 
-    public AttachmentFrontendUtils() {
-        this(new ThriftClients());
-    }
+    protected final ThreadLocal<AttachmentService.Iface> attchmntClient = ThreadLocal.<AttachmentService.Iface>withInitial(
+            () -> {
+                return new ThriftClients().makeAttachmentClient();
+            });
 
-    public AttachmentFrontendUtils(ThriftClients thriftClients) {
-        client = thriftClients.makeAttachmentClient();
+    public AttachmentFrontendUtils() {
     }
 
     public InputStream getStreamToServeAFile(Collection<AttachmentContent> attachments, User user, Object context)
@@ -77,11 +76,11 @@ public class AttachmentFrontendUtils {
     }
 
     public AttachmentContent getAttachmentContent(String id) throws TException {
-        return client.getAttachmentContent(id);
+        return attchmntClient.get().getAttachmentContent(id);
     }
 
     public AttachmentContent makeAttachmentContent(AttachmentContent attachmentContent) throws TException {
-        return client.makeAttachmentContent(attachmentContent);
+        return attchmntClient.get().makeAttachmentContent(attachmentContent);
     }
 
     public Attachment getAttachmentForDisplay(User user, String attachmentContentId) {
@@ -97,7 +96,7 @@ public class AttachmentFrontendUtils {
     public void deleteAttachments(Set<String> attachmentContentIds){
         try {
             for(String id: attachmentContentIds) {
-                client.deleteAttachmentContent(id);
+                attchmntClient.get().deleteAttachmentContent(id);
             }
         } catch (TException e){
             log.error("Could not delete attachments from database.",e);
@@ -121,7 +120,7 @@ public class AttachmentFrontendUtils {
 
     protected AttachmentContent updateAttachmentContent(AttachmentContent attachment) throws TException {
         try {
-            client.updateAttachmentContent(attachment);
+            attchmntClient.get().updateAttachmentContent(attachment);
         } catch (SW360Exception e) {
             log.error("Error updating attachment", e);
             return null;


### PR DESCRIPTION
**Description:**
Currently multiple attachment upload is supported, but due to some concurrency fault, sometimes the upload gets stalled in between. 

**Changes:**
I have fixed this issue by applying synchronization mechanism. Now, we could select multiple attachments and upload the same.

**Testing Steps:**
1) Select/drag and drop multiple attachments and upload the same.
2) Upload attachments from multiple browsers at the same time(to simulate the multi-threaded environment).

closes: #249 

Signed-off-by: Smruti Sahoo <smruti.sahoo@siemens.com>