### PR TITLE
feat(sso-oauth): added possibility to get oauth access tokens when pre authenticated

### DIFF
--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360AuthorizationServerConfiguration.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360AuthorizationServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2019. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -11,12 +11,20 @@
 
 package org.eclipse.sw360.rest.authserver.security;
 
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.rest.authserver.security.basicauth.Sw360LiferayAuthenticationProvider;
+import org.eclipse.sw360.rest.authserver.security.customheaderauth.Sw360CustomHeaderAuthenticationFilter;
+import org.eclipse.sw360.rest.authserver.security.customheaderauth.Sw360CustomHeaderAuthenticationProvider;
+import org.eclipse.sw360.rest.authserver.security.customheaderauth.Sw360CustomHeaderUserDetailsProvider;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.oauth2.config.annotation.configurers.ClientDetailsServiceConfigurer;
 import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerConfigurerAdapter;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
@@ -28,19 +36,35 @@ import org.springframework.security.oauth2.provider.token.store.JwtTokenStore;
 import org.springframework.security.oauth2.provider.token.store.KeyStoreKeyFactory;
 
 import javax.annotation.PostConstruct;
+import javax.servlet.Filter;
+
 import java.io.IOException;
 
-import static org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer.*;
+import static org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer.CONFIG_ACCESS_TOKEN_VALIDITY_SECONDS;
+import static org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer.CONFIG_CLIENT_ID;
+import static org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer.CONFIG_CLIENT_SECRET;
 import static org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority.BASIC;
 import static org.eclipse.sw360.rest.authserver.security.Sw360SecurityEncryptor.decrypt;
 
+/**
+ * This class configures the oauth2 authorization server specialities for the
+ * authorization parts of this server. Only exception is that the
+ * {@link AuthenticationManager} is shared with the standard security and this
+ * one is configured with our oauth2 {@link AuthenticationProvider}s in
+ * {@link Sw360WebSecurityConfiguration}.
+ */
 @Configuration
 @EnableAuthorizationServer
 public class Sw360AuthorizationServerConfiguration extends AuthorizationServerConfigurerAdapter {
-    private final AuthenticationManager authenticationManager;
 
     @Value("${security.oauth2.client.client-id}")
     private String clientId;
+
+    @Value("${security.oauth2.client.client-secret}")
+    private String clientSecret;
+
+    @Value("${security.oauth2.client.scope}")
+    private String[] scopes;
 
     @Value("${security.oauth2.client.authorized-grant-types}")
     private String[] authorizedGrantTypes;
@@ -48,19 +72,11 @@ public class Sw360AuthorizationServerConfiguration extends AuthorizationServerCo
     @Value("${security.oauth2.client.resource-ids}")
     private String resourceIds;
 
-    @Value("${security.oauth2.client.scope}")
-    private String[] scopes;
-
-    @Value("${security.oauth2.client.client-secret}")
-    private String clientSecret;
-
     @Value("${security.oauth2.client.access-token-validity-seconds}")
     private Integer accessTokenValiditySeconds;
 
     @Autowired
-    public Sw360AuthorizationServerConfiguration(AuthenticationManager authenticationManager) {
-        this.authenticationManager = authenticationManager;
-    }
+    private AuthenticationManager authenticationManager;
 
     @PostConstruct
     public void postSw360AuthorizationServerConfiguration() throws IOException {
@@ -78,6 +94,7 @@ public class Sw360AuthorizationServerConfiguration extends AuthorizationServerCo
     @Override
     public void configure(AuthorizationServerEndpointsConfigurer endpoints) throws Exception {
         endpoints
+                .allowedTokenEndpointRequestMethods(HttpMethod.GET, HttpMethod.POST)
                 .tokenStore(tokenStore())
                 .tokenEnhancer(jwtAccessTokenConverter())
                 .authenticationManager(authenticationManager);
@@ -87,7 +104,8 @@ public class Sw360AuthorizationServerConfiguration extends AuthorizationServerCo
     public void configure(AuthorizationServerSecurityConfigurer oauthServer) throws Exception {
         String serverAuthority = BASIC.getAuthority();
         oauthServer.tokenKeyAccess("isAnonymous() || hasAuthority('" + serverAuthority + "')")
-                .checkTokenAccess("hasAuthority('" + serverAuthority + "')");
+                .checkTokenAccess("hasAuthority('" + serverAuthority + "')")
+                .addTokenEndpointAuthenticationFilter(sw360CustomHeaderAuthenticationFilter());
     }
 
     @Override
@@ -114,5 +132,30 @@ public class Sw360AuthorizationServerConfiguration extends AuthorizationServerCo
         JwtAccessTokenConverter jwtAccessTokenConverter = new JwtAccessTokenConverter();
         jwtAccessTokenConverter.setKeyPair(keyStoreKeyFactory.getKeyPair("jwt"));
         return jwtAccessTokenConverter;
+    }
+
+    @Bean
+    protected Filter sw360CustomHeaderAuthenticationFilter() {
+        return new Sw360CustomHeaderAuthenticationFilter();
+    }
+
+    @Bean
+    protected Sw360LiferayAuthenticationProvider sw360LiferayAuthenticationProvider() {
+        return new Sw360LiferayAuthenticationProvider();
+    }
+
+    @Bean
+    protected Sw360CustomHeaderAuthenticationProvider sw360CustomHeaderAuthenticationProvider() {
+        return new Sw360CustomHeaderAuthenticationProvider();
+    }
+
+    @Bean
+    protected Sw360CustomHeaderUserDetailsProvider principalProvider() {
+        return new Sw360CustomHeaderUserDetailsProvider();
+    }
+
+    @Bean
+    protected ThriftClients thriftClients() {
+        return new ThriftClients();
     }
 }

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360WebSecurityConfiguration.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360WebSecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017, 2019. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -11,35 +11,68 @@
 
 package org.eclipse.sw360.rest.authserver.security;
 
+import org.eclipse.sw360.rest.authserver.security.basicauth.Sw360LiferayAuthenticationProvider;
+import org.eclipse.sw360.rest.authserver.security.customheaderauth.Sw360CustomHeaderAuthenticationProvider;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.AuthenticationManagerConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
+/**
+ * This class configures the standard spring security for this server. Only
+ * exception is that the {@link AuthenticationManager} is shared with the oauth2
+ * security and this one is configured with the oauth2
+ * {@link AuthenticationProvider}s from
+ * {@link Sw360AuthorizationServerConfiguration}.
+ */
 @Configuration
 @EnableWebSecurity
 public class Sw360WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
-    private final Sw360AuthenticationProvider sw360AuthenticationProvider;
+    @Autowired
+    private Sw360LiferayAuthenticationProvider sw360LiferayAuthenticationProvider;
 
-    public Sw360WebSecurityConfiguration(Sw360AuthenticationProvider sw360AuthenticationProvider) {
-        this.sw360AuthenticationProvider = sw360AuthenticationProvider;
-    }
-
-    @Override
-    protected void configure(AuthenticationManagerBuilder authenticationManagerBuilder) {
-        authenticationManagerBuilder.authenticationProvider(this.sw360AuthenticationProvider);
-    }
+    @Autowired
+    private Sw360CustomHeaderAuthenticationProvider sw360CustomHeaderAuthenticationProvider;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
                 .authorizeRequests()
-                .antMatchers(HttpMethod.OPTIONS).permitAll() // some JS frameworks make HTTP OPTIONS requests
-                .anyRequest().authenticated()
-                .and().httpBasic()
-                .and().csrf().disable();
+                .antMatchers(HttpMethod.OPTIONS)
+                    .permitAll() // some JS frameworks make HTTP OPTIONS requests
+                .anyRequest()
+                    .authenticated()
+                .and()
+                    .httpBasic()
+                .and()
+                    .csrf().disable();
     }
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder authenticationManagerBuilder) {
+        authenticationManagerBuilder
+                .authenticationProvider(sw360LiferayAuthenticationProvider)
+                .authenticationProvider(sw360CustomHeaderAuthenticationProvider);
+    }
+
+    /**
+     * We have to publish our configured authentication manager because otherwise
+     * some boot default manager will be populated from
+     * {@link AuthenticationManagerConfiguration}.
+     */
+    @Bean(name = "authenticationManager")
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
 }

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationFilter.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationFilter.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver.security.customheaderauth;
+
+import org.eclipse.sw360.datahandler.thrift.users.User;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.common.util.OAuth2Utils;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.TokenRequest;
+import org.springframework.security.oauth2.provider.password.ResourceOwnerPasswordTokenGranter;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+
+import java.io.IOException;
+
+/**
+ * Grant type 'password' for OAuth has an interesting implementation in spring
+ * security: The user for BasicAuth is the client with its secret. After that
+ * one has been authenticated via the ClientDetailsStore (currently inMemory,
+ * later from CouchDB), the method
+ * org.springframework.security.oauth2.provider.password.ResourceOwnerPasswordTokenGranter.getOAuth2Authentication(ClientDetails,
+ * TokenRequest) is exchanging the current {@link Authentication} object and
+ * setting a new one from the credentials given via request params "username"
+ * and "password". These credentials are validated again as well by an
+ * {@link AuthenticationManager} that can contain different
+ * {@link AuthenticationProvider}s.
+ *
+ * So what we are doing for our custom header flow is to retrieve the client
+ * information from request parameters and expect an already authenticated user
+ * id in a configurable header. We then create an {@link Authentication} object
+ * for the client and set the request params for the user from the header. In
+ * this way the standard oauth workflow can take place. We just need to add a
+ * {@link Sw360CustomHeaderAuthenticationProvider} that only uses the given
+ * username from the proxy and another custom request parameter to know that the
+ * user has already been authenticated and create the correct authentication
+ * object from these information.
+ *
+ * It is important that the authenticating webserver is removing all configured
+ * headers for this workflow that might already be set by a client (as usual).
+ * These are the ones given in the configuration file.
+ */
+public class Sw360CustomHeaderAuthenticationFilter extends GenericFilterBean {
+
+    private final Logger log = Logger.getLogger(this.getClass());
+
+    /**
+     * Has to match username extraction in
+     * {@link ResourceOwnerPasswordTokenGranter#getOAuth2Authentication(ClientDetails, TokenRequest)}
+     */
+    private static final String PARAMETER_NAME_USERNAME = "username";
+
+    /**
+     * Not available as constant in {@link OAuth2Utils}...
+     */
+    private static final String PARAMETER_NAME_CLIENT_SECRET = "client_secret";
+
+    @Value("${security.customheader.headername.email:#{null}}")
+    private String customHeaderHeadernameEmail;
+
+    @Value("${security.customheader.headername.extid:#{null}}")
+    private String customHeaderHeadernameExtid;
+
+    @Value("${security.customheader.headername.intermediateauthstore:#{null}}")
+    private String customHeaderHeadernameIntermediateAuthStore;
+
+    private boolean active;
+
+    @Autowired
+    private Sw360CustomHeaderUserDetailsProvider sw360CustomHeaderUserDetailsProvider;
+
+    @PostConstruct
+    public void postSw360CustomHeaderAuthenticationFilterConstruction() {
+        if (StringUtils.isEmpty(customHeaderHeadernameEmail) || StringUtils.isEmpty(customHeaderHeadernameExtid)
+                || StringUtils.isEmpty(customHeaderHeadernameIntermediateAuthStore)) {
+            log.warn("Filter is NOT active! Some configuration is missing. Needed config keys:\n"
+                    + "- security.customheader.headername.email\n"
+                    + "- security.customheader.headername.extid\n"
+                    + "- security.customheader.headername.intermediateauthstore");
+            active = false;
+        } else {
+            log.info("Filter is active!");
+            active = true;
+        }
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        if (active) {
+            CustomHeaderAuthRequestDetails requestDetails = extractRequestDetails((HttpServletRequest) request);
+            if (canAuthenticate(requestDetails)) {
+
+                ServletRequest wrappedRequest = doAuthenticate((HttpServletRequest) request, requestDetails);
+                if (wrappedRequest != null) {
+                    chain.doFilter(wrappedRequest, response);
+                    return;
+                }
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private CustomHeaderAuthRequestDetails extractRequestDetails(HttpServletRequest request) {
+        CustomHeaderAuthRequestDetails result = new CustomHeaderAuthRequestDetails();
+
+        result.currentUser = SecurityContextHolder.getContext().getAuthentication();
+        result.customHeaderEmail = StringUtils.defaultIfEmpty(request.getHeader(customHeaderHeadernameEmail), "");
+        result.customHeaderExtId = StringUtils.defaultIfEmpty(request.getHeader(customHeaderHeadernameExtid), "");
+        result.customParamClientId = request.getParameter(OAuth2Utils.CLIENT_ID);
+        result.customParamClientSecret = request.getParameter(PARAMETER_NAME_CLIENT_SECRET);
+        result.grantType = request.getParameter(OAuth2Utils.GRANT_TYPE);
+
+        return result;
+    }
+
+    private boolean canAuthenticate(CustomHeaderAuthRequestDetails requestDetails) {
+        // we want to be active only for grant type 'password' requests
+        if (!requestDetails.grantType.equals("password")) {
+            log.debug("Cannot create authentication object because grant type is not password!");
+            return false;
+        }
+
+        // if there is already authentication information available, do nothing
+        if (requestDetails.currentUser != null) {
+            log.debug("Cannot create authentication object because there is already one!");
+            return false;
+        }
+
+        // without any auth header, this authentication makes no sense
+        if (StringUtils.isEmpty(requestDetails.customHeaderEmail)
+                && StringUtils.isEmpty(requestDetails.customHeaderExtId)) {
+            log.debug("Cannot create authentication object because user identifying headers from proxy are missing!");
+            return false;
+        }
+
+        // without client info, this authentication makes no sense
+        if (StringUtils.isEmpty(requestDetails.customParamClientId)
+                || StringUtils.isEmpty(requestDetails.customParamClientSecret)) {
+            log.debug("Cannot create authentication object because client identifying request parameters are missing!");
+            return false;
+        }
+
+        return true;
+    }
+
+    private ServletRequest doAuthenticate(HttpServletRequest request, CustomHeaderAuthRequestDetails requestDetails) {
+        Sw360CustomHeaderServletRequestWrapper requestResult = null;
+        Authentication authResult = null;
+
+        User userDetails = sw360CustomHeaderUserDetailsProvider.provideUserDetails(requestDetails.customHeaderEmail, requestDetails.customHeaderExtId);
+        if (userDetails != null) {
+
+            // first create our request wrapper to be able to add params
+            requestResult = new Sw360CustomHeaderServletRequestWrapper(request);
+            requestResult.addParameter(PARAMETER_NAME_USERNAME, new String[] { userDetails.getEmail() });
+            requestResult.addParameter(customHeaderHeadernameIntermediateAuthStore,
+                    new String[] { userDetails.getExternalid() });
+
+            // then create authentication and add to security context
+            authResult = new UsernamePasswordAuthenticationToken(requestDetails.customParamClientId,
+                    requestDetails.customParamClientSecret);
+            SecurityContextHolder.getContext().setAuthentication(authResult);
+
+            log.debug("Created authentication object for client " + requestDetails.customParamClientId
+                    + " and added username " + userDetails.getEmail()
+                    + " as pre authenticated user to the request parameters.");
+        }
+
+        return requestResult;
+    }
+
+    private static class CustomHeaderAuthRequestDetails {
+        public Authentication currentUser;
+        public String customHeaderEmail;
+        public String customHeaderExtId;
+        public String customParamClientId;
+        public String customParamClientSecret;
+        public String grantType;
+    }
+}

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationProvider.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationProvider.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver.security.customheaderauth;
+
+import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer;
+import org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.common.util.OAuth2Utils;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.ClientDetailsService;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+import javax.annotation.PostConstruct;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * This {@link AuthenticationProvider} is specialised on requests where the
+ * {@link Sw360CustomHeaderAuthenticationFilter} made sure that the user has
+ * already been authenticated by some external proxy that set some headers to
+ * let us know about the authentication.
+ *
+ * In addition it is special because it calculates the granted authorities for
+ * the user depending on the user's authorities given by his groups and the
+ * client's scopes. The result will be the intersection between these two lists.
+ */
+public class Sw360CustomHeaderAuthenticationProvider implements AuthenticationProvider {
+
+    private final Logger log = Logger.getLogger(this.getClass());
+
+    @Value("${security.customheader.headername.intermediateauthstore:#{null}}")
+    private String customHeaderHeadernameIntermediateAuthStore;
+
+    private boolean active;
+
+    @Autowired
+    private Sw360CustomHeaderUserDetailsProvider sw360CustomHeaderUserDetailsProvider;
+
+    @Autowired
+    private ClientDetailsService clientDetailsService;
+
+    @PostConstruct
+    public void postSw360CustomHeaderAuthenticationProviderConstruction() {
+        if (StringUtils.isEmpty(customHeaderHeadernameIntermediateAuthStore)) {
+            log.warn("AuthenticationProvider is NOT active! Some configuration is missing. Needed config keys:\n"
+                    + "- security.customheader.headername.intermediateauthstore");
+            active = false;
+        } else {
+            log.info("AuthenticationProvider is active!");
+            active = true;
+        }
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        // check if the marker header of our filter is available
+        if (authentication.getDetails() instanceof Map<?, ?>
+                && ((Map<?, ?>) authentication.getDetails()).containsKey(customHeaderHeadernameIntermediateAuthStore)) {
+            Map<?, ?> authDetails = ((Map<?, ?>) authentication.getDetails());
+
+            // get user details
+            String email = (String) authentication.getPrincipal();
+            String externalId = (String) authDetails.get(customHeaderHeadernameIntermediateAuthStore);
+            User userDetails = sw360CustomHeaderUserDetailsProvider.provideUserDetails(email, externalId);
+
+            // calculate user authorities
+            List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+            grantedAuthorities.add(new SimpleGrantedAuthority(Sw360GrantedAuthority.READ.getAuthority()));
+            if (userDetails != null && PermissionUtils
+                    .isUserAtLeast(Sw360AuthorizationServer.CONFIG_WRITE_ACCESS_USERGROUP, userDetails)) {
+                grantedAuthorities.add(new SimpleGrantedAuthority(Sw360GrantedAuthority.WRITE.getAuthority()));
+            }
+
+            // keep only intersection of user authorities and client scopes
+            String clientId = (String) authDetails.get(OAuth2Utils.CLIENT_ID);
+            ClientDetails clientDetails = clientDetailsService.loadClientByClientId(clientId);
+            Set<String> clientScopes = clientDetails.getScope();
+
+            log.debug("User " + email + " has authorities " + grantedAuthorities + " while used client " + clientId
+                    + " has scopes " + clientScopes
+                    + ". Setting intersection as granted authorities for access token!");
+
+            grantedAuthorities = grantedAuthorities.stream().map(GrantedAuthority::toString)
+                    .filter(gas -> clientScopes.contains(gas))
+                    .map(gas -> Sw360GrantedAuthority.valueOf(gas)).collect(Collectors.toList());
+
+            return new PreAuthenticatedAuthenticationToken(email, "N/A", grantedAuthorities);
+        }
+        return null;
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return active && authentication.equals(UsernamePasswordAuthenticationToken.class);
+    }
+
+}

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderServletRequestWrapper.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderServletRequestWrapper.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver.security.customheaderauth;
+
+import org.apache.log4j.Logger;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.savedrequest.Enumerator;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This {@link HttpServletRequestWrapper} is able to extend the parameter list
+ * of the wrapped request object (which is not possible on standard
+ * {@link HttpServletRequest}s because normally one wants to have exactly the
+ * request params as they are coming from the client / proxy). This is necessary
+ * because we want to be part of the standard oauth 2 workflow of spring with
+ * our custom header pre authentication chain. And in this workflow we need to
+ * pass additional information to our
+ * {@link Sw360CustomHeaderAuthenticationProvider} from our
+ * {@link Sw360CustomHeaderAuthenticationFilter} which is only possible via
+ * request params that are added by the standard flow to the authentication
+ * details in {@link Authentication#getDetails()}.
+ */
+public class Sw360CustomHeaderServletRequestWrapper extends HttpServletRequestWrapper {
+
+    private final Logger log = Logger.getLogger(this.getClass());
+
+    private final Map<String, String[]> addableParameterMap;
+
+    public Sw360CustomHeaderServletRequestWrapper(HttpServletRequest request) {
+        super(request);
+
+        addableParameterMap = new HashMap<String, String[]>(request.getParameterMap());
+    }
+
+    public void addParameter(String name, String[] values) {
+        log.debug("Added parameter with key " + name + " to parameter map of request " + getRequest());
+
+        addableParameterMap.put(name, values);
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        return addableParameterMap;
+    }
+
+    @Override
+    public Enumeration<String> getParameterNames() {
+        return new Enumerator<>(addableParameterMap.keySet());
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        return addableParameterMap.get(name);
+    }
+
+    @Override
+    public String getParameter(String name) {
+        String result = null;
+        String[] allValues = addableParameterMap.get(name);
+
+        if (allValues != null && allValues.length > 0) {
+            result = allValues[0];
+        }
+
+        return result;
+    }
+
+}

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderUserDetailsProvider.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderUserDetailsProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver.security.customheaderauth;
+
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserService;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * This user details provider is able to query the sw360 user thrift service to
+ * check if a user identified by an email address or an external id exists.
+ */
+public class Sw360CustomHeaderUserDetailsProvider {
+
+    private final Logger log = Logger.getLogger(this.getClass());
+
+    @Autowired
+    private ThriftClients thriftClients;
+
+    public User provideUserDetails(String email, String extId) {
+        User result = null;
+
+        log.debug("Looking up user with email <" + email + "> and external id <" + extId + ">.");
+
+        User user = getUserByEmailOrExternalId(email, extId);
+        if (user != null) {
+            log.debug("Found user with email <" + email + "> and external id <" + extId + "> in UserService.");
+            result = user;
+        } else {
+            log.warn("No user found with email <" + email + "> and external id <" + extId + "> in UserService.");
+        }
+
+        return result;
+    }
+
+    private User getUserByEmailOrExternalId(String email, String externalId) {
+        // client should be put into threadlocal some day after this pattern proofed
+        // itself
+        UserService.Iface client = thriftClients.makeUserClient();
+        try {
+            if (StringUtils.isNotEmpty(email) || StringUtils.isNotEmpty(externalId)) {
+                return client.getByEmailOrExternalId(email, externalId);
+            }
+        } catch (TException e) {
+            // do nothing
+        }
+        return null;
+    }
+}

--- a/rest/authorization-server/src/main/resources/application-dev.yml
+++ b/rest/authorization-server/src/main/resources/application-dev.yml
@@ -8,5 +8,10 @@
 #
 
 sw360:
-  test-user-id: admin@sw360.org
+  test-user-id: mockedserviceuser@sw360.org
   test-user-password: sw360-admin-password
+
+security:
+  oauth2:
+    client:
+      scope: READ

--- a/rest/authorization-server/src/main/resources/application.yml
+++ b/rest/authorization-server/src/main/resources/application.yml
@@ -17,13 +17,22 @@ sw360:
     allowed-origin: ${SW360_CORS_ALLOWED_ORIGIN:#{null}}
 
 security:
+  customheader:
+    headername:
+      # Attention: please make sure that the proxy is removing there headers
+      # if they are coming from anywhere else then the authentication server
+      intermediateauthstore: custom-header-auth-marker
+      email: authenticated-email
+      extid: authenticated-extid
+      # also available - at least in saml pre auth - are "givenname", "surname" and "department"
+
   oauth2:
     resource:
       id: sw360-REST-API
     client:
       client-id: trusted-sw360-client
       client-secret: sw360-secret
+      scope: BASIC, READ, WRITE
       resource-ids: sw360-REST-API
       authorized-grant-types: client_credentials,password
       access-token-validity-seconds: 3600
-      scope: all

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsBasicAuthTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsBasicAuthTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver;
+
+import org.junit.Before;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+
+import java.io.IOException;
+
+/**
+ * A POST request for an access token with grant type 'client_credentials' and
+ * basic auth should be possible.
+ */
+public class GrantTypeClientCredentialsBasicAuthTest extends GrantTypeClientCredentialsTestBase {
+
+    @Before
+    public void before() throws IOException {
+        String url = "http://localhost:" + String.valueOf(port) + "/oauth/token?grant_type=" + PARAMETER_GRANT_TYPE
+                + "&client_id=" + clientId;
+
+        responseEntity = new TestRestTemplate(clientId, clientSecret).postForEntity(url, null, String.class);
+    }
+}

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsCustomHeaderAuthTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsCustomHeaderAuthTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver;
+
+import org.junit.Test;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * A POST request for an access token with grant type 'client_credentials' and
+ * custom auth header should NOT be possible.
+ */
+public class GrantTypeClientCredentialsCustomHeaderAuthTest extends IntegrationTestBase {
+
+    @Test
+    public void should_not_login_with_custom_header() throws IOException {
+        String url = "http://localhost:" + String.valueOf(port)
+                + "/oauth/token?grant_type=client_credentials&client_id=" + clientId + "&client_secret=" + clientSecret;
+
+        // since we do not have a proxy that sets the header during test, we set it
+        // already on client-side
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("authenticated-email", testUser.email);
+
+        responseEntity = new TestRestTemplate().postForEntity(url, new HttpEntity<>(headers), String.class);
+
+        assertThat(responseEntity.getStatusCode(), is(HttpStatus.UNAUTHORIZED));
+    }
+
+}

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsTestBase.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017, 2019. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -11,12 +11,8 @@
 
 package org.eclipse.sw360.rest.authserver;
 
-
-import org.junit.Before;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 
 import java.io.IOException;
 
@@ -24,33 +20,22 @@ import static org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority.B
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class ClientCredentialsGrantTest extends IntegrationTestBase {
+public abstract class GrantTypeClientCredentialsTestBase extends IntegrationTestBase {
 
-    private ResponseEntity<String> responseEntity;
-
-    private final String PARAMETER_GRANT_TYPE = "client_credentials";
-
-    @Value("${security.oauth2.client.client-id}")
-    private String clientId;
-
-    @Before
-    public void before() throws IOException {
-        String parameters = "client_id=%s&grant_type=%s";
-        responseEntity = getTokenWithParameters(String.format(parameters, clientId, PARAMETER_GRANT_TYPE));
-    }
+    protected final String PARAMETER_GRANT_TYPE = "client_credentials";
 
     @Test
     public void should_connect_to_authorization_server_with_client_credentials() {
-        assertThat(HttpStatus.OK, is(responseEntity.getStatusCode()));
+        assertThat(responseEntity.getStatusCode(), is(HttpStatus.OK));
     }
 
     @Test
     public void should_get_expected_response_headers() throws IOException {
-        checkResponseBody(responseEntity);
+        checkResponseBody();
     }
 
     @Test
     public void should_get_expected_jwt_attributes() throws IOException {
-        checkJwtClaims(responseEntity, BASIC.getAuthority());
+        checkJwtClaims(BASIC.getAuthority());
     }
 }

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordBasicAuthTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordBasicAuthTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver;
+
+import org.junit.Before;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+
+import java.io.IOException;
+
+/**
+ * A POST request for an access token with grant type 'password' and basic auth
+ * should be possible.
+ */
+public class GrantTypePasswordBasicAuthTest extends GrantTypePasswordTestBase {
+
+    @Value("${sw360.test-user-id}")
+    protected String testUserId;
+
+    @Value("${sw360.test-user-password}")
+    protected String testUserPassword;
+
+    @Before
+    public void before() throws IOException {
+        String url = "http://localhost:" + String.valueOf(port) + "/oauth/token?grant_type=" + PARAMETER_GRANT_TYPE
+                + "&username=" + testUserId + "&password=" + testUserPassword;
+
+        responseEntity = new TestRestTemplate(clientId, clientSecret).postForEntity(url, null, String.class);
+    }
+
+}

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordCustomHeaderGetTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordCustomHeaderGetTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver;
+
+import org.junit.Before;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+
+import java.io.IOException;
+
+/**
+ * A GET request for an access token with grant type 'password' and custom auth
+ * header should be possible.
+ */
+public class GrantTypePasswordCustomHeaderGetTest extends GrantTypePasswordTestBase {
+
+    @Before
+    public void before() throws IOException {
+        String url = "http://localhost:" + String.valueOf(port) + "/oauth/token?grant_type=" + PARAMETER_GRANT_TYPE
+                + "&client_id=" + clientId + "&client_secret=" + clientSecret;
+
+        // since we do not have a proxy that sets the header during test, we set it
+        // already on client-side
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("authenticated-email", testUser.email);
+
+        responseEntity = new TestRestTemplate().exchange(url, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+    }
+}

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordCustomHeaderPostTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordCustomHeaderPostTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver;
+
+import org.junit.Before;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+
+import java.io.IOException;
+
+/**
+ * A POST request for an access token with grant type 'password' and custom auth
+ * header should be possible.
+ */
+public class GrantTypePasswordCustomHeaderPostTest extends GrantTypePasswordTestBase {
+
+    @Before
+    public void before() throws IOException {
+        String url = "http://localhost:" + String.valueOf(port) + "/oauth/token?grant_type=" + PARAMETER_GRANT_TYPE
+                + "&client_id=" + clientId + "&client_secret=" + clientSecret;
+
+        // since we do not have a proxy that sets the header during test, we set it
+        // already on client-side
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("authenticated-email", testUser.email);
+
+        responseEntity = new TestRestTemplate().postForEntity(url, new HttpEntity<>(headers), String.class);
+    }
+}

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordTestBase.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017, 2019. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -12,11 +12,9 @@
 package org.eclipse.sw360.rest.authserver;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.junit.Before;
+
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 
 import java.io.IOException;
 
@@ -24,24 +22,9 @@ import static org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority.R
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class ResourceOwnerCredentialsGrantTest extends IntegrationTestBase {
+public abstract class GrantTypePasswordTestBase extends IntegrationTestBase {
 
-    @Value("${local.server.port}")
-    private int port;
-
-    @Value("${sw360.test-user-id}")
-    private String testUserId;
-
-    @Value("${sw360.test-user-password}")
-    private String testUserPassword;
-
-    private ResponseEntity<String> responseEntity;
-
-    @Before
-    public void before() throws IOException {
-        String parameters = "grant_type=password&username=%s&password=%s";
-        responseEntity = getTokenWithParameters(String.format(parameters, testUserId, testUserPassword));
-    }
+    protected final String PARAMETER_GRANT_TYPE = "password";
 
     @Test
     public void should_connect_to_authorization_server_with_resource_owner_credentials() {
@@ -50,12 +33,12 @@ public class ResourceOwnerCredentialsGrantTest extends IntegrationTestBase {
 
     @Test
     public void should_get_expected_response_headers() throws IOException {
-        checkResponseBody(responseEntity);
+        checkResponseBody();
     }
 
     @Test
     public void should_get_expected_jwt_attributes() throws IOException {
-        JsonNode jwtClaimsJsonNode = checkJwtClaims(responseEntity, READ.getAuthority());
-        assertThat(jwtClaimsJsonNode.get("user_name").asText(), is(testUserId));
+        JsonNode jwtClaimsJsonNode = checkJwtClaims(READ.getAuthority());
+        assertThat(jwtClaimsJsonNode.get("user_name").asText(), is(testUser.email));
     }
 }

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/IntegrationTestBase.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/IntegrationTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017, 2019. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -13,64 +13,108 @@ package org.eclipse.sw360.rest.authserver;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.eclipse.sw360.datahandler.thrift.users.UserService;
+import org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority;
+
+import org.apache.thrift.TException;
+import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.jwt.Jwt;
 import org.springframework.security.jwt.JwtHelper;
+import org.springframework.security.web.FilterChainProxy;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer.CONFIG_CLIENT_ID;
 import static org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer.CONFIG_CLIENT_SECRET;
 import static org.eclipse.sw360.rest.authserver.security.Sw360SecurityEncryptor.decrypt;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Sw360AuthorizationServer.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles({"dev"})
-abstract public class IntegrationTestBase {
+public abstract class IntegrationTestBase {
 
     @Value("${local.server.port}")
     protected int port;
 
     @Value("${security.oauth2.client.client-id}")
-    private String clientId;
+    protected String clientId;
 
     @Value("${security.oauth2.client.client-secret}")
-    private String clientSecret;
+    protected String clientSecret;
 
-    protected ResponseEntity<String> getTokenWithParameters(String parameters) throws IOException {
-        String url = "http://localhost:" + port + "/oauth/token?" + parameters;
-        clientId = CONFIG_CLIENT_ID != null ? CONFIG_CLIENT_ID : clientId;
-        clientSecret = CONFIG_CLIENT_SECRET != null ? decrypt(CONFIG_CLIENT_SECRET) : clientSecret;
-        return new TestRestTemplate(clientId, clientSecret).postForEntity(url, null, String.class);
+    @Autowired
+    protected FilterChainProxy springSecurityFilterChain;
+
+    @MockBean
+    protected ThriftClients thriftClients;
+
+    protected User testUser;
+
+    protected ResponseEntity<String> responseEntity;
+
+    protected String getClientId() {
+        return CONFIG_CLIENT_ID != null ? CONFIG_CLIENT_ID : clientId;
     }
 
-    protected void checkResponseBody(ResponseEntity<String> responseEntity) throws IOException {
+    protected String getClientSecret() throws IOException {
+        return CONFIG_CLIENT_SECRET != null ? decrypt(CONFIG_CLIENT_SECRET) : clientSecret;
+    }
+
+    @Before
+    public void setup() throws TException {
+        testUser = new User("mockedserviceuser@sw360.org", "qa");
+        testUser.externalid = "service-mocked-by-mockito";
+        testUser.fullname = "Mocked Service User";
+        testUser.givenname = "Mocked";
+        testUser.lastname = "Service User";
+        testUser.userGroup = UserGroup.ADMIN;
+
+        UserService.Client mockedUserService = mock(UserService.Client.class);
+        when(mockedUserService.getByEmailOrExternalId(eq(testUser.email), anyString())).thenReturn(testUser);
+
+        when(thriftClients.makeUserClient()).thenReturn(mockedUserService);
+    }
+
+    protected void checkResponseBody() throws IOException {
         String responseBody = responseEntity.getBody();
 
-        assertThat(HttpStatus.OK, is(responseEntity.getStatusCode()));
+        assertThat(responseEntity.getStatusCode(), is(HttpStatus.OK));
 
         JsonNode responseBodyJsonNode = new ObjectMapper().readTree(responseBody);
 
         assertThat(responseBodyJsonNode.get("token_type").asText(), is("bearer"));
-        assertThat(responseBodyJsonNode.get("scope").asText(), is("all"));
+        assertThat(responseBodyJsonNode.get("scope").asText(), is(Sw360GrantedAuthority.READ.toString()));
         assertThat(responseBodyJsonNode.has("access_token"), is(true));
         assertThat(responseBodyJsonNode.has("expires_in"), is(true));
         assertThat(responseBodyJsonNode.has("jti"), is(true));
     }
 
-    protected JsonNode checkJwtClaims(ResponseEntity<String> responseEntity, String expectedAuthority) throws IOException {
+    protected JsonNode checkJwtClaims(String... expectedAuthority) throws IOException {
         String responseBody = responseEntity.getBody();
 
-        assertThat(HttpStatus.OK, is(responseEntity.getStatusCode()));
+        assertThat(responseEntity.getStatusCode(), is(HttpStatus.OK));
 
         JsonNode responseBodyJsonNode = new ObjectMapper().readTree(responseBody);
         assertThat(responseBodyJsonNode.has("access_token"), is(true));
@@ -82,12 +126,27 @@ abstract public class IntegrationTestBase {
         assertThat(jwtClaimsJsonNode.get("aud").get(0).asText(), is("sw360-REST-API"));
         assertThat(jwtClaimsJsonNode.get("client_id").asText(), is("trusted-sw360-client"));
 
-        JsonNode scopeNode = jwtClaimsJsonNode.get("scope");
-        assertThat(scopeNode.get(0).asText(), is("all"));
-        assertThat(scopeNode.size(), is(1));
+        JsonNode scopesNode = jwtClaimsJsonNode.get("scope");
+        List<String> actualScopes = new ArrayList<>();
+        if (scopesNode.isArray()) {
+            for (final JsonNode scopeNode : scopesNode) {
+                actualScopes.add(scopeNode.asText());
+            }
+        } else {
+            actualScopes.add(scopesNode.asText());
+        }
+        assertThat(actualScopes, containsInAnyOrder(Sw360GrantedAuthority.READ.toString()));
 
         JsonNode authoritiesJsonNode = jwtClaimsJsonNode.get("authorities");
-        assertThat(authoritiesJsonNode.get(0).asText(), is(expectedAuthority));
+        List<String> actualAuthorities = new ArrayList<>();
+        if (authoritiesJsonNode.isArray()) {
+            for (final JsonNode authorityTextNode : authoritiesJsonNode) {
+                actualAuthorities.add(authorityTextNode.asText());
+            }
+        } else {
+            actualAuthorities.add(authoritiesJsonNode.asText());
+        }
+        assertThat(actualAuthorities, containsInAnyOrder(expectedAuthority));
 
         return jwtClaimsJsonNode;
     }


### PR DESCRIPTION
* added a Filter that checks pre authentication headers and manipulates the request so that it can be processed by standard spring oauth mechanics
* added a AuthenticationProvider that is able to state for such a manipulated request that the user has been authenticated
* added some configuration to wire it all together
* added some tooling for this to work
* added some tests and documentation

closes eclipse/sw360#542

Signed-off-by: Andreas Klett <andreas.klett@scansation.de>