### PR TITLE
fix:Project spreadsheet export failure due to maximum cell length reached

### DIFF
--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
@@ -11,6 +11,7 @@
 package org.eclipse.sw360.exporter;
 
 
+import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
@@ -96,7 +97,11 @@ public class ExcelExporter<T, U extends ExporterHelper<T>> {
         }
         for (int column = 0; column < helper.getColumns(); column++) {
             Cell cell = row.createCell(column);
-            cell.setCellValue(values.get(column));
+            if(values.get(column).length() >= SpreadsheetVersion.EXCEL2007.getMaxTextLength()) {
+                cell.setCellValue("cell has exceeded max number of characters");
+            }else {
+                cell.setCellValue(values.get(column));
+            }
             cell.setCellStyle(style);
         }
     }


### PR DESCRIPTION
**Summary:**
If the cell value exceeds 32,767 characters then application should not display error page
Instead it should put value as "Export to spread sheet"

Added check for maximum cell limit during writing the values into row. 

**Steps to reproduce:**
1.Create a project and and link around 460 releases to the project so that when user user select export to spreadsheet for the project then "releases with usage" column will have more then 32767 characters.
2.Now try to export all projects from projects tab by selecting "Export to spread sheet".
**Actual Result:**
If the cell value exceeds 32767 (max allowed) characters then when just display an error message inside #cell has exceeded max number of characters.


Closes: #519 