### PR TITLE
feat(UI-attachment): Create attachment bundle zip container, even for only one attachment

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -131,6 +131,7 @@ public class PortalConstants {
     public static final String ADDED_ATTACHMENTS = "added_attachments";
     public static final String REMOVED_ATTACHMENTS = "removed_attachments";
     public static final String ATTACHMENT_ID = "attachmentId";
+    public static final String ALL_ATTACHMENTS = "all_attachments";
     public static final String CONTEXT_TYPE = "context_type";
     public static final String CONTEXT_ID = "context_id";
     public static final String ATTACHMENT_USAGE_COUNT_MAP = "attachmenUsageCountMap";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayDownloadAttachmentBundle.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayDownloadAttachmentBundle.java
@@ -48,6 +48,7 @@ public class DisplayDownloadAttachmentBundle extends DisplayDownloadAbstract {
         for (Attachment attachment : attachments) {
             urlWriter.withParam(PortalConstants.ATTACHMENT_ID, attachment.attachmentContentId);
         }
+        urlWriter.withParam(PortalConstants.ALL_ATTACHMENTS, "true");
     }
 
     @Override

--- a/libraries/commonIO/src/main/java/org/eclipse/sw360/commonIO/AttachmentFrontendUtils.java
+++ b/libraries/commonIO/src/main/java/org/eclipse/sw360/commonIO/AttachmentFrontendUtils.java
@@ -49,11 +49,20 @@ public class AttachmentFrontendUtils {
 
     public InputStream getStreamToServeAFile(Collection<AttachmentContent> attachments, User user, Object context)
             throws TException, IOException {
-        if(attachments == null || attachments.size() == 0){
+        if (attachments == null || attachments.size() == 0) {
             throw new SW360Exception("Tried to download empty set of Attachments");
-        }else if(attachments.size() == 1){
+        } else if(attachments.size() == 1) {
             // Temporary solutions, permission check needs to be implemented (getAttachmentStream)
             return getConnector().unsafeGetAttachmentStream(attachments.iterator().next());
+        } else {
+            return getConnector().getAttachmentBundleStream(new HashSet<>(attachments), user, context);
+        }
+    }
+
+    public InputStream getStreamToServeBundle(Collection<AttachmentContent> attachments, User user, Object context)
+            throws TException, IOException {
+        if (attachments == null || attachments.size() == 0) {
+            throw new SW360Exception("Tried to download empty set of Attachments");
         } else {
             return getConnector().getAttachmentBundleStream(new HashSet<>(attachments), user, context);
         }


### PR DESCRIPTION
**Summary:**
 During attachment bundle download , if there is only one file to download then on click of download button it directly download the file without zip container and the tooltip for the same shows "Download AttachmentBundle.zip". 

**Steps to reproduce:**
1.Open any of the project or component then go to "Attachment" tab.
2.Make sure you have only one attachment to download then click on the download attachment bundle icon to download all the attachments.

**Result:**
1.It should download the attachments into zip container even though there is only one file to download. 

Closes :  #127 
