### PR TITLE
feat(default vendor): added possibility to save a default vendor for components

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ComponentSummary.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ComponentSummary.java
@@ -10,8 +10,6 @@
  */
 package org.eclipse.sw360.components.summary;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableListMultimap;
 import org.eclipse.sw360.datahandler.db.ReleaseRepository;
 import org.eclipse.sw360.datahandler.db.VendorRepository;
 import org.eclipse.sw360.datahandler.thrift.ThriftUtils;
@@ -19,7 +17,8 @@ import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
 
 import static org.eclipse.sw360.datahandler.thrift.ThriftUtils.copyField;
 

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -224,6 +224,8 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
         setMainLicenses(component);
 
+        vendorRepository.fillVendor(component);
+
         // Set permissions
         makePermission(component, user).fillPermissions();
 
@@ -513,6 +515,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 .add(Component._Fields.CREATED_BY)
                 .add(Component._Fields.CATEGORIES)
                 .add(Component._Fields.COMPONENT_TYPE)
+                .add(Component._Fields.DEFAULT_VENDOR_ID)
                 .add(Component._Fields.HOMEPAGE)
                 .add(Component._Fields.BLOG)
                 .add(Component._Fields.WIKI)

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/VendorRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/VendorRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2015, 2019. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -10,20 +10,15 @@
  */
 package org.eclipse.sw360.datahandler.db;
 
-import com.google.common.base.Strings;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseRepository;
-import org.eclipse.sw360.datahandler.thrift.RequestStatus;
-import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
-import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
-import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
+
 import org.ektorp.support.View;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static org.eclipse.sw360.datahandler.common.SW360Assert.assertNotNull;
-import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 
 /**
  * CRUD access for the Vendor class
@@ -38,6 +33,17 @@ public class VendorRepository extends DatabaseRepository<Vendor> {
         super(Vendor.class, db);
 
         initStandardDesignDocument();
+    }
+
+    public void fillVendor(Component component) {
+        if (component.isSetDefaultVendorId()) {
+            final String vendorId = component.getDefaultVendorId();
+            if (!isNullOrEmpty(vendorId)) {
+                final Vendor vendor = get(vendorId);
+                if (vendor != null)
+                    component.setDefaultVendor(vendor);
+            }
+        }
     }
 
     public void fillVendor(Release release) {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -169,7 +169,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
         } else if (PortalConstants.UPDATE_ALL_VULNERABILITIES.equals(action)) {
             updateAllVulnerabilities(request, response);
         } else if (PortalConstants.UPDATE_VULNERABILITY_VERIFICATION.equals(action)){
-                updateVulnerabilityVerification(request,response);
+            updateVulnerabilityVerification(request, response);
         } else if (PortalConstants.EXPORT_TO_EXCEL.equals(action)) {
             exportExcel(request, response);
         } else if (isGenericAction(action)) {
@@ -498,7 +498,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
 
         try {
             ComponentService.Iface client = thriftClients.makeComponentClient();
-
+            Component component;
             Release release;
 
             if (!isNullOrEmpty(releaseId)) {
@@ -516,13 +516,17 @@ public class ComponentPortlet extends FossologyAwarePortlet {
                 if (isNullOrEmpty(id)) {
                     id = release.getComponentId();
                 }
+                component = client.getComponentById(id, user);
 
             } else {
+                component = client.getComponentById(id, user);
                 release = (Release) request.getAttribute(RELEASE);
                 if(release == null) {
                     release = new Release();
                     release.setComponentId(id);
                     release.setClearingState(ClearingState.NEW_CLEARING);
+                    release.setVendorId(component.getDefaultVendorId());
+                    release.setVendor(component.getDefaultVendor());
                     request.setAttribute(RELEASE, release);
                     putDirectlyLinkedReleaseRelationsInRequest(request, release);
                     setAttachmentsInRequest(request, release);
@@ -531,7 +535,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
                 }
             }
 
-            Component component = client.getComponentById(id, user);
+
             addComponentBreadcrumb(request, response, component);
             if (!isNullOrEmpty(release.getId())) { //Otherwise the link is meaningless
                 addReleaseBreadcrumb(request, response, release);
@@ -1297,6 +1301,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
     public JSONArray getComponentData(List<Component> componentList, PaginationParameters componentParameters) {
         List<Component> sortedComponents = sortComponentList(componentList, componentParameters);
         int count = getComponentDataCount(componentParameters, componentList.size());
+        VendorService.Iface vendorClient = thriftClients.makeVendorClient();
 
         JSONArray componentData = createJSONArray();
         for (int i = componentParameters.getDisplayStart(); i < count; i++) {
@@ -1310,17 +1315,31 @@ public class ComponentPortlet extends FossologyAwarePortlet {
             jsonObject.put("attsSize", String.valueOf(comp.getAttachmentsSize()));
 
             JSONArray vendorArray = createJSONArray();
-            if (comp.isSetVendorNames()) {
-                comp.getVendorNames().stream().sorted().forEach(vendorArray::put);
+            Set<String> vendorNames = new HashSet<>();
+            if (comp.isSetDefaultVendorId()) {
+                Vendor defaultVendor = null;
+                try {
+                    defaultVendor = vendorClient.getByID(comp.getDefaultVendorId());
+                } catch (TException e) {
+                    log.error("Could not get vendor for id [" + comp.getDefaultVendorId() + "] in component with id ["
+                            + comp.getId() + "] because of: ", e);
+                }
+                if (defaultVendor != null) {
+                    vendorNames.add(defaultVendor.getShortname());
+                }
             }
+            if (comp.isSetVendorNames()) {
+                vendorNames.addAll(comp.getVendorNames());
+            }
+            vendorNames.stream().sorted().forEach(vendorArray::put);
+            jsonObject.put("vndrs", vendorArray);
 
             JSONArray licenseArray = createJSONArray();
             if (comp.isSetMainLicenseIds()) {
                 comp.getMainLicenseIds().stream().sorted().forEach(licenseArray::put);
             }
-
-            jsonObject.put("vndrs", vendorArray);
             jsonObject.put("lics", licenseArray);
+
             componentData.put(jsonObject);
         }
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayVendorEdit.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayVendorEdit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2013-2015, 2019. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -10,57 +10,37 @@
  */
 package org.eclipse.sw360.portal.tags;
 
-import com.google.common.base.Strings;
-import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vendors.VendorService;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.thrift.TException;
 
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspWriter;
 
 /**
- * This displays a user in Edit mode
- *
- * @author Johannes.Najjar@tngtech.com
+ * This displays a vendor field that can be used as extension point for a vendor
+ * search dialog via onclick listeners (see also
+ * src/main/webapp/js/components/includes/vendors/searchVendor.js)
  */
 public class DisplayVendorEdit extends NameSpaceAwareTag {
 
-    private String id;
-    private String vendorId="";
-    private Vendor vendor=null;
-    private String onclick = "";
-    private String releaseId = "";
     private String namespace;
-    private Boolean displayLabel=true;
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public void setVendor(Vendor vendor) {
-        this.vendor = vendor;
-    }
-    public void setVendorId(String vendorId) {
-        this.vendorId = vendorId;
-    }
-
-    public void setOnclick(String onclick) {
-        this.onclick = onclick;
-    }
-
-    public void setReleaseId(String releaseId) {
-        this.releaseId = releaseId;
-    }
+    private String id;
+    private String vendorId = "";
+    private Vendor vendor = null;
+    private String releaseId = "";
+    private String label = "";
 
     public int doStartTag() throws JspException {
-
         JspWriter jspWriter = pageContext.getOut();
 
         namespace = getNamespace();
         StringBuilder display = new StringBuilder();
         try {
-
-            if (vendor==null && !Strings.isNullOrEmpty(vendorId)) {
+            if (vendor == null && StringUtils.isNotEmpty(vendorId)) {
                 VendorService.Iface client;
                 try {
                     client = new ThriftClients().makeVendorClient();
@@ -86,25 +66,42 @@ public class DisplayVendorEdit extends NameSpaceAwareTag {
         printLabel(display);
         display.append(String.format("<input type=\"hidden\" readonly=\"\" value=\"\"  id=\"%s\" name=\"%s%s\"/>", id, namespace, id))
                 .append(String.format(
-                        "<input type=\"text\" readonly=\"\" class=\"clickable edit-vendor\" placeholder=\"Click to set vendor\" id=\"%sDisplay\" onclick=\"%s\" data-release-id=\"%s\"/>",
-                        id, onclick, releaseId));
-    }
-
-    private void printLabel(StringBuilder display) {
-        if(displayLabel) {
-            display.append(String.format("<label class=\"textlabel stackedLabel\" for=\"%sDisplay\">Vendor</label>", id));
-        }
+                        "<input type=\"text\" readonly=\"\" class=\"clickable edit-vendor\" placeholder=\"Click to set vendor\" id=\"%sDisplay\" data-release-id=\"%s\"/>",
+                        id, releaseId));
     }
 
     private void printFullVendor(StringBuilder display, Vendor vendor) {
         printLabel(display);
         display.append(String.format("<input type=\"hidden\" readonly=\"\" value=\"%s\"  id=\"%s\" name=\"%s%s\"/>", vendor.getId(), id, namespace, id))
                 .append(String.format(
-                        "<input type=\"text\" readonly=\"\" class=\"clickable edit-vendor\" value=\"%s\" id=\"%sDisplay\" onclick=\"%s\" data-release-id=\"%s\"/>",
-                        vendor.getFullname(), id, onclick, releaseId));
+                        "<input type=\"text\" readonly=\"\" class=\"clickable edit-vendor\" value=\"%s\" id=\"%sDisplay\" data-release-id=\"%s\"/>",
+                        vendor.getFullname(), id, releaseId));
     }
 
-    public void setDisplayLabel(Boolean displayLabel) {
-        this.displayLabel = displayLabel;
+    private void printLabel(StringBuilder display) {
+        if (StringUtils.isNotEmpty(label)) {
+            display.append(
+                    String.format("<label class=\"textlabel stackedLabel\" for=\"%sDisplay\">%s</label>", id, label));
+        }
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void setVendorId(String vendorId) {
+        this.vendorId = vendorId;
+    }
+
+    public void setVendor(Vendor vendor) {
+        this.vendor = vendor;
+    }
+
+    public void setReleaseId(String releaseId) {
+        this.releaseId = releaseId;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
     }
 }

--- a/frontend/sw360-portlet/src/main/webapp/WEB-INF/customTags.tld
+++ b/frontend/sw360-portlet/src/main/webapp/WEB-INF/customTags.tld
@@ -344,15 +344,9 @@
             <rtexprvalue>true</rtexprvalue>
         </attribute>
         <attribute>
-            <name>onclick</name>
+            <name>label</name>
             <required>false</required>
             <type>java.lang.String</type>
-            <rtexprvalue>true</rtexprvalue>
-        </attribute>
-        <attribute>
-            <name>displayLabel</name>
-            <required>false</required>
-            <type>java.lang.Boolean</type>
             <rtexprvalue>true</rtexprvalue>
         </attribute>
     </tag>

--- a/frontend/sw360-portlet/src/main/webapp/html/admin/bulkReleaseEdit/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/admin/bulkReleaseEdit/view.jsp
@@ -61,7 +61,7 @@
                     <span style="display:none" id='plaincpeid${release.id}'>${release.cpeid}</span>
                 </td>
                 <td width="20%">
-                    <sw360:DisplayVendorEdit id='vendorId${release.id}' displayLabel="false"
+                    <sw360:DisplayVendorEdit id='vendorId${release.id}' label=""
                                              vendor="${release.vendor}" releaseId="${release.id}"/>
                     <span style="display:none" id='plainvendor${release.id}'>${release.vendor.fullname}</span>
                 </td>

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/editBasicInfo.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/editBasicInfo.jspf
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2018. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2019. Part of the SW360 Portal Project.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
   ~
@@ -49,17 +49,20 @@
             <sw360:DisplayEnumInfo type="<%=ComponentType.class%>"/>
         </td>
         <td width="33%">
+            <sw360:DisplayVendorEdit id="<%=Component._Fields.DEFAULT_VENDOR_ID.toString()%>" vendorId="${component.defaultVendorId}" vendor="${component.defaultVendor}" label="Default vendor"/>
+        </td>
+        <td width="33%">
             <label class="textlabel stackedLabel" for="comp_homeurl">Homepage URL</label>
             <input class="toplabelledInput" id="comp_homeurl" name="<portlet:namespace/><%=Component._Fields.HOMEPAGE%>" type="URL" align="middle"
                    value="<sw360:out value="${component.homepage}"/>" placeholder="Enter Home Url"/>
         </td>
+    </tr>
+    <tr>
         <td width="33%">
             <label class="textlabel stackedLabel" for="comp_blogurl">Blog URL</label>
             <input class="toplabelledInput" id="comp_blogurl" name="<portlet:namespace/><%=Component._Fields.BLOG%>" type="URL" align="middle"
                    placeholder="Enter Blog Url" value="<sw360:out value="${component.blog}"/>"/>
         </td>
-    </tr>
-    <tr>
         <td width="33%">
             <label class="textlabel stackedLabel" for="comp_wikiurl">Wiki URL</label>
             <input class="toplabelledInput" id="comp_wikiurl" name="<portlet:namespace/><%=Component._Fields.WIKI%>" type="URL" align="middle"
@@ -70,10 +73,12 @@
             <input class="toplabelledInput" id="mailinglist" name="<portlet:namespace/><%=Component._Fields.MAILINGLIST%>" type="text"
                    placeholder="Enter Mailing List Url" value="<sw360:out value="${component.mailinglist}"/>"/>
         </td>
-        <td width="33%">
+    </tr>
+    <tr>
+        <td colspan="3">
             <label class="textlabel stackedLabel" for="comp_desc">Short Description</label>
             <textarea class="toplabelledInput" id="comp_desc" name="<portlet:namespace/><%=Component._Fields.DESCRIPTION%>" rows="4" cols="30"
-                      style="width:200px; height: 25px; resize:both;"
+                      style="width: 97%; height: 25px; resize:both;"
                       placeholder="Enter Description"><sw360:out value="${component.description}"/></textarea>
         </td>
     </tr>
@@ -125,11 +130,13 @@
 <core_rt:set var="customMap" value="${component.roles}"/>
 <%@include file="/html/utils/includes/mapEdit.jspf" %>
 
+<%@include file="/html/components/includes/vendors/searchVendor.jspf" %>
+
 <core_rt:set var="CODESCOOP_URL" value="<%=PortalConstants.CODESCOOP_URL%>"/>
 <core_rt:set var="CODESCOOP_TOKEN" value="<%=PortalConstants.CODESCOOP_TOKEN%>"/>
 <!-- Adding similar component popup for new component case -->
 <script>
-    require([ 'modules/linkListDialog' ], function(linkListDialog) {
+    require([ 'modules/linkListDialog', 'components/includes/vendors/searchVendor' ], function(linkListDialog, vendorsearch) {
         <portlet:resourceURL var="checkComponentNameUrl">
             <portlet:param name="<%=PortalConstants.ACTION%>" value="<%=PortalConstants.CHECK_COMPONENT_NAME%>"/>
         </portlet:resourceURL>
@@ -141,5 +148,21 @@
         <core_rt:if test="${empty CODESCOOP_URL || empty CODESCOOP_TOKEN}">
         linkListDialog.registerLinkListDialog(openOnBlurOfElementId, checkComponentNameUrl, checkComponentNameParamKey);
         </core_rt:if>
+
+
+        // vendor handling
+
+        $('#ComponentGeneralInfo input.edit-vendor').on('click', function() {
+            vendorsearch.openSearchDialog('<portlet:namespace/>what', '<portlet:namespace/>where',
+                      '<portlet:namespace/>FULLNAME', '<portlet:namespace/>SHORTNAME', '<portlet:namespace/>URL', fillVendorInfo);
+        });
+
+        function fillVendorInfo(vendorInfo) {
+            var beforeComma = vendorInfo.substr(0, vendorInfo.indexOf(","));
+            var afterComma = vendorInfo.substr(vendorInfo.indexOf(",") + 1);
+
+            $('#<%=Component._Fields.DEFAULT_VENDOR_ID.toString()%>').val(beforeComma.trim());
+            $('#<%=Component._Fields.DEFAULT_VENDOR_ID.toString()%>Display').val(afterComma.trim());
+        }
     });
 </script>

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/summary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/summary.jspf
@@ -38,6 +38,10 @@
         <td><sw360:DisplayEnum value="${component.componentType}"/></td>
     </tr>
     <tr>
+        <td>Default vendor:</td>
+        <td><sw360:out value="${component.defaultVendor.fullname}"/></td>
+    </tr>
+    <tr>
         <td>Homepage:</td>
         <td><sw360:DisplayLink target="${component.homepage}"/></td>
     </tr>

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseInformation.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseInformation.jspf
@@ -10,6 +10,7 @@
 --%>
 <%@ page import="org.eclipse.sw360.datahandler.common.SW360Utils" %>
 <%@ page import="org.eclipse.sw360.datahandler.thrift.components.Component" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.components.Release"%>
 <%@ page import="org.eclipse.sw360.datahandler.thrift.MainlineState" %>
 
 <table class="table info_table" id="ComponentBasicInfo">
@@ -20,7 +21,7 @@
     </thead>
     <tr>
         <td width="33%">
-            <sw360:DisplayVendorEdit id="<%=Release._Fields.VENDOR_ID.toString()%>" vendor="${release.vendor}" />
+            <sw360:DisplayVendorEdit id="<%=Release._Fields.VENDOR_ID.toString()%>" vendor="${release.vendor}" label="Vendor"/>
         </td>
         <td width="33%">
             <label class="textlabel stackedLabel mandatory" for="comp_name">Name</label>

--- a/frontend/sw360-portlet/src/main/webapp/html/components/mergeComponent.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/mergeComponent.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2017, 2019. Part of the SW360 Portal Project.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
   ~
@@ -154,13 +154,13 @@
             $stepElement.append(wizard.createSingleMergeLine('Created by', data.componentTarget.createdBy, data.componentSource.createdBy));
             $stepElement.append(wizard.createMultiMergeLine('Categories', data.componentTarget.categories, data.componentSource.categories));
             $stepElement.append(wizard.createSingleMergeLine('Component Type', data.componentTarget.componentType, data.componentSource.componentType, getComponentTypeDisplayString));
+            $stepElement.append(wizard.createSingleMergeLine('Default Vendor', data.componentTarget.defaultVendor, data.componentSource.defaultVendor, getDefaultVendorDisplayString));
             $stepElement.append(wizard.createSingleMergeLine('Homepage', data.componentTarget.homepage, data.componentSource.homepage));
             $stepElement.append(wizard.createSingleMergeLine('Blog', data.componentTarget.blog, data.componentSource.blog));
             $stepElement.append(wizard.createSingleMergeLine('Wiki', data.componentTarget.wiki, data.componentSource.wiki));
             $stepElement.append(wizard.createSingleMergeLine('Mailing list', data.componentTarget.mailinglist, data.componentSource.mailinglist));
             $stepElement.append(wizard.createSingleMergeLine('Description', data.componentTarget.description, data.componentSource.description));
             $stepElement.append(wizard.createSingleMergeLine('External ids', data.componentTarget.externalids, data.componentSource.externalids));
-
 
             $stepElement.append(wizard.createCategoryLine('Roles'));
             $stepElement.append(wizard.createSingleMergeLine('Component owner', data.componentTarget.componentOwner, data.componentSource.componentOwner));
@@ -202,6 +202,8 @@
             componentSelection.createdBy = wizard.getFinalSingleValue('Created by');
             componentSelection.categories = wizard.getFinalMultiValue('Categories');
             componentSelection.componentType = wizard.getFinalSingleValue('Component Type');
+            componentSelection.defaultVendor = wizard.getFinalSingleValue('Default Vendor');
+            componentSelection.defaultVendorId = componentSelection.defaultVendor ? componentSelection.defaultVendor.id : undefined;
             componentSelection.homepage = wizard.getFinalSingleValue('Homepage');
             componentSelection.blog = wizard.getFinalSingleValue('Blog');
             componentSelection.wiki = wizard.getFinalSingleValue('Wiki');
@@ -256,6 +258,7 @@
             $stepElement.append(wizard.createSingleDisplayLine('Created by', data.componentSelection.createdBy));
             $stepElement.append(wizard.createMultiDisplayLine('Categories', data.componentSelection.categories));
             $stepElement.append(wizard.createSingleDisplayLine('Component Type', data.componentSelection.componentType, getComponentTypeDisplayString));
+            $stepElement.append(wizard.createSingleDisplayLine('Default Vendor', data.componentSelection.defaultVendor, getDefaultVendorDisplayString));
             $stepElement.append(wizard.createSingleDisplayLine('Homepage', data.componentSelection.homepage));
             $stepElement.append(wizard.createSingleDisplayLine('Blog', data.componentSelection.blog));
             $stepElement.append(wizard.createSingleDisplayLine('Wiki', data.componentSelection.wiki));
@@ -305,8 +308,12 @@
         componentTypeDisplayStrings[${ct.value}] = '${ThriftEnumUtils.enumToString(ct)}';
         </core_rt:forEach>
 
-        function getComponentTypeDisplayString(componentType){
-          return componentTypeDisplayStrings[componentType];
+        function getComponentTypeDisplayString(componentType) {
+            return componentTypeDisplayStrings[componentType];
+        }
+
+        function getDefaultVendorDisplayString(defaultVendor) {
+            return defaultVendor ? defaultVendor.fullname : '';
         }
     });
 </script>

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
@@ -12,11 +12,9 @@ package org.eclipse.sw360.datahandler.thrift;
 
 import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
+
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
-import org.eclipse.sw360.datahandler.thrift.components.Component;
-import org.eclipse.sw360.datahandler.thrift.components.ECCStatus;
-import org.eclipse.sw360.datahandler.thrift.components.EccInformation;
-import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.licenses.*;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -170,6 +168,12 @@ public class ThriftValidate {
 
         // Unset fields that do not make sense
         component.unsetReleases();
+        component.unsetDefaultVendor();
+        // we might want to have a logic someday that the defaultVendorId will be set
+        // from defaultVendor if the latter one is set and the former one not - but
+        // until now the thought is that clients need to make sure that the
+        // defaultVendorId is set and that the component contains the vendor itself is
+        // just convenience
     }
 
     public static List<Component> prepareComponents(Collection<Component> components) throws SW360Exception {

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -263,6 +263,9 @@ struct Component {
 
     35: optional set<string> mainLicenseIds,        //Aggregate of release main licenses
 
+    36: optional Vendor defaultVendor,
+    37: optional string defaultVendorId,
+
     // List of keywords
     40: optional set<string> categories,
     41: optional set<string> languages,             //Aggregate of release languages

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -13,17 +13,17 @@
 
 package org.eclipse.sw360.rest.resourceserver.core;
 
-import java.util.Map;
-import java.util.Set;
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
 import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.Visibility;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
-import org.eclipse.sw360.datahandler.thrift.components.Component;
-import org.eclipse.sw360.datahandler.thrift.components.ECCStatus;
-import org.eclipse.sw360.datahandler.thrift.components.EccInformation;
-import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
@@ -34,14 +34,12 @@ import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO;
 import org.eclipse.sw360.rest.resourceserver.core.serializer.JsonProjectRelationSerializer;
 import org.eclipse.sw360.rest.resourceserver.core.serializer.JsonReleaseRelationSerializer;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.util.Map;
+import java.util.Set;
 
 @Configuration
 class JacksonCustomizations {
@@ -259,6 +257,8 @@ class JacksonCustomizations {
                 "releasesSize",
                 "setReleases",
                 "setReleaseIds",
+                "setDefaultVendor",
+                "setDefaultVendorId",
                 "setCategories",
                 "languagesSize",
                 "setLanguages",

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -10,12 +10,6 @@
  */
 package org.eclipse.sw360.rest.resourceserver.core;
 
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import org.apache.log4j.Logger;
-import org.apache.thrift.TBase;
-import org.apache.thrift.TException;
-import org.apache.thrift.TFieldIdEnum;
 import org.eclipse.sw360.datahandler.resourcelists.*;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
@@ -37,24 +31,30 @@ import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.eclipse.sw360.rest.resourceserver.user.UserController;
 import org.eclipse.sw360.rest.resourceserver.vendor.Sw360VendorService;
 import org.eclipse.sw360.rest.resourceserver.vendor.VendorController;
+
+import org.apache.log4j.Logger;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TException;
+import org.apache.thrift.TFieldIdEnum;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.hateoas.Link;
-import org.springframework.hateoas.PagedResources;
-import org.springframework.hateoas.Resource;
-import org.springframework.hateoas.Resources;
+import org.springframework.hateoas.*;
+import org.springframework.hateoas.core.EmbeddedWrapper;
+import org.springframework.hateoas.core.EmbeddedWrappers;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.hateoas.core.EmbeddedWrapper;
-import org.springframework.hateoas.core.EmbeddedWrappers;
 import org.springframework.stereotype.Service;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
 import javax.servlet.http.HttpServletRequest;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -246,8 +246,8 @@ public class RestControllerHelper<T> {
         }
     }
 
-    public void addEmbeddedVendors(HalResource<Component> halComponent, Set<String> vendors) {
-        for (String vendorFullName : vendors) {
+    public void addEmbeddedVendors(HalResource<Component> halComponent, Set<String> vendorFullnames) {
+        for (String vendorFullName : vendorFullnames) {
             HalResource<Vendor> vendorHalResource = addEmbeddedVendor(vendorFullName);
             halComponent.addEmbeddedResource("sw360:vendors", vendorHalResource);
         }


### PR DESCRIPTION
* added default vendor handling
  * default vendor can be added and updated in component details edit mode
  * default vendor can be seen in component details view
  * default vendor id will be handled in moderation requests
  * default vendor is part of component merge
  * default vendor is part of REST
  * default vendor is part of vendors list in component list view
  * default vendor is added to new release edit view
  * default vendor is NOT yet part of import/export functionalities

closes eclipse/sw360#267

Signed-off-by: Andreas Klett <andreas.klett@scansation.de>

@mcjaeger what about import/export functionalities? Should we add the new fields there as well? If yes, in which parts exactly?