### PR TITLE
fix(license-import): add missing dependency

### DIFF
--- a/backend/src/src-licenseinfo/pom.xml
+++ b/backend/src/src-licenseinfo/pom.xml
@@ -53,6 +53,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.8.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
             <version>2.0</version>

--- a/backend/src/src-licenses/pom.xml
+++ b/backend/src/src-licenses/pom.xml
@@ -25,6 +25,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.8.1</version>
+        </dependency>
     </dependencies>
 
     <parent>

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/licenseAdmin/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/licenseAdmin/view.jsp
@@ -78,7 +78,7 @@
     </tr>
     <tr>
         <td>Import all SPDX license information</td>
-        <td><a id="importSPDXLink" href="#">Import</a>
+        <td><a href="#" onclick="importSpdxLicenseInformation(); return false;">Import</a>
         </td>
     </tr>
     <tr>
@@ -160,11 +160,6 @@
 
         var confirmMessage = "Do you really want to import all SPDX licenses";
         deleteConfirmed(confirmMessage, importSpdxLicenseInformationInternal);
-    }
-
-    window.onload = function() {
-        var a = document.getElementById("importSPDXLink");
-        a.onclick = importSpdxLicenseInformation;
     }
 </script>
 


### PR DESCRIPTION
Due to the changes in https://github.com/eclipse/sw360/commit/8fee82570cc54018540dc1e53457cfa08216c8b3#diff-522eb230e2bc520bfed39d0abf54dd21 (for https://github.com/eclipse/sw360/pull/459) the **import all SPDX licenses** feature is broken:

![2019-02-22_14 56 09](https://user-images.githubusercontent.com/1187050/53249545-9d276d80-36b8-11e9-973e-f2ea525b6bce.png)

This PR adds a replacement for the excluded dependency.

The added dependency `org.apache.commons:commons-lang3:3.8.1` is already in the eclipse system, and we can piggyback of `[CQ18249] Apache commons-lang3 3.8.1` (see: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=19043)