### PR TITLE
fix(ui): After removing a task from Home page, the task is back in the list when navigating back

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/html/homepage/mytasksubmissions/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/homepage/mytasksubmissions/view.jsp
@@ -104,6 +104,15 @@ require(['jquery', 'modules/confirm', 'datatables.net', 'jquery-confirm'], funct
     }
 });
 
+    window.addEventListener( "pageshow", function ( event ) {
+        var doNotRefresh = ((typeof window.performance != "undefined"
+                                && typeof window.performance.now !== 'undefined'
+	                            && window.performance.navigation.type !== 2 ));
+        if (!doNotRefresh) {
+            window.location.reload();
+        }
+    });
+
 </script>
 
 


### PR DESCRIPTION
#### Summary:
 After removing a task from Home page, the task is back in the list when navigating back.
#### Steps to reproduce:
1. In home page delete any of the task from "My Task Submissions".
2.Now click on any of the task from the "My Task Submissions" list.
3.It will open the task and then click on browser back button to go back to home page.
#### Expected result:
1."My Task Submissions" list in home page should display the updated list of tasks.

Closes: #121 



