### PR TITLE
fix(ui): MyComponents and MyProjects does not list in Home page if email is changed

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MyComponentsPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MyComponentsPortlet.java
@@ -46,7 +46,7 @@ public class MyComponentsPortlet extends Sw360Portlet {
         List<Component> components;
         try {
             final User user = UserCacheHolder.getUserFromRequest(request);
-            components = thriftClients.makeComponentClient().getMyComponents(user);
+            components = thriftClients.makeComponentClient().getComponentSummary(user);
         } catch (TException e) {
             log.error("Could not fetch your components from backend", e);
             components = new ArrayList<>();

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MyProjectsPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MyProjectsPortlet.java
@@ -43,7 +43,7 @@ public class MyProjectsPortlet extends Sw360Portlet {
         List<Project> myProjects = new ArrayList<>();
         User user = UserCacheHolder.getUserFromRequest(request);
         try {
-            myProjects = thriftClients.makeProjectClient().getMyProjects(user.getEmail());
+            myProjects = thriftClients.makeProjectClient().getAccessibleProjectsSummary(user);
         } catch (TException e) {
             LOGGER.error("Could not fetch myProjects from backend for user, " + user.getEmail(), e);
         }


### PR DESCRIPTION
#### Summary:
 If a user changes the e-mail, the view of the projects (and components) within the Home page is not showing the projects and components referring to the old e-mail.
### Root Cause:
In home page earlier the search was based on  user email because of which when we change the email application is not able to find any result for that.As per latest changes projects and components are searched based on user id.
#### Steps to reproduce:
1.Login to the application and check the projects and components list on the home page.
2.Now go to "My Account" and change the email address for the logged in user and save the changes.
3.Now go back to home page and refresh the page.

#### Result:
1.It should show the same list of  all projects and components associated to the user. 

Closes #302 