### PR TITLE
feat(spreadsheet): Added component categories field on spreadsheet export of Project with linked releases

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ComponentSummary.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ComponentSummary.java
@@ -70,6 +70,7 @@ public class ComponentSummary extends DocumentSummary<Component> {
         copyField(document, copy, Component._Fields.NAME);
         copyField(document, copy, Component._Fields.VENDOR_NAMES);
         copyField(document, copy, Component._Fields.COMPONENT_TYPE);
+        copyField(document, copy, Component._Fields.CATEGORIES);
 
         if (type == SummaryType.SUMMARY) {
             for (Component._Fields field : Component.metaDataMap.keySet()) {

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseExporter.java
@@ -109,6 +109,7 @@ public class ReleaseExporter extends ExcelExporter<Release, ReleaseHelper> {
             case COMPONENT_ID:
                 headers.add(displayNameFor(field.getFieldName(), nameToDisplayName));
                 headers.add(displayNameFor("component type", nameToDisplayName));
+                headers.add(displayNameFor("categories", nameToDisplayName));
                 break;
             case VENDOR:
                 Vendor.metaDataMap.keySet().stream()

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/helper/ReleaseHelper.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/helper/ReleaseHelper.java
@@ -117,7 +117,7 @@ public class ReleaseHelper implements ExporterHelper<Release> {
                 // second, add joined data, remark that headers have already been added
                 // accordingly
 
-                // add component type in every case
+                // add component type and categories in every case
                 Component component = this.preloadedComponents.get(release.componentId);
                 if (component == null) {
                     // maybe cache was not initialized properly, so try to load manually
@@ -132,8 +132,14 @@ public class ReleaseHelper implements ExporterHelper<Release> {
                 // check again and add value
                 if (component == null) {
                     row.add("");
+                    row.add("");
                 } else {
                     row.add(ThriftEnumUtils.enumToString(component.getComponentType()));
+                    if (component.getCategories() == null) {
+                        row.add("");
+                    } else {
+                        row.add(component.getCategories().toString());
+                    }
                 }
 
                 // project origin and project mainline state only if wanted


### PR DESCRIPTION
**Summary:** Added "Categories" field of component to spreadsheet export of "Project with linked releases".

**Steps to reproduce:**
1. Go to Projects tab and select "Projects with linked releases" from the drop own and click on "Export Spreadsheet".

**Result:**
1.Categories column should be present on the spreadsheet with value as corresponding component categories of the linked release to project.

closes : #530 
