### PR TITLE
test(REST): add documentation for Licenses in Releases

### DIFF
--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -20,6 +20,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultHandler;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,13 +52,13 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
     @Before
     public void before() throws TException {
         license = new License();
-        license.setId("apache20");
+        license.setId("Apache-2.0");
         license.setFullname("Apache License 2.0");
         license.setShortname("Apache 2.0");
         license.setText("placeholder for the Apache 2.0 license text");
 
         License license2 = new License();
-        license2.setId("mit");
+        license2.setId("MIT");
         license2.setFullname("The MIT License (MIT)");
         license2.setShortname("MIT");
         license2.setText("placeholder for the MIT license text");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -17,9 +17,11 @@ import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
+import org.eclipse.sw360.rest.resourceserver.license.Sw360LicenseService;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.junit.Before;
@@ -31,6 +33,8 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultHandler;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -66,6 +70,9 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
 
     @MockBean
     private Sw360AttachmentService attachmentServiceMock;
+
+    @MockBean
+    private Sw360LicenseService licenseServiceMock;
 
     private Release release;
     private Attachment attachment;
@@ -116,6 +123,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         release.setExternalIds(Collections.singletonMap("mainline-id-component", "1432"));
         release.setAttachments(attachmentList);
         release.setLanguages(new HashSet<>(Arrays.asList("C++", "Java")));
+        release.setMainLicenseIds(new HashSet<>(Arrays.asList("GPL-2.0-or-later", "Apache-2.0")));
         release.setOperatingSystems(ImmutableSet.of("Windows", "Linux"));
         releaseList.add(release);
 
@@ -158,6 +166,15 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                 new User("admin@sw360.org", "sw360").setId("123456789"));
         given(this.userServiceMock.getUserByEmail("jane@sw360.org")).willReturn(
                 new User("jane@sw360.org", "sw360").setId("209582812"));
+        given(this.licenseServiceMock.getLicenseById("Apache-2.0")).willReturn(
+                new License("Apache 2.0 License")
+                        .setText("Dummy License Text")
+                        .setShortname("Apache-2.0")
+                        .setId(UUID.randomUUID().toString()));
+        given(this.licenseServiceMock.getLicenseById("GPL-2.0-or-later")).willReturn(
+                new License("GNU General Public License 2.0").setText("GNU General Public License 2.0 Text")
+                        .setShortname("GPL-2.0-or-later")
+                        .setId(UUID.randomUUID().toString()));
     }
 
     @Test
@@ -226,6 +243,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("downloadurl").description("the download url of the release"),
                                 fieldWithPath("externalIds").description("When releases are imported from other tools, the external ids can be stored here"),
                                 fieldWithPath("languages").description("The language of the component"),
+                                fieldWithPath("_embedded.sw360:licenses").description("An array of all main licenses with their fullName and link to their <<resources-license-get,License resource>>"),
                                 fieldWithPath("operatingSystems").description("The OS on which the release operates"),
                                 fieldWithPath("_embedded.sw360:moderators").description("An array of all release moderators with email and link to their <<resources-user-get,User resource>>"),
                                 fieldWithPath("_embedded.sw360:attachments").description("An array of all release attachments and link to their <<resources-attachment-get,Attachment resource>>"),
@@ -280,6 +298,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("downloadurl").description("the download url of the release"),
                                 fieldWithPath("externalIds").description("When releases are imported from other tools, the external ids can be stored here"),
                                 fieldWithPath("languages").description("The language of the component"),
+                                fieldWithPath("_embedded.sw360:licenses").description("An array of all main licenses with their fullName and link to their <<resources-license-get,License resource>>"),
                                 fieldWithPath("operatingSystems").description("The OS on which the release operates"),
                                 fieldWithPath("_embedded.sw360:moderators").description("An array of all release moderators with email and link to their <<resources-user-get,User resource>>"),
                                 fieldWithPath("_embedded.sw360:attachments").description("An array of all release attachments and link to their <<resources-attachment-get,Attachment resource>>"),


### PR DESCRIPTION
I have also tried to add a test to upgrade the license list of a release to `ReleaseTest.java`, but for example the following has not worked for me and I do not know how to represent the information correctly in the test case
```diff
diff --git a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
index 7031999c..fcd9a498 100644
--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
@@ -103,6 +103,7 @@ public class ReleaseTest extends TestIntegrationBase {
         Map<String, String> body = new HashMap<>();
         body.put("name", updatedReleaseName);
         body.put("wrong_prop", "abc123");
+        body.put("mainLicenseIds", "[]");
         ResponseEntity<String> response =
                 new TestRestTemplate().exchange("http://localhost:" + port + "/api/releases/" + releaseId,
                         HttpMethod.PATCH,

```