### PR TITLE
fix(UI-Release): UI error on duplicate release creation

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -1138,8 +1138,8 @@ public class ComponentPortlet extends FossologyAwarePortlet {
     }
 
     private void fillVendor(Release release) throws TException {
-        VendorService.Iface client = thriftClients.makeVendorClient();
-        if(release.isSetVendorId()) {
+        if(!isNullOrEmpty(release.getVendorId()) && release.isSetVendorId()) {
+            VendorService.Iface client = thriftClients.makeVendorClient();
             Vendor vendor = client.getByID(release.getVendorId());
             release.setVendor(vendor);
         }


### PR DESCRIPTION
Signed-off-by: Nutan Das <nutan.das@siemens.com>

#### Issue:
Vendor Id null check was missing for new release .As exception handling was not proper so there was a abnormal termination from code flow which was causing the issue. 

#### Steps to test:
1.Create a new release with any of the existing version name.

#### Expected result:
1.It should give a error message for duplicate release and it should display the same new release window.
Closes  : #468 




