### PR TITLE
fix(users): write screenname into externalID field

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/UserRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/UserRepository.java
@@ -34,7 +34,7 @@ import java.util.Set;
         @View(name = "all",
                 map = "function(doc) { if (doc.type == 'user') emit(null, doc._id) }"),
         @View(name = "byExternalId",
-                map = "function(doc) { if (doc.type == 'user') emit(doc.externalid.toLowerCase(), doc._id) }"),
+                map = "function(doc) { if (doc.type == 'user' && doc.externalid) emit(doc.externalid.toLowerCase(), doc._id) }"),
         @View(name = "byApiToken",
                 map = "function(doc) { if (doc.type == 'user') " +
                         "  for (var i in doc.restApiTokens) {" +
@@ -66,6 +66,10 @@ public class UserRepository extends SummaryAwareRepository<User> {
     }
 
     public User getByExternalId(String externalId) {
+        if(externalId == null || "".equals(externalId)) {
+            // liferay contains the setup user with externalId=="" and we do not want to match him or any other one with empty externalID
+            return null;
+        }
         final Set<String> userIds = queryForIdsAsValue("byExternalId", externalId.toLowerCase());
         return getUserFromIds(userIds);
     }

--- a/backend/src/src-users/src/main/java/org/eclipse/sw360/users/UserHandler.java
+++ b/backend/src/src-users/src/main/java/org/eclipse/sw360/users/UserHandler.java
@@ -33,14 +33,14 @@ public class UserHandler implements UserService.Iface {
 
     private static final Logger log = Logger.getLogger(UserHandler.class);
 
-    UserDatabaseHandler db;
+    private UserDatabaseHandler db;
 
     public UserHandler() throws IOException {
         db = new UserDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_USERS);
     }
 
     @Override
-    public User getUser(String id) throws TException {
+    public User getUser(String id) {
         return db.getUser(id);
     }
 
@@ -70,12 +70,12 @@ public class UserHandler implements UserService.Iface {
     }
 
     @Override
-    public List<User> searchUsers(String searchText) throws TException {
+    public List<User> searchUsers(String searchText) {
         return db.searchUsers(searchText);
     }
 
     @Override
-    public List<User> getAllUsers() throws TException {
+    public List<User> getAllUsers() {
         return db.getAll();
     }
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
@@ -39,7 +39,6 @@ public class ErrorMessages {
     public static final String PASSWORDS_DONT_MATCH = "Password do not match.";
     public static final String COULD_NOT_CREATE_USER_MODERATION_REQUEST = "Could not create user moderation request.";
     public static final String EMAIL_ALREADY_EXISTS = "Email already exists.";
-    public static final String FULL_NAME_ALREADY_EXISTS = "Full name already exists.";
     public static final String EXTERNAL_ID_ALREADY_EXISTS = "External id already exists.";
     public static final String DEFAULT_ERROR_MESSAGE = "Request could not be processed.";
     public static final String DOCUMENT_NOT_AVAILABLE = "The requested document is not available.";
@@ -70,7 +69,6 @@ public class ErrorMessages {
             .add(PASSWORDS_DONT_MATCH)
             .add(COULD_NOT_CREATE_USER_MODERATION_REQUEST)
             .add(EMAIL_ALREADY_EXISTS)
-            .add(FULL_NAME_ALREADY_EXISTS)
             .add(EXTERNAL_ID_ALREADY_EXISTS)
             .add(DOCUMENT_NOT_AVAILABLE)
             .add(ERROR_GETTING_PROJECT)

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/UserPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/UserPortlet.java
@@ -109,7 +109,7 @@ public class UserPortlet extends Sw360Portlet {
                     }
                 }
 
-                String gid = liferayUser.getOpenId();
+                String gid = liferayUser.getScreenName();
                 String passwordHash = liferayUser.getPassword();
 
                 return !(isNullOrEmpty(firstName) || isNullOrEmpty(lastName) || isNullOrEmpty(emailAddress) || isNullOrEmpty(department) || isNullOrEmpty(userGroup) || isNullOrEmpty(gid) || isNullOrEmpty(passwordHash));
@@ -167,7 +167,7 @@ public class UserPortlet extends Sw360Portlet {
     }
 
 
-    public void backUpUsers(ResourceRequest request, ResourceResponse response) throws PortletException, IOException, SystemException, PortalException {
+    public void backUpUsers(ResourceRequest request, ResourceResponse response) throws IOException, SystemException, PortalException {
         List<User> liferayUsers;
         try {
             liferayUsers = UserLocalServiceUtil.getUsers(QueryUtil.ALL_POS, QueryUtil.ALL_POS);
@@ -196,7 +196,7 @@ public class UserPortlet extends Sw360Portlet {
                 department = organizations.get(0).getName();
             }
 
-            String gid = liferayUser.getOpenId();
+            String gid = liferayUser.getScreenName();
             boolean isMale = liferayUser.isMale();
             String passwordHash = liferayUser.getPassword();
             if (isNullOrEmpty(emailAddress) || isNullOrEmpty(department)) {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserPortletUtils.java
@@ -58,7 +58,7 @@ public class UserPortletUtils {
         long roleId = role.getRoleId();
 
         try {
-            if (userAlreadyExists(requestAdapter.getErrorMessagesConsumer(), emailAddress, externalId, externalId, companyId)){
+            if (userAlreadyExists(requestAdapter.getErrorMessagesConsumer(), emailAddress, externalId, companyId)){
                 return null;
             }
         } catch (PortalException | SystemException e) {
@@ -128,17 +128,14 @@ public class UserPortletUtils {
         }
     }
 
-    private static boolean userAlreadyExists(Consumer<String> errorMessageConsumer, String emailAddress, String externalId, String screenName, long companyId) throws PortalException, SystemException {
+    private static boolean userAlreadyExists(Consumer<String> errorMessageConsumer, String emailAddress, String externalId, long companyId) throws PortalException, SystemException {
         boolean sameEmailExists = userByFieldExists(emailAddress, UserLocalServiceUtil::getUserByEmailAddress, companyId);
-        boolean sameScreenNameExists = userByFieldExists(screenName, UserLocalServiceUtil::getUserByScreenName, companyId);
-        boolean sameExternalIdExists = userByFieldExists(externalId, UserLocalServiceUtil::getUserByOpenId, companyId);
-        boolean alreadyExists = sameScreenNameExists || sameEmailExists || sameExternalIdExists;
+        boolean sameExternalIdExists = userByFieldExists(externalId, UserLocalServiceUtil::getUserByScreenName, companyId);
+        boolean alreadyExists = sameEmailExists || sameExternalIdExists;
 
         if(alreadyExists) {
             String errorMessage;
-            if(sameScreenNameExists) {
-                errorMessage = ErrorMessages.FULL_NAME_ALREADY_EXISTS;
-            } else if(sameEmailExists) {
+            if(sameEmailExists) {
                 errorMessage = ErrorMessages.EMAIL_ALREADY_EXISTS;
             } else {
                 errorMessage = ErrorMessages.EXTERNAL_ID_ALREADY_EXISTS;

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserUtils.java
@@ -156,7 +156,7 @@ public class UserUtils {
         } catch (NoSuchUserException e) {
             log.info("Could not find user with email: '" + email + "'. Will try searching by external id.");
             try {
-                return UserLocalServiceUtil.getUserByOpenId(companyId, externalId);
+                return UserLocalServiceUtil.getUserByScreenName(companyId, externalId);
             } catch (NoSuchUserException nsue) {
                 log.info("Could not find user with externalId: '" + externalId);
                 throw new NoSuchUserException("Couldn't find user either with email or external id", nsue);

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserUtils.java
@@ -174,15 +174,15 @@ public class UserUtils {
         String userEmailAddress = user.getEmailAddress();
         org.eclipse.sw360.datahandler.thrift.users.User refreshed = UserCacheHolder.getRefreshedUserFromEmail(userEmailAddress);
         if (!equivalent(refreshed, user)) {
-            synchronizeUserWithDatabase(user, thriftClients, user::getEmailAddress, user::getOpenId, UserUtils::fillThriftUserFromLiferayUser);
+            synchronizeUserWithDatabase(user, thriftClients, user::getEmailAddress, user::getScreenName, UserUtils::fillThriftUserFromLiferayUser);
             UserCacheHolder.getRefreshedUserFromEmail(userEmailAddress);
         }
     }
 
-    private boolean equivalent(org.eclipse.sw360.datahandler.thrift.users.User refreshed, User user) {
-        final org.eclipse.sw360.datahandler.thrift.users.User thriftUser = new org.eclipse.sw360.datahandler.thrift.users.User();
-        fillThriftUserFromLiferayUser(thriftUser, user);
-        return thriftUser.equals(refreshed);
+    private boolean equivalent(org.eclipse.sw360.datahandler.thrift.users.User userInSW360, User user) {
+        final org.eclipse.sw360.datahandler.thrift.users.User userFromLiferay = new org.eclipse.sw360.datahandler.thrift.users.User();
+        fillThriftUserFromLiferayUser(userFromLiferay, user);
+        return userFromLiferay.equals(userInSW360);
     }
 
     public static void fillThriftUserFromUserCSV(final org.eclipse.sw360.datahandler.thrift.users.User thriftUser, final UserCSV userCsv) {
@@ -201,7 +201,7 @@ public class UserUtils {
         thriftUser.setEmail(user.getEmailAddress());
         thriftUser.setType(TYPE_USER);
         thriftUser.setUserGroup(getUserGroupFromLiferayUser(user));
-        thriftUser.setExternalid(user.getOpenId());
+        thriftUser.setExternalid(user.getScreenName());
         thriftUser.setFullname(user.getFullName());
         thriftUser.setGivenname(user.getFirstName());
         thriftUser.setLastname(user.getLastName());


### PR DESCRIPTION
This tries to fix #477, but it fails to fix existing instances. The problem is that in existing instances there is already a user with multiple email addresses. There is no direct way to differentiate that user back into individual users.

This might also collide with other approaches, where the `openId` of a liferay user is actually used, for storing the external ID.