### PR TITLE
feat(Projects): Added new field "domain" to project summary

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -31,6 +31,7 @@ public class PortalConstants {
 
     public static final String PROPERTIES_FILE_PATH = "/sw360.properties";
     public static final String PROGRAMMING_LANGUAGES;
+    public static final Set<String> DOMAIN;
     public static final String SOFTWARE_PLATFORMS;
     public static final String OPERATING_SYSTEMS;
     public static final Set<String> SET_CLEARING_TEAMS_STRING;
@@ -417,6 +418,7 @@ public class PortalConstants {
         Properties props = CommonUtils.loadProperties(PortalConstants.class, PROPERTIES_FILE_PATH);
 
         PROGRAMMING_LANGUAGES = props.getProperty("programming.languages", "[ \"ActionScript\", \"AppleScript\", \"Asp\",\"Bash\", \"BASIC\", \"C\", \"C++\", \"C#\", \"Cocoa\", \"Clojure\",\"COBOL\",\"ColdFusion\", \"D\", \"Delphi\", \"Erlang\", \"Fortran\", \"Go\", \"Groovy\",\"Haskell\", \"JSP\", \"Java\",\"JavaScript\", \"Objective-C\", \"Ocaml\",\"Lisp\", \"Perl\", \"PHP\", \"Python\", \"Ruby\", \"SQL\", \"SVG\",\"Scala\",\"SmallTalk\", \"Scheme\", \"Tcl\", \"XML\", \"Node.js\", \"JSON\" ]");
+        DOMAIN = CommonUtils.splitToSet(props.getProperty("domain", "Application Software, Documentation, Embedded Software, Hardware, Test and Diagnostics"));
         SOFTWARE_PLATFORMS = props.getProperty("software.platforms", "[ \"Adobe AIR\", \"Adobe Flash\", \"Adobe Shockwave\", \"Binary Runtime Environment for Wireless\", \"Cocoa (API)\", \"Cocoa Touch\", \"Java (software platform)|Java platform\", \"Java Platform, Micro Edition\", \"Java Platform, Standard Edition\", \"Java Platform, Enterprise Edition\", \"JavaFX\", \"JavaFX Mobile\", \"Microsoft XNA\", \"Mono (software)|Mono\", \"Mozilla Prism\", \".NET Framework\", \"Silverlight\", \"Open Web Platform\", \"Oracle Database\", \"Qt (framework)|Qt\", \"SAP NetWeaver\", \"Smartface\", \"Vexi\", \"Windows Runtime\" ]");
         OPERATING_SYSTEMS = props.getProperty("operating.systems", "[ \"Android\", \"BSD\", \"iOS\", \"Linux\", \"OS X\", \"QNX\", \"Microsoft Windows\", \"Windows Phone\", \"IBM z/OS\"]");
         SET_CLEARING_TEAMS_STRING = CommonUtils.splitToSet(props.getProperty("clearing.teams", "org1,org2,org3"));

--- a/frontend/sw360-portlet/src/main/resources/sw360.properties
+++ b/frontend/sw360-portlet/src/main/resources/sw360.properties
@@ -18,7 +18,7 @@
 
 ## values just used for UI, not forcing DB writes
 # operating.systems= [ "Android", "BSD", "iOS", "Linux", "Mac OS X", "QNX", "Microsoft Windows", "Windows Phone", "IBM z/OS"]
-
+#domain=  Application Software, Documentation, Embedded Software, Hardware, Test and Diagnostics
 ## values just used for UI, not forcing DB writes, should be in sync with fossology config
 # clearing.teams=org1,org2,org3
 

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/basicInfo.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/basicInfo.jspf
@@ -18,6 +18,7 @@
 
 <core_rt:set var="clearingTeamsStringSet" value='<%=PortalConstants.SET_CLEARING_TEAMS_STRING%>'/>
 <core_rt:set var="preferredCountryCodes" value='<%=PortalConstants.PREFERRED_COUNTRY_CODES%>'/>
+<core_rt:set var="domain" value='<%=PortalConstants.DOMAIN%>'/>
 
 <table class="table info_table" id="ProjectBasicInfo">
     <thead>
@@ -94,6 +95,29 @@
                       name="<portlet:namespace/><%=Project._Fields.DESCRIPTION%>" rows="4" cols="30"
                       style="width: 200px; height: 25px; resize:both;"
                       placeholder="Enter Description"><sw360:out value="${project.description}" stripNewlines="false"/></textarea>
+        </td>
+    </tr>
+    <tr>
+        <td width="33%">
+            <label class="textlabel stackedLabel" for="proj_domain">Domain</label>
+             <select class="toplabelledInput" id="domain" name="<portlet:namespace/><%=Project._Fields.DOMAIN%>" data-selected="${project.domain}"
+                style="min-width: 162px; min-height: 28px;">
+                <option value>-- Select Domain --</option>
+                <core_rt:forEach items="${domain}" var="entry">
+                    <c:choose>
+                        <c:when test="${entry eq project.domain}">
+                            <option selected="selected" value="<sw360:out value="${entry}"/>" class="textlabel stackedLabel"> ${entry} </option>
+                        </c:when>
+                        <c:otherwise>
+                            <option value="<sw360:out value="${entry}"/>" class="textlabel stackedLabel"> ${entry} </option>
+                        </c:otherwise>
+                    </c:choose>
+                </core_rt:forEach>
+            </select>
+        </td>
+        <td width="33%">
+        </td>
+        <td width="33%">
         </td>
     </tr>
     <tr>

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/summary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/summary.jspf
@@ -49,6 +49,10 @@
         <td><sw360:DisplayEnum value="${project.projectType}"/></td>
     </tr>
     <tr>
+        <td>Domain:</td>
+        <td><sw360:out value="${project.domain}"/></td>
+    </tr>
+    <tr>
         <td>Tag:</td>
         <td><sw360:out value="${project.tag}"/></td>
     </tr>

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -73,6 +73,7 @@ struct Project {
     4: required string name,
     5: optional string description,
     6: optional string version,
+    7: optional string domain,
 
     // information from external data sources
     9: optional map<string, string> externalIds,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
@@ -30,6 +30,7 @@ import org.springframework.hateoas.hal.CurieProvider;
 import org.springframework.hateoas.hal.DefaultCurieProvider;
 
 import java.util.Properties;
+import java.util.Set;
 
 @SpringBootApplication
 @Import(Sw360CORSFilter.class)
@@ -44,12 +45,15 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
     public static final String API_TOKEN_HASH_SALT;
     public static final String API_TOKEN_MAX_VALIDITY_READ_IN_DAYS;
     public static final String API_TOKEN_MAX_VALIDITY_WRITE_IN_DAYS;
+    public static final Set<String> DOMAIN;
 
     static {
         Properties props = CommonUtils.loadProperties(Sw360ResourceServer.class, PROPERTIES_FILE_PATH);
         API_TOKEN_MAX_VALIDITY_READ_IN_DAYS = props.getProperty("rest.apitoken.read.validity.days", "90");
         API_TOKEN_MAX_VALIDITY_WRITE_IN_DAYS = props.getProperty("rest.apitoken.write.validity.days", "30");
         API_TOKEN_HASH_SALT = props.getProperty("rest.apitoken.hash.salt", "$2a$04$Software360RestApiSalt");
+        DOMAIN = CommonUtils.splitToSet(props.getProperty("domain",
+                "Application Software, Documentation, Embedded Software, Hardware, Test and Diagnostics"));
     }
 
     @Bean

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -99,6 +99,7 @@ class JacksonCustomizations {
                 "setType",
                 "setName",
                 "setDescription",
+                "setDomain",
                 "setVersion",
                 "setExternalIds",
                 "setAttachments",

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -24,6 +24,7 @@ import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectType;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.Sw360ResourceServer;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
 import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.licenseinfo.Sw360LicenseInfoService;
@@ -118,6 +119,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         project.setProjectType(ProjectType.PRODUCT);
         project.setVersion("1.0.2");
         project.setDescription("Emerald Web provides a suite of components for Critical Infrastructures.");
+        project.setDomain("Hardware");
         project.setCreatedOn("2016-12-15");
         project.setCreatedBy("admin@sw360.org");
         project.setModerators(new HashSet<>(Arrays.asList("admin@sw360.org", "jane@sw360.org")));
@@ -155,6 +157,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         project2.setVersion("2.0.1");
         project2.setProjectType(ProjectType.PRODUCT);
         project2.setDescription("Orange Web provides a suite of components for documentation.");
+        project.setDomain("Hardware");
         project2.setCreatedOn("2016-12-17");
         project2.setCreatedBy("john@sw360.org");
         project2.setBusinessUnit("sw360 EX DF");
@@ -302,6 +305,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("createdOn").description("The date the project was created"),
                                 fieldWithPath("description").description("The project description"),
                                 fieldWithPath("projectType").description("The project type, possible values are: " + Arrays.asList(ProjectType.values())),
+                                fieldWithPath("domain").description("The domain, possible values are:"  + Sw360ResourceServer.DOMAIN.toString()),
                                 fieldWithPath("visibility").description("The project visibility, possible values are: " + Arrays.asList(Visibility.values())),
                                 fieldWithPath("businessUnit").description("The business unit this project belongs to"),
                                 fieldWithPath("externalIds").description("When projects are imported from other tools, the external ids can be stored here"),
@@ -547,6 +551,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                         fieldWithPath("version").description("The project version"),
                         fieldWithPath("createdOn").description("The date the project was created"),
                         fieldWithPath("description").description("The project description"),
+                        fieldWithPath("domain").description("The domain, possible values are:"  + Sw360ResourceServer.DOMAIN.toString()),
                         fieldWithPath("projectType").description("The project type, possible values are: "
                                 + Arrays.asList(ProjectType.values())),
                         fieldWithPath("visibility").description("The project visibility, possible values are: "


### PR DESCRIPTION
Summary:
Added new field "domain" to project summary
Field domain" will be a dropdown and the values will be fetched from sw360.properties file
Added rest api support for the field.
Added the field to rest api documentation

Steps to test:
-Create new project and look for a field with name "domain" under project summary.
-The field should of type dropdown and the values should be fetched from sw360.properties file.
-User should be able to select and save the field value.
-User should be able to add the field values by create project from rest end point.
-On entering invalid values rest end point should give error response. 

closes : #539 