### PR TITLE
refactor(REST): add BasicController for REST as base class

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/BasicController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/BasicController.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Bosch Software Innovations GmbH, 2019.
+ * Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.resourceserver.core;
+
+import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.ResourceProcessor;
+import org.springframework.hateoas.ResourceSupport;
+import org.springframework.hateoas.Resources;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public abstract class BasicController<T, S extends ResourceSupport> implements ResourceProcessor<S> {
+    protected ResponseEntity<Resources<Resource<T>>> mkResponse(List<T> objects) {
+        Resources<Resource<T>> resources = new Resources<>(objects.stream()
+                .map(r -> new Resource<>(r))
+                .collect(Collectors.toList()));
+        return new ResponseEntity<>(resources, HttpStatus.OK);
+    }
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -24,6 +24,7 @@ import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.rest.resourceserver.attachment.AttachmentInfo;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.component.ComponentController;
+import org.eclipse.sw360.rest.resourceserver.core.BasicController;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.MultiStatus;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
@@ -57,7 +58,7 @@ import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 
 @BasePathAwareController
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
-public class ReleaseController implements ResourceProcessor<RepositoryLinksResource> {
+public class ReleaseController extends BasicController<Release,RepositoryLinksResource> {
     public static final String RELEASES_URL = "/releases";
     private static final Logger log = Logger.getLogger(ReleaseController.class);
 
@@ -84,11 +85,9 @@ public class ReleaseController implements ResourceProcessor<RepositoryLinksResou
             sw360Releases.addAll(releaseService.getReleasesForUser(sw360User));
         }
 
-        Resources<Resource<Release>> resources = new Resources<>(sw360Releases.stream()
+        return mkResponse(sw360Releases.stream()
                 .map(r -> restControllerHelper.convertToEmbeddedRelease(r, fields))
-                .map(r -> new Resource<>(r))
                 .collect(Collectors.toList()));
-        return new ResponseEntity<>(resources, HttpStatus.OK);
     }
 
     private Release searchReleaseBySha1(String sha1, User sw360User) throws TException {


### PR DESCRIPTION
I am currently trying to understand our REST implementation, but I ran into problems. 

The reduced problem is that the minor refactoring described here in this PR does not work. It causes the service to return `500` in some cases, caused by 
```
java.lang.ClassCastException: org.eclipse.sw360.rest.resourceserver.core.HalResource cannot be cast to org.springframework.data.rest.webmvc.RepositoryLinksResource
	at org.eclipse.sw360.rest.resourceserver.release.ReleaseController.process(ReleaseController.java:59)
	at org.springframework.hateoas.mvc.ResourceProcessorInvoker$DefaultProcessorWrapper.invokeProcessor(ResourceProcessorInvoker.java:224)
[...]
```

## My question is now:
what is the cause for this?

**Edit:** The **question is answered** in: https://github.com/eclipse/sw360/pull/475#issuecomment-467491529

## Other information:
The following nearly equivalent refactoring works:
```diff
diff --git a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
index 437f877a..322d2c8d 100644
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -24,6 +24,7 @@ import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.rest.resourceserver.attachment.AttachmentInfo;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.component.ComponentController;
+import org.eclipse.sw360.rest.resourceserver.core.BasicController;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.MultiStatus;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
@@ -51,6 +52,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 
@@ -70,7 +72,7 @@ public class ReleaseController implements ResourceProcessor<RepositoryLinksResou
     private RestControllerHelper restControllerHelper;
 
     @RequestMapping(value = RELEASES_URL, method = RequestMethod.GET)
-    public ResponseEntity<Resources<Resource>> getReleasesForUser(
+    public ResponseEntity<Resources<Resource<Release>>> getReleasesForUser(
             @RequestParam(value = "sha1", required = false) String sha1,
             @RequestParam(value = "fields", required = false) List<String> fields) throws TException {
 
@@ -83,14 +85,9 @@ public class ReleaseController implements ResourceProcessor<RepositoryLinksResou
             sw360Releases.addAll(releaseService.getReleasesForUser(sw360User));
         }
 
-        List<Resource> releaseResources = new ArrayList<>();
-        for (Release sw360Release : sw360Releases) {
-            Release embeddedRelease = restControllerHelper.convertToEmbeddedRelease(sw360Release, fields);
-            Resource<Release> releaseResource = new Resource<>(embeddedRelease);
-            releaseResources.add(releaseResource);
-        }
-        Resources<Resource> resources = new Resources<>(releaseResources);
-
+        Resources<Resource<Release>> resources = new Resources<>(sw360Releases.stream()
+                .map(r -> restControllerHelper.convertToEmbeddedRelease(r, fields))
+                .map(r -> new Resource<>(r))
+                .collect(Collectors.toList()));
         return new ResponseEntity<>(resources, HttpStatus.OK);
     }
```
The actually braking refactoring is just the second commit:
```diff
diff --git a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/BasicController.java b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/BasicController.java
new file mode 100644
index 00000000..2e82a404
--- /dev/null
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/BasicController.java
@@ -0,0 +1,31 @@
+package org.eclipse.sw360.rest.resourceserver.core;
+
+import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.ResourceProcessor;
+import org.springframework.hateoas.ResourceSupport;
+import org.springframework.hateoas.Resources;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public abstract class BasicController<T, S extends ResourceSupport> implements ResourceProcessor<S> {
+    protected ResponseEntity<Resources<Resource<T>>> mkResponse(List<T> objects) {
+        Resources<Resource<T>> resources = new Resources<>(objects.stream()
+                .map(r -> new Resource<>(r))
+                .collect(Collectors.toList()));
+        return new ResponseEntity<>(resources, HttpStatus.OK);
+    }
+}
diff --git a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
index 8ea29aa6..02cd9849 100644
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -24,6 +24,7 @@ import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.rest.resourceserver.attachment.AttachmentInfo;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.component.ComponentController;
+import org.eclipse.sw360.rest.resourceserver.core.BasicController;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.MultiStatus;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
@@ -57,7 +58,7 @@ import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 
 @BasePathAwareController
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
-public class ReleaseController implements ResourceProcessor<RepositoryLinksResource> {
+public class ReleaseController extends BasicController<Release,RepositoryLinksResource> {
     public static final String RELEASES_URL = "/releases";
     private static final Logger log = Logger.getLogger(ReleaseController.class);
 
@@ -84,11 +85,9 @@ public class ReleaseController implements ResourceProcessor<RepositoryLinksResou
             sw360Releases.addAll(releaseService.getReleasesForUser(sw360User));
         }
 
-        Resources<Resource<Release>> resources = new Resources<>(sw360Releases.stream()
+        return mkResponse(sw360Releases.stream()
                 .map(r -> restControllerHelper.convertToEmbeddedRelease(r, fields))
-                .map(r -> new Resource<>(r))
                 .collect(Collectors.toList()));
-        return new ResponseEntity<>(resources, HttpStatus.OK);
     }
 
     private Release searchReleaseBySha1(String sha1, User sw360User) throws TException {
```

#### Potentially related:
- https://stackoverflow.com/questions/43428862/spring-data-rest-adding-link-to-root-repositorylinksresource-cannot-be-cast-to