### PR TITLE
fix(report): fix indentation and message text

### DIFF
--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
@@ -97,9 +97,9 @@ public class ExcelExporter<T, U extends ExporterHelper<T>> {
         }
         for (int column = 0; column < helper.getColumns(); column++) {
             Cell cell = row.createCell(column);
-            if(values.get(column).length() >= SpreadsheetVersion.EXCEL2007.getMaxTextLength()) {
-                cell.setCellValue("cell has exceeded max number of characters");
-            }else {
+            if (values.get(column).length() >= SpreadsheetVersion.EXCEL2007.getMaxTextLength()) {
+                cell.setCellValue("#cell has exceeded max number of characters");
+            } else {
                 cell.setCellValue(values.get(column));
             }
             cell.setCellStyle(style);


### PR DESCRIPTION
**Summary:** Added indentation fix and message text 

During spread sheet generation If the cell content exceeds 32,767 characters then it should display a message "#cell has exceeded max number of characters".