### PR TITLE
feat(subproject licenses): added possibility to take over license selection from subproject

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentDatabaseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2016. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2016, 2019. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -10,21 +10,18 @@
  */
 package org.eclipse.sw360.datahandler.db;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
-import org.eclipse.sw360.datahandler.thrift.RequestStatus;
-import org.eclipse.sw360.datahandler.thrift.RequestSummary;
-import org.eclipse.sw360.datahandler.thrift.SW360Exception;
-import org.eclipse.sw360.datahandler.thrift.Source;
-import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
-import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage;
-import org.eclipse.sw360.datahandler.thrift.attachments.UsageData;
+import org.eclipse.sw360.datahandler.thrift.*;
+import org.eclipse.sw360.datahandler.thrift.attachments.*;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
 import org.ektorp.BulkDeleteDocument;
@@ -156,13 +153,18 @@ public class AttachmentDatabaseHandler {
         }
     }
 
-    private List<AttachmentUsage> distinctAttachmentUsages(List<AttachmentUsage> attachmentUsages) {
+    @VisibleForTesting
+    protected List<AttachmentUsage> distinctAttachmentUsages(List<AttachmentUsage> attachmentUsages) {
         return attachmentUsages.stream()
                 .filter(CommonUtils.distinctByKey(au -> ImmutableList.of(
                         au.getOwner(),
                         au.getUsedBy(),
                         au.getAttachmentContentId(),
-                        au.isSetUsageData() ? au.getUsageData().getSetField() : "")))
+                        au.isSetUsageData() ? au.getUsageData().getSetField() : "",
+                        au.isSetUsageData() && au.getUsageData().getSetField().equals(UsageData._Fields.LICENSE_INFO)
+                                && au.getUsageData().getLicenseInfo().isSetProjectPath()
+                                        ? au.getUsageData().getLicenseInfo().getProjectPath()
+                                        : "")))
                 .collect(Collectors.toList());
     }
 

--- a/backend/src-common/src/test/java/org/eclipse/sw360/datahandler/db/AttachmentDatabaseHandlerTest.java
+++ b/backend/src-common/src/test/java/org/eclipse/sw360/datahandler/db/AttachmentDatabaseHandlerTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import com.google.common.collect.Sets;
+
+import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.thrift.Source;
+import org.eclipse.sw360.datahandler.thrift.attachments.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.eclipse.sw360.datahandler.TestUtils.assertTestString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AttachmentDatabaseHandlerTest {
+
+    private static final String dbName = DatabaseSettings.COUCH_DB_DATABASE;
+    private static final String attachmentsDbName = DatabaseSettings.COUCH_DB_ATTACHMENTS;
+
+    private AttachmentDatabaseHandler uut;
+
+    @Before
+    public void setup() throws MalformedURLException {
+        assertTestString(dbName);
+        assertTestString(attachmentsDbName);
+
+        // currently we are only testing methods that do not access the database so we
+        // only need the parameters to call the constructor
+        // when this changes, the database has to be created before and deleted
+        // afterwards - see e.g. ProjectDatabaseHandlerTest
+        uut = new AttachmentDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), dbName, attachmentsDbName);
+    }
+
+    @Test
+    public void testDistinctAttachmentUsagesSimple() {
+        // given:
+        List<AttachmentUsage> attachmentUsagesIn = new ArrayList<>();
+
+        AttachmentUsage au1 = new AttachmentUsage(Source.releaseId("r1"), "aci1", Source.projectId("p1"));
+        UsageData ua1 = new UsageData();
+        LicenseInfoUsage liu1 = new LicenseInfoUsage(Sets.newHashSet("e1", "e2"));
+        liu1.setProjectPath("p1:p2");
+        ua1.setLicenseInfo(liu1);
+        au1.setUsageData(ua1);
+        attachmentUsagesIn.add(au1);
+
+        // when:
+        List<AttachmentUsage> actual = uut.distinctAttachmentUsages(attachmentUsagesIn);
+
+        // then:
+        assertTrue(actual.size() == 1);
+    }
+
+    @Test
+    public void testDistinctAttachmentUsagesLicenseInfos() {
+        // given:
+        List<AttachmentUsage> attachmentUsagesIn = new ArrayList<>();
+
+        AttachmentUsage au1 = new AttachmentUsage(Source.releaseId("r1"), "aci1", Source.projectId("p1"));
+        UsageData ua1 = new UsageData();
+        LicenseInfoUsage liu1 = new LicenseInfoUsage(Sets.newHashSet("el1", "el2"));
+        liu1.setProjectPath("p1:p2");
+        ua1.setLicenseInfo(liu1);
+        au1.setUsageData(ua1);
+        attachmentUsagesIn.add(au1);
+
+        // same attachment of same release in same project root, but with in different
+        // subproject path => should not be a duplicate
+        AttachmentUsage au2 = new AttachmentUsage(Source.releaseId("r1"), "aci1", Source.projectId("p1"));
+        UsageData ua2 = new UsageData();
+        LicenseInfoUsage liu2 = new LicenseInfoUsage(Sets.newHashSet("el3"));
+        liu2.setProjectPath("p1:p2:p3");
+        ua2.setLicenseInfo(liu2);
+        au2.setUsageData(ua2);
+        attachmentUsagesIn.add(au2);
+
+        // same attachment of different release in same project root with different
+        // subproject path => should not be a duplicate
+        AttachmentUsage au3 = new AttachmentUsage(Source.releaseId("r2"), "aci1", Source.projectId("p1"));
+        UsageData ua3 = new UsageData();
+        LicenseInfoUsage liu3 = new LicenseInfoUsage(Sets.newHashSet("el4"));
+        liu3.setProjectPath("p1:p2");
+        ua3.setLicenseInfo(liu3);
+        au3.setUsageData(ua3);
+        attachmentUsagesIn.add(au3);
+
+        // same attachment of same release in same project root with same
+        // subproject path => should be a duplicate (and can only happen with old data
+        // where a release could have the same attachment twice)
+        AttachmentUsage au4 = new AttachmentUsage(Source.releaseId("r1"), "aci1", Source.projectId("p1"));
+        UsageData ua4 = new UsageData();
+        LicenseInfoUsage liu4 = new LicenseInfoUsage(Sets.newHashSet("el5"));
+        liu4.setProjectPath("p1:p2");
+        ua4.setLicenseInfo(liu4);
+        au4.setUsageData(ua4);
+        attachmentUsagesIn.add(au4);
+
+        // when:
+        List<AttachmentUsage> actual = uut.distinctAttachmentUsages(attachmentUsagesIn);
+
+        // then:
+        assertTrue(attachmentUsagesIn.size() == 4);
+        assertTrue(actual.size() == 3);
+        assertEquals(attachmentUsagesIn.get(0), actual.get(0));
+        assertEquals(attachmentUsagesIn.get(1), actual.get(1));
+        assertEquals(attachmentUsagesIn.get(2), actual.get(2));
+    }
+
+    @Test
+    public void testDistinctAttachmentUsagesSourcePackage() {
+        // given:
+        List<AttachmentUsage> attachmentUsagesIn = new ArrayList<>();
+
+        AttachmentUsage au1 = new AttachmentUsage(Source.releaseId("r1"), "aci1", Source.projectId("p1"));
+        UsageData ua1 = new UsageData();
+        SourcePackageUsage spu1 = new SourcePackageUsage();
+        spu1.setDummy("d1");
+        ua1.setSourcePackage(spu1);
+        au1.setUsageData(ua1);
+        attachmentUsagesIn.add(au1);
+
+        // same attachment of same release in same project root, but with different
+        // dummy => should be a duplicate
+        AttachmentUsage au2 = new AttachmentUsage(Source.releaseId("r1"), "aci1", Source.projectId("p1"));
+        UsageData ua2 = new UsageData();
+        SourcePackageUsage spu2 = new SourcePackageUsage();
+        spu2.setDummy("d2");
+        ua2.setSourcePackage(spu2);
+        au2.setUsageData(ua2);
+        attachmentUsagesIn.add(au2);
+
+        // same attachment of different release in same project root => should not be a
+        // duplicate
+        AttachmentUsage au3 = new AttachmentUsage(Source.releaseId("r2"), "aci1", Source.projectId("p1"));
+        UsageData ua3 = new UsageData();
+        SourcePackageUsage spu3 = new SourcePackageUsage();
+        spu3.setDummy("d1");
+        ua3.setSourcePackage(spu3);
+        au3.setUsageData(ua3);
+        attachmentUsagesIn.add(au3);
+
+        // when:
+        List<AttachmentUsage> actual = uut.distinctAttachmentUsages(attachmentUsagesIn);
+
+        // then:
+        assertTrue(attachmentUsagesIn.size() == 3);
+        assertTrue(actual.size() == 2);
+        assertEquals(attachmentUsagesIn.get(0), actual.get(0));
+        assertEquals(attachmentUsagesIn.get(2), actual.get(1));
+    }
+
+    @Test
+    public void testDistinctAttachmentUsagesMixed() {
+        // given:
+        List<AttachmentUsage> attachmentUsagesIn = new ArrayList<>();
+
+        AttachmentUsage au1 = new AttachmentUsage(Source.releaseId("r1"), "aci1", Source.projectId("p1"));
+        UsageData ua1 = new UsageData();
+        LicenseInfoUsage liu1 = new LicenseInfoUsage(Sets.newHashSet("el1", "el2"));
+        liu1.setProjectPath("p1:p2");
+        ua1.setLicenseInfo(liu1);
+        au1.setUsageData(ua1);
+        attachmentUsagesIn.add(au1);
+
+        // same attachment of same release in same project root with same
+        // subproject path => should be a duplicate (and can only happen with old data
+        // where a release could have the same attachment twice)
+        AttachmentUsage au2 = new AttachmentUsage(Source.releaseId("r1"), "aci1", Source.projectId("p1"));
+        UsageData ua2 = new UsageData();
+        LicenseInfoUsage liu2 = new LicenseInfoUsage(Sets.newHashSet("el5"));
+        liu2.setProjectPath("p1:p2");
+        ua2.setLicenseInfo(liu2);
+        au2.setUsageData(ua2);
+        attachmentUsagesIn.add(au2);
+
+        // same attachment of same release in same project root, but with different
+        // usage type => should not be a duplicate
+        AttachmentUsage au3 = new AttachmentUsage(Source.releaseId("r1"), "aci1", Source.projectId("p1"));
+        UsageData ua3 = new UsageData();
+        SourcePackageUsage spu1 = new SourcePackageUsage();
+        spu1.setDummy("d1");
+        ua3.setSourcePackage(spu1);
+        au3.setUsageData(ua3);
+        attachmentUsagesIn.add(au3);
+
+        // same attachment of same release in same project root, but with different
+        // usage type => should be a duplicate
+        AttachmentUsage au4 = new AttachmentUsage(Source.releaseId("r1"), "aci1", Source.projectId("p1"));
+        UsageData ua4 = new UsageData();
+        SourcePackageUsage spu2 = new SourcePackageUsage();
+        spu2.setDummy("d2");
+        ua4.setSourcePackage(spu2);
+        au4.setUsageData(ua4);
+        attachmentUsagesIn.add(au4);
+
+        // when:
+        List<AttachmentUsage> actual = uut.distinctAttachmentUsages(attachmentUsagesIn);
+
+        // then:
+        assertTrue(attachmentUsagesIn.size() == 4);
+        assertTrue(actual.size() == 2);
+        assertEquals(attachmentUsagesIn.get(0), actual.get(0));
+        assertEquals(attachmentUsagesIn.get(2), actual.get(1));
+    }
+
+}

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -170,6 +170,8 @@ public class PortalConstants {
     public static final String LICENSE_INFO_ATTACHMENT_USAGES = "licInfoAttUsages";
     public static final String SOURCE_CODE_ATTACHMENT_USAGES = "sourceAttUsages";
     public static final String MANUAL_ATTACHMENT_USAGES = "manualAttUsages";
+    public static final String PROJECT_PATH = "projectPath";
+    public static final String PROJECT_PATHS = "projectPaths";
 
 
     public static final String FOSSOLOGY_FINGER_PRINTS = "fingerPrints";

--- a/frontend/sw360-portlet/src/main/webapp/css/sw360.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/sw360.css
@@ -349,6 +349,16 @@ input[readonly].clickable {
     padding-right: 0px;
 }
 
+#LinkedProjectsInfo input.use-subproject-selection {
+    margin-top: -2px;
+    margin-right: 5px;
+}
+
+#LinkedProjectsInfo .use-subproject-selection-label {
+    margin-top: 5px;
+    font-size: 12px;
+}
+
 .sw360modal button:last-of-type {
     float: right;
 }

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentSelectTable.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentSelectTable.jspf
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2016-2018. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2016-2019. Part of the SW360 Portal Project.
   ~ Copyright Bosch Software Innovations GmbH, 2017.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
@@ -31,6 +31,7 @@
 </div>
 
 <table class="table info_table" id="LinkedProjectsInfo"
+    data-project-id="${project.id}"
     data-table-mode="${projectLinkTableMode}"
     data-table-mode-license-info="${tableModeLicenseInfo}"
     data-table-mode-source-bundle="${tableModeSourceBundle}"
@@ -38,8 +39,10 @@
     data-license-info-base-url="<%=downloadLicenseInfoURL%>"
     data-license-info-state-url="<%=downloadLicenseInfoStateURL%>"
     data-source-package-state-url="<%=downloadSourcePackageStateURL%>"
+    data-project-id-parameter-name="<%=PortalConstants.PROJECT_ID%>"
     data-attachment-id-parameter-name="<%=PortalConstants.ATTACHMENT_ID%>"
     data-release-id-parameter-name="<%=PortalConstants.RELEASE_ID%>"
+    data-project-path-parameter-name="<%=PortalConstants.PROJECT_PATH%>"
 >
     <colgroup>
         <col style="width: 40px;" />
@@ -67,7 +70,9 @@
     <tbody>
     <%--linked projects and their linked projects--%>
     <core_rt:forEach items="${projectList}" var="projectLink" varStatus="loop">
+        <c:set var="projectPath">${projectLink.id}</c:set>
         <core_rt:if test="${loop.index!=0}">
+            <c:set var="projectPath">${projectPaths[projectLink.nodeId]}</c:set>
             <tr id="projectLinkRow${loop.count}" data-tt-id="${projectLink.nodeId}"
                 <core_rt:if test="${not empty projectLink.parentNodeId}">data-tt-parent-id="${projectLink.parentNodeId}"</core_rt:if>
             >
@@ -78,6 +83,13 @@
                     <a href="<sw360:DisplayProjectLink projectId="${projectLink.id}" bare="true" />"><sw360:out
                         value="${projectLink.name}" maxChar="50"/> <sw360:out
                             value="${projectLink.version}"/></a>
+                    <core_rt:if test="${projectLinkTableMode == tableModeLicenseInfo}">
+                        <br />
+                        <label class="use-subproject-selection-label" for="${projectPath}_use-sel">
+                            <input type="button" id="${projectPath}_use-sel" class="use-subproject-selection" data-tt-parent-id="${projectLink.nodeId}" value="Use selection of this subproject">
+                            Attention: current selection will be overwritten!
+                        </label>
+                    </core_rt:if>
                 </td><td>
                     <sw360:DisplayEnum value="${projectLink.projectType}"/>
                 </td><td>
@@ -116,11 +128,14 @@
                 <td>
                 </td>
             </tr>
+            <%-- TODO what is the logic that is controlled by this variable?! --%>
             <core_rt:set var="attachmentSelected" value="false" scope="request"/>
             <core_rt:forEach items="${releaseLink.attachments}" var="attachment" varStatus="attachmentloop">
-                <tr id="attachmentRow${loop.count}_${releaseloop.count}_${attachmentloop.count}" data-tt-id="${releaseLink.nodeId}_${attachment.attachmentContentId}"
+                <tr id="attachmentRow${loop.count}_${releaseloop.count}_${attachmentloop.count}"
+                    data-tt-id="${releaseLink.nodeId}_${attachment.attachmentContentId}"
                     data-tt-parent-id="${releaseLink.nodeId}"
-                <core_rt:if test="${projectLinkTableMode == tableModeLicenseInfo}">data-tt-branch="true"</core_rt:if>
+                    data-project-path="${projectPath}"
+                    <core_rt:if test="${projectLinkTableMode == tableModeLicenseInfo}">data-tt-branch="true"</core_rt:if>
                     data-row-type="attachment"
                     data-tree-level="${projectLink.treeLevel + 1}"
                     data-release-id="${releaseLink.id}"
@@ -130,11 +145,12 @@
                 >
                     <td>
                         <input type="checkbox"
-                               name="<portlet:namespace/><%=PortalConstants.LICENSE_INFO_RELEASE_TO_ATTACHMENT%>"
-                               value="${releaseLink.id}:${attachment.attachmentContentId}"
-                               <core_rt:if test="${!attachmentSelected && (releaseLink.attachments.size() == 1 || attachment.createdTeam == sw360User.department)}">checked="checked" class="defaultChecked"
-                                <core_rt:set var="attachmentSelected" value="true" scope="request"/>
-                        </core_rt:if>
+                                name="<portlet:namespace/><%=PortalConstants.LICENSE_INFO_RELEASE_TO_ATTACHMENT%>"
+                                <core_rt:if test="${projectLinkTableMode == tableModeLicenseInfo}">value='${projectPath.concat(":").concat(releaseLink.id).concat(":").concat(attachment.attachmentContentId)}'</core_rt:if>
+                                <core_rt:if test="${projectLinkTableMode != tableModeLicenseInfo}">value='${releaseLink.id.concat(":").concat(attachment.attachmentContentId)}'</core_rt:if>
+                                <core_rt:if test="${!attachmentSelected && (releaseLink.attachments.size() == 1 || attachment.createdTeam == sw360User.department)}">checked="checked" class="defaultChecked"
+                                    <core_rt:set var="attachmentSelected" value="true" scope="request"/>
+                                </core_rt:if>
                         />
                     </td>
                     <td>
@@ -188,10 +204,10 @@
 
                 if(data.tableMode === data.tableModeLicenseInfo) {
                     initializeTableForLicenseInfo($linkedProjectsInfoTable);
-                    loadSavedSelectionState($linkedProjectsInfoTable);
+                    loadSavedSelectionState($linkedProjectsInfoTable, data.projectId);
                 } else if(data.tableMode === data.tableModeSourceBundle) {
                     initializeTableForSourceBundle($linkedProjectsInfoTable);
-                    loadSavedSelectionState($linkedProjectsInfoTable);
+                    loadSavedSelectionState($linkedProjectsInfoTable, data.projectId);
                 } else {
                     $linkedProjectsInfoTable.before($('<div/>', {
                         'class': 'error foregroundAlert',
@@ -208,6 +224,28 @@
                         $linkedProjectsInfoTable.find(":checkbox.defaultChecked").prop('checked', true).trigger('change');
                     }
                 });
+
+                $(".use-subproject-selection").on("click", function(event) {
+                    var node = event.target,
+                        prefix = node.id.indexOf(':') > 0 ? node.id.substr(0, node.id.lastIndexOf(':') + 1) : '',
+                        subprojectId = node.id.substr(node.id.lastIndexOf(':') + 1, 32),
+                        ttParentId = $(node).data().ttParentId;
+
+                    addProjectLoader(ttParentId);
+                    loadSavedSelectionState($linkedProjectsInfoTable, subprojectId, ttParentId, prefix);
+                });
+
+                function addProjectLoader(ttParentId) {
+                    $linkedProjectsInfoTable.find('tr[data-tt-id=' + ttParentId + ']')
+                        .after($('<tr>', { 'data-tt-id': ttParentId + '_loader', 'data-tt-parent-id': ttParentId } )
+                        .append($('<td>', { 'colspan': 7 })
+                        .append($('<div>', { 'class': 'spinner' })
+                        .append($('<span>', { text: 'Loading subproject license information. Please wait...' })))));
+                }
+
+                function removeProjectLoader(ttParentId) {
+                    $linkedProjectsInfoTable.find('tr[data-tt-id=' + ttParentId + '_loader]').remove();
+                }
 
                 // helper functions
                 function initializeTableForSourceBundle($linkedProjectsInfoTable) {
@@ -239,13 +277,20 @@
                 function expandLicenseFile($linkedProjectsInfoTable, node, loadedCallback) {
                     var url,
                         urlData = $linkedProjectsInfoTable.data(),
-                        data = node.row.data();
+                        data;
 
                     loadedCallback = loadedCallback || function() {};
+                    if (!node || !node.row.data()) {
+                        loadedCallback('No node given to expand.');
+                        return;
+                    }
+
+                    data = node.row.data();
                     if(data.rowType !== 'attachment' || data.loaded) {
                         loadedCallback();
                         return;
                     }
+
                     // we set it to loaded here to prevent double requests by collapsing and expanding again
                     // on the other hand we have to unset it on errors
                     data.loaded = true;
@@ -256,6 +301,7 @@
                     url = Liferay.PortletURL.createURL(urlData.licenseInfoBaseUrl);
                     url.setParameter(urlData.attachmentIdParameterName, data.attachmentId);
                     url.setParameter(urlData.releaseIdParameterName, data.releaseId);
+                    url.setParameter(urlData.projectPathParameterName, data.projectPath);
 
                     $.ajax({
                         url: url.toString(),
@@ -274,8 +320,8 @@
                             return;
                         }
 
-                        $rows = convertDataToRows(urlData.portletNamespace, data.ttId, data.treeLevel,
-                                        data.attachmentId, node.row.find('input[type=checkbox]:first').is(':checked'), licenses);
+                        $rows = convertDataToRows(urlData.portletNamespace, data.ttId, data.treeLevel, data.projectPath,
+                                        data.releaseId, data.attachmentId, node.row.find('input[type=checkbox]:first').is(':checked'), licenses);
                         $rows.find('.license-text').tooltip({
                             delay: 0,
                             content: function () {
@@ -288,17 +334,17 @@
 
                         // synchronize checkbox of each license with checkbox of attachment
                         node.row.find('input[type=checkbox]:first').on('change', function() {
-                            $linkedProjectsInfoTable.find('tr input[name=' + urlData.portletNamespace + data.attachmentId + ']').
+                            $linkedProjectsInfoTable.find('tr input[name="' + urlData.portletNamespace + data.projectPath + ':' + data.releaseId + ':' + data.attachmentId + '"]').
                                 prop('checked', this.checked).trigger('change');
                         });
                         // be sure that attachment is checked if at least one license is checked and that attachment is not checked
                         // if no license is checked
-                        $linkedProjectsInfoTable.find('tr input[name=' + urlData.portletNamespace + data.attachmentId + ']').on('change', function() {
+                        $linkedProjectsInfoTable.find('tr input[name="' + urlData.portletNamespace + data.projectPath + ':' + data.releaseId + ':' + data.attachmentId + '"]').on('change', function() {
                             if(this.checked) {
                                 // do not trigger change here, otherwise all license would be selected.
                                 node.row.find('input[type=checkbox]:first').prop('checked', true);
                             } else {
-                                if($linkedProjectsInfoTable.find('tr input[name=' + urlData.portletNamespace + data.attachmentId + ']:checked').length == 0) {
+                                if($linkedProjectsInfoTable.find('tr input[name="' + urlData.portletNamespace + data.projectPath + ':' + data.releaseId + ':' + data.attachmentId + '"]:checked').length == 0) {
                                     // do not trigger change here, otherwise all license would be selected.
                                     node.row.find('input[type=checkbox]:first').prop('checked', false);
                                 }
@@ -313,7 +359,7 @@
                     });
                 }
 
-                function convertDataToRows(portletNamespace, parentNodeId, treeLevel, attachmentContentId, initialCheck, licenses) {
+                function convertDataToRows(portletNamespace, parentNodeId, treeLevel, projectPath, releaseId, attachmentContentId, initialCheck, licenses) {
                     var index = 0,
                         $rows = $();
 
@@ -327,8 +373,8 @@
 
                         $checkbox = $('<input/>', {
                             type:         'checkbox',
-                            name:         portletNamespace + attachmentContentId,
-                            value:         index++,
+                            name:         portletNamespace + projectPath + ':' + releaseId + ":" + attachmentContentId,
+                            value:        index++,
                         });
                         if(initialCheck) {
                             $checkbox.attr('checked', 'checked');
@@ -337,7 +383,7 @@
                             $checkbox,
                             $('<input/>', {
                                 type:     'hidden',
-                                name:     portletNamespace + attachmentContentId + '_key',
+                                name:     portletNamespace + projectPath + ':' + releaseId + ":" + attachmentContentId + '_key',
                                 value:    license.key
                             })
                         ).appendTo($row);
@@ -386,25 +432,36 @@
                     $linkedProjectsInfoTable.find('tr[data-tt-id=' + ttId + '_loader] td .spinner').hide();
                 }
 
-                function loadSavedSelectionState($linkedProjectsInfoTable) {
-                    var config = $linkedProjectsInfoTable.data();
-                    var url;
+                function loadSavedSelectionState($linkedProjectsInfoTable, projectId, ttId, prefix) {
+                    var config = $linkedProjectsInfoTable.data(),
+                        prefix = prefix || '',
+                        url;
                     if(config.tableMode === config.tableModeLicenseInfo) {
                         url = config.licenseInfoStateUrl;
                     } else {
                         url = config.sourcePackageStateUrl;
                     }
+                    url = Liferay.PortletURL.createURL(url);
+                    url.setParameter(config.projectIdParameterName, projectId);
 
                     $.ajax({
                         type: 'GET',
                         url: url,
                     }).done(function(result) {
                         if(!result || result.length == 0) {
+                            if(prefix) {
+                                // this means a subproject selection has been loaded
+                                removeProjectLoader(ttId);
+                            }
                             $('#infobar').removeClass('backgroundWarning').addClass('backgroundOK').html($('<span>', {
                                 text: "No previous selection found. If you have writing permissions to this project, your selection will be stored automatically when downloading."
                             }));
                         } else {
-                            restoreSelection($linkedProjectsInfoTable, result, function(error, warnings) {
+                            restoreSelection($linkedProjectsInfoTable, result, ttId, prefix, function(error, warnings) {
+                                if(prefix) {
+                                    // this means a subproject selection has been loaded
+                                    removeProjectLoader(ttId);
+                                }
                                 if(error) {
                                     $('#infobar').removeClass('backgroundGrey').addClass('backgroundAlert').html($('<span>', {
                                         text: "Cannot restore previous selection: " + error
@@ -460,61 +517,104 @@
                     return $list;
                 }
 
-                function restoreSelection($linkedProjectsInfoTable, attachmentUsages, readyCallback) {
+                function restoreSelection($linkedProjectsInfoTable, attachmentUsages, ttId, prefix, readyCallback) {
                     var warnings = [],
                         loadCountdown = countdown(attachmentUsages.length, function() { readyCallback(null, warnings); }),
                         config = $linkedProjectsInfoTable.data();
 
-                    $("#selectAllCheckbox").prop('checked', false).trigger('change');
+                    if (!prefix) {
+                        // on first load (=prefix is empty) reset all default selected checkboxes if we have a stored selection
+                        $("#selectAllCheckbox").prop('checked', false).trigger('change');
+                    } else {
+                        // on subproject loads (=prefix is set) reset only subtree checkboxes
+                        $ttNode = $linkedProjectsInfoTable.treetable('node', ttId);
+                        uncheckAttachmentInSubtree($ttNode);
+                    }
                     attachmentUsages.forEach(function(usage) {
-                        $linkedProjectsInfoTable.find('tr input[value="' + usage.owner.releaseId + ':' + usage.attachmentContentId + '"]:first').prop('checked', true).trigger('change');
+                        var inputPrefix = config.tableMode === config.tableModeLicenseInfo ? prefix + usage.usageData.licenseInfo.projectPath + ':' : '',
+                            node;
+                        // check all checkboxes by checking the parent one because we are storing exclusions and only
+                        // excluded ones will be unchecked
+                        $linkedProjectsInfoTable.find('tr input[value="' + inputPrefix + usage.owner.releaseId + ':' + usage.attachmentContentId + '"]:first').prop('checked', true).trigger('change');
 
                         if(usage.usageData.licenseInfo && usage.usageData.licenseInfo.excludedLicenseIds.length > 0) {
-                            expandLicenseFile($linkedProjectsInfoTable, findNode($linkedProjectsInfoTable, usage), function(error) {
-                                if(error) {
-                                    readyCallback(error);
-                                    return;
-                                }
-                                usage.usageData.licenseInfo.excludedLicenseIds.forEach(function(licenseId) {
-                                    var $parentRow = $linkedProjectsInfoTable.find('tr[data-release-id=' + usage.owner.releaseId + '][data-attachment-id=' + usage.attachmentContentId + ']:first'),
-                                        $row = $linkedProjectsInfoTable.find('tr[data-tt-parent-id="' + $parentRow.data().ttId + '"][data-license-name="' + licenseId + '"]');
-
-                                    if($row.length == 0) {
-                                        warnings.push({
-                                            release: findReleaseName($linkedProjectsInfoTable, usage),
-                                            attachment: findAttachmentName($linkedProjectsInfoTable, usage),
-                                            text: 'License "' + licenseId + '" not found. License is not excluded.'
-                                        });
-                                    } else if($row.length > 1) {
-                                        warnings.push({
-                                            release: findReleaseName($linkedProjectsInfoTable, usage),
-                                            attachment: findAttachmentName($linkedProjectsInfoTable, usage),
-                                            text: 'License "' + licenseId + '" is not unique. License is not excluded.'
-                                        });
-                                    } else {
-                                        $row.find('input[name="' + config.portletNamespace + usage.attachmentContentId + '"]').prop('checked', false).trigger('change');
-                                    }
+                            if (!usage.usageData.licenseInfo.projectPath) {
+                                // if an export happened in older storage format, just try naive fix and pretend release
+                                // has been in main project. if that does not work, just print warning that restore
+                                // might have failed
+                                usage.usageData.licenseInfo.projectPath = config.projectId;
+                            }
+                            node = findNode($linkedProjectsInfoTable, usage, prefix);
+                            if (!node) {
+                                var releaseName = findReleaseName($linkedProjectsInfoTable, usage, prefix),
+                                    attachmentName = findAttachmentName($linkedProjectsInfoTable, usage, prefix);
+                                warnings.push({
+                                    release: releaseName || 'unknown release',
+                                    attachment: attachmentName || 'unknown attachment',
+                                    text: 'Last export happened with old storage format, so restored data might not be correct for attachments of releases in subprojects.'
                                 });
                                 loadCountdown.decrement();
-                            });
+                            } else {
+                                expandLicenseFile($linkedProjectsInfoTable, node, function(error) {
+                                    if(error) {
+                                        readyCallback(error);
+                                        return;
+                                    }
+                                    usage.usageData.licenseInfo.excludedLicenseIds.forEach(function(licenseId) {
+                                        var $parentRow = $linkedProjectsInfoTable.find('tr[data-project-path="' + prefix + usage.usageData.licenseInfo.projectPath + '"][data-release-id=' + usage.owner.releaseId + '][data-attachment-id=' + usage.attachmentContentId + ']:first'),
+                                            $row = $linkedProjectsInfoTable.find('tr[data-tt-parent-id="' + $parentRow.data().ttId + '"][data-license-name="' + licenseId + '"]');
+
+                                        if($row.length == 0) {
+                                            warnings.push({
+                                                release: findReleaseName($linkedProjectsInfoTable, usage, prefix),
+                                                attachment: findAttachmentName($linkedProjectsInfoTable, usage, prefix),
+                                                text: 'License "' + licenseId + '" not found. License is not excluded.'
+                                            });
+                                        } else if($row.length > 1) {
+                                            warnings.push({
+                                                release: findReleaseName($linkedProjectsInfoTable, usage, prefix),
+                                                attachment: findAttachmentName($linkedProjectsInfoTable, usage, prefix),
+                                                text: 'License "' + licenseId + '" is not unique. License is not excluded.'
+                                            });
+                                        } else {
+                                            $row.find('input[name="' + config.portletNamespace + prefix + usage.usageData.licenseInfo.projectPath + ':' + usage.owner.releaseId + ':' + usage.attachmentContentId + '"]').prop('checked', false).trigger('change');
+                                        }
+                                    });
+                                    loadCountdown.decrement();
+                                });
+                            }
                         } else {
                             loadCountdown.decrement();
                         }
                     });
                 }
 
-                function findNode($linkedProjectsInfoTable, usage) {
-                    var $row = $linkedProjectsInfoTable.find('tr[data-release-id=' + usage.owner.releaseId + '][data-attachment-id=' + usage.attachmentContentId + ']:first');
-                    return $linkedProjectsInfoTable.treetable("node", $row.data().ttId);
+                function uncheckAttachmentInSubtree($ttNode) {
+                    if ($ttNode.row.data().rowType !== 'attachment') {
+                        $ttNode.children.forEach(function(childNode) {
+                            uncheckAttachmentInSubtree(childNode);
+                        });
+                    } else {
+                        $ttNode.row.find('input[type="checkbox"]:first').prop('checked', false).trigger('change');
+                    }
                 }
 
-                function findAttachmentName($linkedProjectsInfoTable, usage) {
-                    var $row = $linkedProjectsInfoTable.find('tr[data-release-id=' + usage.owner.releaseId + '][data-attachment-id=' + usage.attachmentContentId + ']:first');
+                function findNode($linkedProjectsInfoTable, usage, prefix) {
+                    var $row = $linkedProjectsInfoTable.find('tr[data-project-path="' + prefix + usage.usageData.licenseInfo.projectPath + '"][data-release-id=' + usage.owner.releaseId + '][data-attachment-id=' + usage.attachmentContentId + ']:first');
+                    if ($row.length > 0) {
+                        return $linkedProjectsInfoTable.treetable("node", $row.data().ttId);
+                    } else {
+                        return null;
+                    }
+                }
+
+                function findAttachmentName($linkedProjectsInfoTable, usage, prefix) {
+                    var $row = $linkedProjectsInfoTable.find('tr[data-project-path="' + prefix + usage.usageData.licenseInfo.projectPath + '"][data-release-id=' + usage.owner.releaseId + '][data-attachment-id=' + usage.attachmentContentId + ']:first');
                     return $row.find('td.filename').text();
                 }
 
-                function findReleaseName($linkedProjectsInfoTable, usage) {
-                    var $row = $linkedProjectsInfoTable.find('tr[data-release-id=' + usage.owner.releaseId + ']:first');
+                function findReleaseName($linkedProjectsInfoTable, usage, prefix) {
+                    var $row = $linkedProjectsInfoTable.find('tr[data-project-path="' + prefix + usage.usageData.licenseInfo.projectPath + '"][data-release-id=' + usage.owner.releaseId + ']:first');
                     return $row.find('td.release-name a').text();
                 }
 

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/licenseInfo.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/licenseInfo.jsp
@@ -8,6 +8,7 @@
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v10.html
   --%>
+<%@ page import="java.util.Map"%>
 <%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
@@ -33,6 +34,7 @@
     <jsp:useBean id="sw360User" class="org.eclipse.sw360.datahandler.thrift.users.User" scope="request"/>
     <jsp:useBean id="projectList" type="java.util.List<org.eclipse.sw360.datahandler.thrift.projects.ProjectLink>"
                  scope="request"/>
+    <jsp:useBean id="projectPaths" type="java.util.Map<java.lang.String, java.lang.String>" scope="request"/>
     <jsp:useBean id="licenseInfoOutputFormats"
                  type="java.util.List<org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatInfo>"
                  scope="request"/>

--- a/libraries/lib-datahandler/src/main/thrift/attachments.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/attachments.thrift
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2014-2018. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2014-2019. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
  *
  * SPDX-License-Identifier: EPL-1.0
@@ -113,10 +113,16 @@ union UsageData {
 
 /**
  * Stores specific information if an attachment is used for license info generation. Holds the license ids
- * that were excluded from generation.
+ * that were excluded from generation. In addition it holds the path of project ids as one string separated
+ * with ":", where the project id from the root project in "usedBy" is always included, so this string is never
+ * empty. This means that each usage becomes really unique by the complete path
+ *     projectPath:owner(=releaseId):attachmentContentId
+ * Since the projectPath was added over time, it is not required yet and the code has to deal with the case that
+ * it is empty. This might change in the future.
  */
 struct LicenseInfoUsage {
     1: required set<string> excludedLicenseIds;
+    2: optional string projectPath;
 }
 
 /**


### PR DESCRIPTION
* changed page behavior: same attachments of same releases are no longer
coupled in the tree if they belong to different subprojects
* license file contains the union of all selected licenses (so if the
same license is not selected on one leaf but is selected on another, it
will be part of the license file)
* added new field in LicenseInfoUsage to store the project path to this
attachment
* added button to take over the license selection of a subproject in a
fire and forget manner
* added loading spinner row
* source code bundle generation should still be the same

closes eclipse/sw360#483

Signed-off-by: Andreas Klett <andreas.klett@scansation.de>


The basic idea of the new license info file generation page is, that licenses are identified by the pattern
`projectid:subprojectid1:subprodjectid2:releaseid:attachmentcontentid:license`.
So the chain of (sub-)projectids has been added as an identifier in this PR. This was necessary to decouple the licenses in the same attachment at the same release in different project tree parts, so that one can take over the license selections for a subproject subtree without changing anything outside of this subtree.

Regarding testing, there are a lot of possibilities to test. Especially combinations with bigger subproject trees, where the same release (and therefore the same license relevant attachments) is available in different parts of this tree. Not only the UI is interesting in these cases when (un-)folding different tree parts first, then take over subproject selections or doing it the other way around - but also the license file generation. Especially the cases where a license is selected in one part of the tree and not selected in another branch.
In addition, loading of the last selection can be tested when entering the process again.

And as said before the source code bundle generation should be tested because it shares a lot of code with the license file generation. But it should be untouched by these changes.