### PR TITLE
feat(spdx-import): added functionality to view and use spdx information

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParser.java
@@ -12,27 +12,28 @@
  */
 package org.eclipse.sw360.licenseinfo.parsers;
 
-import com.google.common.collect.ImmutableList;
-import org.apache.log4j.Logger;
-import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
-import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfo;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
 import org.spdx.rdfparser.InvalidSPDXAnalysisException;
 import org.spdx.rdfparser.SPDXDocumentFactory;
-import org.spdx.rdfparser.model.*;
+import org.spdx.rdfparser.model.SpdxDocument;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 import static org.eclipse.sw360.licenseinfo.parsers.SPDXParserTools.getLicenseInfoFromSpdx;
 

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParserTest.java
@@ -12,8 +12,7 @@
 package org.eclipse.sw360.licenseinfo.parsers;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.input.ReaderInputStream;
+
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
 import org.eclipse.sw360.datahandler.db.ComponentDatabaseHandler;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
@@ -25,13 +24,15 @@ import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.ReaderInputStream;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.io.InputStream;
 import java.io.StringReader;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,11 +40,14 @@ import java.util.stream.Collectors;
 import static org.eclipse.sw360.licenseinfo.TestHelper.assertLicenseInfoParsingResult;
 import static org.eclipse.sw360.licenseinfo.TestHelper.makeAttachmentContentStream;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyObject;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * @author: alex.borodin@evosoft.com

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.sw360.licenses.db;
 
-import org.apache.log4j.Logger;
 import org.eclipse.sw360.components.summary.SummaryType;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
@@ -28,8 +27,9 @@ import org.eclipse.sw360.datahandler.thrift.licenses.*;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.licenses.tools.SpdxConnector;
+
+import org.apache.log4j.Logger;
 import org.ektorp.DocumentOperationResult;
 import org.ektorp.http.HttpClient;
 import org.jetbrains.annotations.NotNull;
@@ -140,7 +140,9 @@ public class LicenseDatabaseHandler {
     public License getLicenseForOrganisation(String id, String organisation) throws SW360Exception {
         License license = licenseRepository.get(id);
 
-        assertNotNull(license);
+        if (license == null) {
+            throw new SW360Exception("No license details found in the database for id " + id + ".");
+        }
 
         fillLicenseForOrganisation(organisation, license);
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
@@ -26,7 +26,7 @@ public class ErrorMessages {
     public static final String DUPLICATE_ATTACHMENT = "Multiple attachments with same name or content cannot be present in attachment list.";
     public static final String ERROR_GETTING_PROJECT = "Error fetching project from backend.";
     public static final String ERROR_GETTING_COMPONENT = "Error fetching component from backend.";
-    public static final String ERROR_GETTING_LICENSE = "Error fetching license from backend.";
+    public static final String ERROR_GETTING_LICENSE = "No license details found in the database for given license id.";
     public static final String ERROR_GETTING_RELEASE = "Error fetching release from backend.";
     public static final String LICENSE_USED_BY_RELEASE =  "Request could not be processed, as license is used by at least one release!";
     public static final String DOCUMENT_USED_BY_PROJECT_OR_RELEASE = "Document could not be processed, as it is used by other Projects or Releases!";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -128,6 +128,7 @@ public class PortalConstants {
 
     //! Specialized keys for attachments
     public static final String ATTACHMENTS = "attachments";
+    public static final String SPDX_ATTACHMENTS = "spdxAttachments";
     public static final String ADDED_ATTACHMENTS = "added_attachments";
     public static final String REMOVED_ATTACHMENTS = "removed_attachments";
     public static final String ATTACHMENT_ID = "attachmentId";
@@ -137,6 +138,7 @@ public class PortalConstants {
     public static final String ATTACHMENT_USAGE_COUNT_MAP = "attachmenUsageCountMap";
     public static final String ATTACHMENT_USAGES = "attachmentUsages";
     public static final String ATTACHMENT_USAGES_RESTRICTED_COUNTS = "attachmentUsagesRestrictedCounts";
+    public static final String SPDX_LICENSE_INFO = "spdxLicenseInfo";
 
     //! Specialized keys for projects
     public static final String PROJECT_ID = "projectid";
@@ -287,6 +289,8 @@ public class PortalConstants {
     public static final String DOWNLOAD_SAMPLE_RELEASE_LINK_INFO = "DownloadSampleReleaseLinkInfo";
     public static final String DOWNLOAD_RELEASE_LINK_INFO = "DownloadReleaseLinkInfo";
     public static final String DOWNLOAD_LICENSE_BACKUP = "DownloadLicenseBackup";
+    public static final String LOAD_SPDX_LICENSE_INFO = "LoadSpdxLicenseInfo";
+    public static final String WRITE_SPDX_LICENSE_INFO_INTO_RELEASE = "WriteSpdxLicenseInfoIntoRelease";
 
     // linked projects and releases actions
     public static final String LINKED_OBJECTS_PREFIX = "load_linked_";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/licenses/LicensesPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/licenses/LicensesPortlet.java
@@ -199,7 +199,7 @@ public class LicensesPortlet extends Sw360Portlet {
                 addLicenseBreadcrumb(request, response, moderationLicense);
 
             } catch (TException e) {
-                log.error("Error fetching license details from backend", e);
+                log.error("Error fetching license details for id " + id + " from backend", e);
                 setSW360SessionError(request, ErrorMessages.ERROR_GETTING_LICENSE);
             }
         }

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/clearingDetails.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/clearingDetails.jspf
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
+  ~ Copyright Siemens AG, 2013-2017, 2019. Part of the SW360 Portal Project.
   ~
   ~ SPDX-License-Identifier: EPL-1.0
   ~
@@ -9,9 +9,43 @@
   ~ http://www.eclipse.org/legal/epl-v10.html
 --%>
 
+<portlet:resourceURL var="loadSpdxLicenseInfoUrl">
+    <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.LOAD_SPDX_LICENSE_INFO%>'/>
+</portlet:resourceURL>
+<portlet:resourceURL var="writeSpdxLicenseInfoIntoReleaseUrl">
+    <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.WRITE_SPDX_LICENSE_INFO_INTO_RELEASE%>'/>
+</portlet:resourceURL>
+
 <%@include file="/html/utils/includes/fossologyClearing.jspf"%>
 
 <core_rt:set var="clearingInfo" value="${release.clearingInformation}"/>
+
+<table class="table info_table" id="spdxAttachments"
+        data-load-spdx-license-info-url="<%=loadSpdxLicenseInfoUrl%>"
+        data-write-spdx-license-info-into-release-url="<%=writeSpdxLicenseInfoIntoReleaseUrl%>"
+        data-release-id-parameter-name="<%=PortalConstants.RELEASE_ID%>"
+        data-attachment-id-parameter-name="<%=PortalConstants.ATTACHMENT_ID%>"
+        data-spdx-license-info-parameter-name="<%=PortalConstants.SPDX_LICENSE_INFO%>">
+    <thead>
+        <tr>
+            <th colspan="3">SPDX Attachments</th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <core_rt:forEach items="${spdxAttachments}" var="spdxAttachment">
+            <tr id="${spdxAttachment.attachmentContentId}">
+                <td colspan="2">
+                    <sw360:out value="${spdxAttachment.filename}"/>
+                </td>
+                <td data-attachment-id="${spdxAttachment.attachmentContentId}">
+                    <button class="showSpdxContentBtn" data-release-id="${release.id}" data-attachment-id="${spdxAttachment.attachmentContentId}">Show License Info</button>
+                </td>
+            </tr>
+        </core_rt:forEach>
+    </tbody>
+</table>
+
 <table class="table info_table" id="ReleaseClearingOverview">
     <thead>
     <tr>
@@ -167,6 +201,115 @@
                 var data = $(event.currentTarget).data();
                 fossology.openSelectClearingDialog('fossologySending', data.releaseId);
             });
+
+            $('.showSpdxContentBtn').on('click', function(event) {
+                handleShowSpdxContentClick($(event.currentTarget));
+            });
+
+            function handleShowSpdxContentClick($btn) {
+                var tableData = $('#spdxAttachments').data(),
+                    rawUrl = tableData.loadSpdxLicenseInfoUrl,
+                    url = Liferay.PortletURL.createURL(rawUrl),
+                    btnData = $btn.data(),
+                    releaseId = btnData.releaseId,
+                    attachmentId = btnData.attachmentId,
+                    $row = $('#' + attachmentId),
+                    $btnCell = $row.find('td[data-attachment-id=' + attachmentId + ']');
+
+                url.setParameter(tableData.releaseIdParameterName, releaseId);
+                url.setParameter(tableData.attachmentIdParameterName, attachmentId);
+
+                replaceContentWithSpinner($btnCell);
+
+                $.ajax({
+                    type: 'GET',
+                    dataType: 'json',
+                    url: url.toString(),
+                }).done(function(result) {
+                    if (!result || result.length == 0 || Object.getOwnPropertyNames(result).length == 0) {
+                        replaceContentWithWarning($btnCell, 'No license information found in file.');
+                    } else {
+                        printResult($row, result);
+                        addTakeOverBtn($btnCell, releaseId, attachmentId, result);
+                    }
+                }).fail(function(error) {
+                    replaceContentWithError($btnCell, 'Cannot load license information: ' + error.statusText + ' (' + error.status + ').');
+                });
+            }
+
+            function printResult($sibbling, data) {
+                var $resultRow = $('<tr style="background-color: #f8f7f7;">');
+
+                $resultRow.append($('<td>'));
+                $resultRow.append($('<td>').append($('<span>', { text: 'Concluded License Ids'})));
+                $resultRow.append($('<td>').append($('<span>', { text: data.concludedLicenseIds.join(', ')})));
+
+                $sibbling.after($resultRow);
+            }
+
+            function addTakeOverBtn($parent, releaseId, attachmentId, data) {
+                var $newBtn = $('<button>', { 'class': 'spdxTakeOverBtn', 'data-release-id': releaseId, 'data-attachment-id': attachmentId, text: 'Add data to this release' });
+
+                $newBtn.data('result', data);
+                $parent.html('');
+                $parent.append($newBtn);
+
+                $newBtn.on('click', function(event) {
+                    handleTakeOverClick($(event.currentTarget));
+                });
+            }
+
+            function handleTakeOverClick($btn) {
+                var tableData = $('#spdxAttachments').data(),
+                    rawUrl = tableData.writeSpdxLicenseInfoIntoReleaseUrl,
+                    url = Liferay.PortletURL.createURL(rawUrl),
+                    btnData = $btn.data(),
+                    releaseId = btnData.releaseId,
+                    attachmentId = btnData.attachmentId,
+                    data = btnData.result,
+                    $row = $('#' + attachmentId),
+                    $btnCell = $row.find('td[data-attachment-id=' + attachmentId + ']'),
+                    dataObj = {};
+
+                url.setParameter(tableData.releaseIdParameterName, releaseId);
+                dataObj[ '<portlet:namespace/>' + tableData.spdxLicenseInfoParameterName ] = JSON.stringify(data);
+
+                replaceContentWithSpinner($btnCell);
+
+                $.ajax({
+                    type: 'POST',
+                    dataType: 'json',
+                    url: url.toString(),
+                    data: dataObj
+                }).done(function(result) {
+                    if (!result || result.length == 0 || result.result !== 'SUCCESS') {
+                        replaceContentWithError($btnCell, 'Could not write SPDX data into release: ' + result.result);
+                    } else {
+                        replaceContentWithSuccess($btnCell, 'Success! Please reload page to see the changes!');
+                    }
+                }).fail(function(error) {
+                    replaceContentWithError($btnCell, 'Could not write SPDX data into release: ' + error.statusText + ' (' + error.status + ').');
+                });
+            }
+
+            function replaceContentWithSuccess($parent, message) {
+                replaceContentWith($parent, 'backgroundOK', null, message);
+            }
+            function replaceContentWithWarning($parent, message) {
+                replaceContentWith($parent, 'backgroundWarning', null, message);
+            }
+            function replaceContentWithError($parent, message) {
+                replaceContentWith($parent, 'backgroundAlert', null, message);
+            }
+            function replaceContentWithSpinner($parent) {
+                replaceContentWith($parent, null, 'spinner', 'Loading SPDX file information. Please wait...');
+            }
+            function replaceContentWith($parent, parentStyleClass, styleClass, message) {
+                $parent.html('');
+                $parent.attr('class', parentStyleClass ? parentStyleClass : '');
+                $parent.append($('<div>', { 'class': styleClass ? styleClass : '' })
+                       .append($('<span>', { 'text': message })));
+            }
         });
 
     });

--- a/libraries/lib-datahandler/src/main/thrift/licenseinfo.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/licenseinfo.thrift
@@ -58,6 +58,7 @@ struct LicenseInfo {
     21: optional set<LicenseNameWithText> licenseNamesWithTexts,
     22: optional string sha1Hash,
     23: optional string componentName,
+    24: optional set<string> concludedLicenseIds,
 }
 
 struct LicenseInfoParsingResult {


### PR DESCRIPTION
* added additional infos to existing licenseinfo object (filled only from spdx parsers)
* added portlet methods to get an array of concluded license ids and to use this info as input for a release update
  * implemented in a way that can be extended if other information should be handled as well
* added some javascript handling in clearing details tab of releases to offer actions and show results
* added POST-redirect-GET pattern to release update to avoid duplicate release updates when triggering a reload because of the new functionality after coming from edit mode
* improved error message for not found licenses

closes eclipse/sw360#92

Signed-off-by: Andreas Klett <andreas.klett@scansation.de>