### PR TITLE
fix(UI): Deleting submitted task under My Task Submission section.

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/mytasksubmissions/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/mytasksubmissions/view.jsp
@@ -41,7 +41,9 @@
 
 <link rel="stylesheet" href="<%=request.getContextPath()%>/webjars/jquery-confirm2/dist/jquery-confirm.min.css">
 <script src="<%=request.getContextPath()%>/webjars/jquery-confirm2/dist/jquery-confirm.min.js" type="text/javascript"></script>
+<%@ include file="/html/utils/includes/requirejs.jspf" %>
 <script>
+require(['jquery', 'modules/confirm', 'datatables.net', 'jquery-confirm'], function($, confirm) {
     var moderationRequestsTable;
 
     Liferay.on('allPortletsReady', function() {
@@ -52,7 +54,7 @@
             "DT_RowId": "${moderation.id}",
             "0": "<sw360:DisplayModerationRequestLink moderationRequest="${moderation}"/>",
             "1": "<sw360:DisplayEnum value="${moderation.moderationState}"/>",
-            "2": "<img src='<%=request.getContextPath()%>/images/Trash.png' onclick=\"deleteModerationRequest('${moderation.id}','<b><sw360:out value="${moderation.documentName}"/></b>')\"  alt='Delete' title='Delete'>"
+            "2": "<img class='delete' src='<%=request.getContextPath()%>/images/Trash.png' data-moderation-id='${moderation.id}' data-document-name='<b><sw360:out value="${moderation.documentName}"/></b>' alt='Delete' title='Delete'>"
         });
         </core_rt:forEach>
 
@@ -68,6 +70,11 @@
             ],
             autoWidth: false
         });
+    });
+
+    $('#tasksubmissionTable').on('click', 'img.delete', function(event) {
+        var data = $(event.currentTarget).data();
+        deleteModerationRequest(data.moderationId, data.documentName);
     });
 
     function deleteModerationRequest(id, docName) {
@@ -93,9 +100,9 @@
                 }
             });
         }
-
-        deleteConfirmed("Do you really want to delete the moderation request for " + docName + " ?", deleteModerationRequestInternal);
+        confirm.confirmDeletion("Do you really want to delete the moderation request for " + docName + " ?", deleteModerationRequestInternal);
     }
+});
 
 </script>
 


### PR DESCRIPTION
**Summary:**
User is not able to delete the submitted task under "My Task Submission" in homepage.

**Changes:**
Fixed the jQuery-confirm loading issue by adding require js support in the jsp.

**Steps to Test:**
Go to Home screen -> "My Task Submissions" -> Try to delete any existing task.

**Expected result:**
The confirm dialog box should appear, after clicking on the "confirm", the task should be removed from the list.

Signed-off-by: Smruti Sahoo <smruti.sahoo@siemens.com>

closes: #481 