### PR TITLE
fix(REST API): Attachmentupload endpoint documentation

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/components.adoc
+++ b/rest/resource-server/src/docs/asciidoc/components.adoc
@@ -135,6 +135,38 @@ include::{snippets}/should_document_get_component_attachment_info/curl-request.a
 ===== Example response
 include::{snippets}/should_document_get_component_attachment_info/http-response.adoc[]
 
+[[resources-component-attachment-upload]]
+==== Upload attachment to component
+
+A `POST` request is used to upload attachment to component
+
+[red]#Request structure#
+|===
+|Path |Type |Description
+
+|file
+|file
+|File path of the attachment
+
+|attachment.filename
+|String
+|Name of the file
+
+|attachment.attachmentContentId
+|String
+|Attachment content id
+|===
+
+[red]#Response structure#
+|===
+|Complete Component will be returned
+|===
+
+===== Example request
+include::{snippets}/should_document_upload_attachment_to_component/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_upload_attachment_to_component/http-response.adoc[]
 
 [[resources-component-attachment-get]]
 ==== Download attachment

--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -101,6 +101,39 @@ include::{snippets}/should_document_get_project_attachment_info/curl-request.ado
 include::{snippets}/should_document_get_project_attachment_info/http-response.adoc[]
 
 
+[[resources-project-attachment-upload]]
+==== Upload attachment to project
+
+A `POST` request is used to upload attachment to project
+
+[red]#Request structure#
+|===
+|Path |Type |Description
+
+|file
+|file
+|File path of the attachment
+
+|attachment.filename
+|String
+|Name of the file
+
+|attachment.attachmentContentId
+|String
+|Attachment content id
+|===
+
+[red]#Response structure#
+|===
+|Complete Project will be returned
+|===
+
+===== Example request
+include::{snippets}/should_document_upload_attachment_to_project/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_upload_attachment_to_project/http-response.adoc[]
+
 [[resources-project-attachment-get]]
 ==== Download attachment
 
@@ -202,3 +235,4 @@ include::{snippets}/should_document_create_project/curl-request.adoc[]
 
 ===== Example response
 include::{snippets}/should_document_create_project/http-response.adoc[]
+

--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -81,6 +81,39 @@ include::{snippets}/should_document_get_release_attachment_info/curl-request.ado
 include::{snippets}/should_document_get_release_attachment_info/http-response.adoc[]
 
 
+[[resources-release-attachment-upload]]
+==== Upload attachment to release
+
+A `POST` request is used to upload attachment to release
+
+[red]#Request structure#
+|===
+|Path |Type |Description
+
+|file
+|file
+|File path of the attachment
+
+|attachment.filename
+|String
+|Name of the file
+
+|attachment.attachmentContentId
+|String
+|Attachment content id
+|===
+
+[red]#Response structure#
+|===
+|Complete Release will be returned
+|===
+
+===== Example request
+include::{snippets}/should_document_upload_attachment_to_release/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_upload_attachment_to_release/http-response.adoc[]
+
 [[resources-release-attachment-get]]
 ==== Download attachment
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -33,6 +33,7 @@ import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
@@ -72,7 +73,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
     private Attachment attachment;
 
     @Before
-    public void before() throws TException {
+    public void before() throws TException, IOException {
         Set<Attachment> attachmentList = new HashSet<>();
         List<Resource<Attachment>> attachmentResources = new ArrayList<>();
         attachment = new Attachment("1231231254", "spring-core-4.3.4.RELEASE.jar");
@@ -82,7 +83,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
 
         given(this.attachmentServiceMock.getAttachmentContent(anyObject())).willReturn(new AttachmentContent().setId("1231231254").setFilename("spring-core-4.3.4.RELEASE.jar").setContentType("binary"));
         given(this.attachmentServiceMock.getResourcesFromList(anyObject())).willReturn(new Resources<>(attachmentResources));
-
+        given(this.attachmentServiceMock.uploadAttachment(anyObject(), anyObject(), anyObject())).willReturn(attachment);
         Map<String, Set<String>> externalIds = new HashMap<>();
         externalIds.put("component-id-key", Collections.singleton(""));
 
@@ -505,5 +506,10 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("_embedded.sw360:components[]externalIds").description("External Ids of the component"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
+    }
+
+    @Test
+    public void should_document_upload_attachment_to_component() throws Exception {
+        testAttachmentUpload("/api/components/", angularComponent.getId());
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -36,6 +36,7 @@ import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
@@ -78,7 +79,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
 
 
     @Before
-    public void before() throws TException {
+    public void before() throws TException, IOException {
         Set<Attachment> attachmentList = new HashSet<>();
         List<Resource<Attachment>> attachmentResources = new ArrayList<>();
         attachment = new Attachment("1231231254", "spring-core-4.3.4.RELEASE.jar");
@@ -88,6 +89,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
 
         given(this.attachmentServiceMock.getAttachmentContent(anyObject())).willReturn(new AttachmentContent().setId("1231231254").setFilename("spring-core-4.3.4.RELEASE.jar").setContentType("binary"));
         given(this.attachmentServiceMock.getResourcesFromList(anyObject())).willReturn(new Resources<>(attachmentResources));
+        given(this.attachmentServiceMock.uploadAttachment(anyObject(), anyObject(), anyObject())).willReturn(attachment);
 
         Map<String, ProjectReleaseRelationship> linkedReleases = new HashMap<>();
         Map<String, ProjectRelationship> linkedProjects = new HashMap<>();
@@ -483,4 +485,10 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("_embedded.createdBy").description("The user who created this project")
                         )));
     }
+
+    @Test
+    public void should_document_upload_attachment_to_project() throws Exception {
+        testAttachmentUpload("/api/projects/", project.getId());
+    }
+
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -32,6 +32,7 @@ import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
@@ -71,7 +72,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
     private String releaseId = "3765276512";
 
     @Before
-    public void before() throws TException {
+    public void before() throws TException, IOException {
         Set<Attachment> attachmentList = new HashSet<>();
         List<Resource<Attachment>> attachmentResources = new ArrayList<>();
         attachment = new Attachment("1231231254", "spring-core-4.3.4.RELEASE.jar");
@@ -81,6 +82,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
 
         given(this.attachmentServiceMock.getAttachmentContent(anyObject())).willReturn(new AttachmentContent().setId("1231231254").setFilename("spring-core-4.3.4.RELEASE.jar").setContentType("binary"));
         given(this.attachmentServiceMock.getResourcesFromList(anyObject())).willReturn(new Resources<>(attachmentResources));
+        given(this.attachmentServiceMock.uploadAttachment(anyObject(), anyObject(), anyObject())).willReturn(attachment);
 
         Map<String, Set<String>> externalIds = new HashMap<>();
         externalIds.put("mainline-id-component", new HashSet<>(Arrays.asList("1432", "4876")));
@@ -346,5 +348,10 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("createdOn").description("The creation date of the internal sw360 release"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
                         )));
+    }
+
+    @Test
+    public void should_document_upload_attachment_to_release() throws Exception {
+        testAttachmentUpload("/api/releases/", releaseId);
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/TestRestDocsSpecBase.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/TestRestDocsSpecBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017,2019. Part of the SW360 Portal Project.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,28 +9,44 @@
 
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.ByteArrayInputStream;
+
+import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.JUnitRestDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest
 @ContextConfiguration
 public abstract class TestRestDocsSpecBase {
+
+    @Value("${sw360.test-user-id}")
+    private String testUserId;
+
+    @Value("${sw360.test-user-password}")
+    private String testUserPassword;
 
     @Autowired
     protected WebApplicationContext context;
@@ -63,5 +79,23 @@ public abstract class TestRestDocsSpecBase {
                         .withPort(443))
                 .alwaysDo(this.documentationHandler)
                 .build();
+    }
+
+    public void testAttachmentUpload(String url, String id) throws Exception {
+        String attachment = "{ \"filename\":\"spring-core-4.3.4.RELEASE.jar\", \"attachmentContentId\":\"2\"}";
+        /*
+         * TODO Suggestion to use better library in future, instead of MockMultipartFile
+         * to have better document generation feature. below logic is used to generate
+         * the correct restapi end point documentation
+         */
+        MockMultipartFile jsonFile = new MockMultipartFile("attachment", "", "application/json",
+                new ByteArrayInputStream(attachment.getBytes()));
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.fileUpload(url + id + "/attachments")
+                .file("file", "@/spring-core-4.3.4.RELEASE.jar".getBytes())
+                .file(jsonFile)
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .header("Authorization", "Bearer " + accessToken);
+        this.mockMvc.perform(builder).andExpect(status().isOk()).andDo(this.documentationHandler.document());
     }
 }


### PR DESCRIPTION
Added logic to add REST API documentation for attachment upload to project,component and release which records a CURL request and response in the documentation.
Please search for the end point with sub heading ""Upload Attachment" under the corresponding section of Projects and Components and Releases

