### PR TITLE
feat(rest): Whitelisting Fields in the REST API Response

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -34,7 +34,7 @@ import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityDTO;
 import org.eclipse.sw360.rest.resourceserver.core.serializer.JsonProjectRelationSerializer;
 import org.eclipse.sw360.rest.resourceserver.core.serializer.JsonReleaseRelationSerializer;
-
+import org.eclipse.sw360.rest.resourceserver.project.EmbeddedProject;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -62,6 +62,7 @@ class JacksonCustomizations {
             setMixInAnnotation(Vulnerability.class, Sw360Module.VulnerabilityMixin.class);
             setMixInAnnotation(VulnerabilityDTO.class, Sw360Module.VulnerabilityDTOMixin.class);
             setMixInAnnotation(EccInformation.class, Sw360Module.EccInformationMixin.class);
+            setMixInAnnotation(EmbeddedProject.class, Sw360Module.EmbeddedProjectMixin.class);
         }
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -153,9 +154,7 @@ class JacksonCustomizations {
                 "setOwnerAccountingUnit",
                 "setLicenseInfoHeaderText",
                 "setProjectOwner",
-                "enableSvm",
                 "setEnableSvm",
-                "enableVulnerabilitiesDisplay",
                 "setEnableVulnerabilitiesDisplay"
         })
         static abstract class ProjectMixin extends Project {
@@ -182,6 +181,15 @@ class JacksonCustomizations {
             @JsonProperty("id")
             abstract public String getId();
         }
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonIgnoreProperties({
+		"enableSvm",
+		"enableVulnerabilitiesDisplay"
+	})
+	static abstract class EmbeddedProjectMixin extends ProjectMixin {
+
+	}
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonIgnoreProperties({
@@ -236,7 +244,6 @@ class JacksonCustomizations {
                 "releases",
                 "mainLicenseIds",
                 "softwarePlatforms",
-                "homepage",
                 "mailinglist",
                 "wiki",
                 "blog",

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -23,6 +23,7 @@ import org.eclipse.sw360.rest.resourceserver.attachment.AttachmentController;
 import org.eclipse.sw360.rest.resourceserver.component.ComponentController;
 import org.eclipse.sw360.rest.resourceserver.license.LicenseController;
 import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
+import org.eclipse.sw360.rest.resourceserver.project.EmbeddedProject;
 import org.eclipse.sw360.rest.resourceserver.project.ProjectController;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.eclipse.sw360.rest.resourceserver.release.ReleaseController;
@@ -351,7 +352,8 @@ public class RestControllerHelper<T> {
     }
 
     public Project convertToEmbeddedProject(Project project) {
-        Project embeddedProject = new Project(project.getName());
+        Project embeddedProject = new EmbeddedProject();
+        embeddedProject.setName(project.getName());
         embeddedProject.setId(project.getId());
         embeddedProject.setProjectType(project.getProjectType());
         embeddedProject.setVersion(project.getVersion());

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/EmbeddedProject.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/EmbeddedProject.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.resourceserver.project;
+
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.springframework.hateoas.core.Relation;
+
+/**
+ * 
+ * This class is used for json customization for embedded project.
+ * 
+ * @author smruti.sahoo@siemens.com
+ *
+ */
+@Relation(collectionRelation = "sw360:projects")
+public class EmbeddedProject extends Project {
+
+	private static final long serialVersionUID = 1L;
+
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -107,6 +107,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
         angularComponent.setOperatingSystems(ImmutableSet.of("Windows", "Linux"));
         angularComponent.setAttachments(attachmentList);
         angularComponent.setExternalIds(Collections.singletonMap("component-id-key", "1831A3"));
+        angularComponent.setHomepage("https://angular.io");
         componentList.add(angularComponent);
         componentListByName.add(angularComponent);
 
@@ -304,6 +305,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("languages").description("The language of the component"),
                                 fieldWithPath("externalIds").description("When projects are imported from other tools, the external ids can be stored here"),
                                 fieldWithPath("operatingSystems").description("The OS on which the component operates"),
+                                fieldWithPath("homepage").description("The homepage url of the component"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
                                 fieldWithPath("_embedded.createdBy").description("The user who created this component"),
                                 fieldWithPath("_embedded.sw360:releases").description("An array of all component releases with version and link to their <<resources-releases,Releases resource>>"),
@@ -319,6 +321,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
         component.put("name", "Spring Framework");
         component.put("description", "The Spring Framework provides a comprehensive programming and configuration model for modern Java-based enterprise applications.");
         component.put("componentType", ComponentType.OSS.toString());
+        component.put("homepage", "https://angular.io");
 
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
         this.mockMvc.perform(
@@ -331,7 +334,8 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                         requestFields(
                                 fieldWithPath("name").description("The name of the component"),
                                 fieldWithPath("description").description("The component description"),
-                                fieldWithPath("componentType").description("The component type, possible values are: " + Arrays.asList(ComponentType.values()))
+                                fieldWithPath("componentType").description("The component type, possible values are: " + Arrays.asList(ComponentType.values())),
+                                fieldWithPath("homepage").description("The homepage url of the component")
                         ),
                         responseFields(
                                 fieldWithPath("name").description("The name of the component"),
@@ -442,6 +446,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("categories").description("The component categories"),
                                 fieldWithPath("languages").description("The language of the component"),
                                 fieldWithPath("operatingSystems").description("The OS on which the component operates"),
+                                fieldWithPath("homepage").description("The homepage url of the component"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
                                 fieldWithPath("_embedded.createdBy").description("The user who created this component"),
                                 fieldWithPath("_embedded.sw360:releases").description("An array of all component releases with version and link to their <<resources-releases,Releases resource>>"),

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -306,6 +306,8 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("linkedReleases").description("The relationship between linked releases of the project"),
                                 fieldWithPath("securityResponsibles").description("An array of users responsible for security of the project."),
                                 fieldWithPath("projectResponsible").description("A user who is responsible for the project."),
+                                fieldWithPath("enableSvm").description("Security vulnerability monitoring flag"),
+                                fieldWithPath("enableVulnerabilitiesDisplay").description("Displaying vulnerabilities flag."),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
                                 fieldWithPath("_embedded.createdBy").description("The user who created this project"),
                                 fieldWithPath("_embedded.sw360:projects").description("An array of <<resources-projects, Projects resources>>"),
@@ -490,6 +492,8 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("description").description("The project description"),
                                 fieldWithPath("projectType").description("The project type, possible values are: " + Arrays.asList(ProjectType.values())),
                                 fieldWithPath("securityResponsibles").description("An array of users responsible for security of the project."),
+                                fieldWithPath("enableSvm").description("Security vulnerability monitoring flag"),
+                                fieldWithPath("enableVulnerabilitiesDisplay").description("Displaying vulnerabilities flag."),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
                                 fieldWithPath("_embedded.createdBy").description("The user who created this project")
                         )));


### PR DESCRIPTION
* White listed "homepage" field at component level.
* White listed "enableSvm" and   "enableVulnerabilitiesDIsplay" at project level.

Signed-off-by: Smruti Sahoo <smruti.sahoo@siemens.com>

closes #487 , closes #516 