### PR TITLE
feat(Projects): enabled Project/Release mainline state change only for clearing admins

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/common/utils/BackendUtils.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/common/utils/BackendUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.common.utils;
+
+import java.util.Properties;
+
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+
+public class BackendUtils {
+
+    private static final String PROPERTIES_FILE_PATH = "/sw360.properties";
+    protected static final Properties loadedProperties;
+    public static final Boolean MAINLINE_STATE_ENABLED_FOR_USER;
+
+    static {
+        loadedProperties = CommonUtils.loadProperties(BackendUtils.class, PROPERTIES_FILE_PATH);
+        MAINLINE_STATE_ENABLED_FOR_USER = Boolean.parseBoolean(loadedProperties.getProperty("mainline.state.enabled.for.user", "true"));
+    }
+
+    protected BackendUtils() {
+        // Utility class with only static functions
+    }
+}

--- a/backend/src-common/src/main/java/org/eclipse/sw360/mail/MailUtil.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/mail/MailUtil.java
@@ -13,6 +13,7 @@ package org.eclipse.sw360.mail;
 import com.google.common.collect.Sets;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.common.utils.BackendUtils;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
@@ -36,7 +37,7 @@ import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
  *
  * @author birgit.heydenreich@tngtech.com
  */
-public class MailUtil {
+public class MailUtil extends BackendUtils {
 
     private static final Logger log = Logger.getLogger(MailUtil.class);
 
@@ -45,7 +46,6 @@ public class MailUtil {
     private static final int MAIL_ASYNC_SEND_QUEUE_LIMIT = 1000;
 
     private static ExecutorService mailExecutor;
-    private Properties loadedProperties;
     private Session session;
 
     private String from;
@@ -60,7 +60,6 @@ public class MailUtil {
     private String supportMailAddress;
 
     public MailUtil() {
-        loadedProperties = CommonUtils.loadProperties(MailUtil.class, MailConstants.MAIL_PROPERTIES_FILE_PATH);
         mailExecutor = fixedThreadPoolWithQueueSize(MAIL_ASYNC_SEND_THREAD_LIMIT, MAIL_ASYNC_SEND_QUEUE_LIMIT);
         setBasicProperties();
         setSession();

--- a/backend/src-common/src/main/resources/sw360.properties
+++ b/backend/src-common/src/main/resources/sw360.properties
@@ -10,6 +10,7 @@
 backend.url= http://localhost:8080
 
 licenseinfo.spdxparser.use-license-info-from-files=true
+mainline.state.enabled.for.user=false
 
 # settings for the mail utility:
 # if host is not set, e-mailing is disabled

--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -235,7 +235,7 @@ public class ComponentHandler implements ComponentService.Iface {
         assertIdUnset(release.getId());
         assertUser(user);
 
-        return handler.addRelease(release, user.getEmail());
+        return handler.addRelease(release, user);
     }
 
     ///////////////////////////////

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -161,7 +161,7 @@ public class ComponentDatabaseHandlerTest {
                 .setCreatedBy(email1).setVendorId("V1").setReleaseIdToRelationship(releaseLink);
 
         handler.addComponent(component, email1);
-        handler.addRelease(release, email1);
+        handler.addRelease(release, user1);
 
         final Set<Component> usingComponents = handler.getUsingComponents("R1A");
 
@@ -182,7 +182,7 @@ public class ComponentDatabaseHandlerTest {
                 .setCreatedBy(email1).setVendorId("V1").setReleaseIdToRelationship(releaseLink);
 
         handler.addComponent(component, email1);
-        handler.addRelease(release, email1);
+        handler.addRelease(release, user1);
 
         final Set<Component> usingComponents = handler.getUsingComponents(ImmutableSet.of("R1A", "R2A"));
 
@@ -484,7 +484,7 @@ public class ComponentDatabaseHandlerTest {
         Release release = new Release().setId("DelR").setComponentId("Del").setName("delete Release").setVersion("1.0").setCreatedBy(email1).setVendorId("V1").setClearingState(ClearingState.NEW_CLEARING);
 
         handler.addComponent(component, email1);
-        handler.addRelease(release, email1);
+        handler.addRelease(release, user1);
 
         {
             Component del = handler.getComponent("Del", user1);
@@ -591,7 +591,7 @@ public class ComponentDatabaseHandlerTest {
         Release expected = new Release().setName("REL").setVersion("VER");
         expected.setComponentId("C1");
 
-        String id = handler.addRelease(expected, "new@mail.com").getId();
+        String id = handler.addRelease(expected, user1).getId();
         assertNotNull(id);
 
         Release actual = handler.getRelease(id, user1);
@@ -648,7 +648,7 @@ public class ComponentDatabaseHandlerTest {
                 .setMainLicenseIds(licenseIds)
                 .setComponentId(componentId);
         nextReleaseVersion++;
-        String id = handler.addRelease(release, user1.getEmail()).getId();
+        String id = handler.addRelease(release, user1).getId();
         assertNotNull(id);
         return id;
     }
@@ -680,7 +680,7 @@ public class ComponentDatabaseHandlerTest {
         Release release = new Release().setName("REL").setVersion("VER").setOperatingSystems(os).setLanguages(lang).setVendorId("V1");
         release.setComponentId(componentId);
 
-        String id = handler.addRelease(release, user1.getEmail()).getId();
+        String id = handler.addRelease(release, user1).getId();
         assertNotNull(id);
 
         {
@@ -701,7 +701,7 @@ public class ComponentDatabaseHandlerTest {
         Release release2 = new Release().setName("REL2").setVersion("VER2").setOperatingSystems(os2).setLanguages(lang2).setVendorId("V2");
         release2.setComponentId(componentId);
 
-        String id2 = handler.addRelease(release2, user1.getEmail()).getId();
+        String id2 = handler.addRelease(release2, user1).getId();
 
         {
             Component component = handler.getComponent(componentId, user1);
@@ -1002,7 +1002,7 @@ public class ComponentDatabaseHandlerTest {
         final Release tmp = handler.getRelease(originalReleaseId, user1);
         tmp.unsetId();
         tmp.unsetRevision();
-        String newReleaseId = handler.addRelease(tmp, email1).getId();
+        String newReleaseId = handler.addRelease(tmp, user1).getId();
 
         final Map<String, List<String>> duplicateReleases = handler.getDuplicateReleases();
 
@@ -1018,7 +1018,7 @@ public class ComponentDatabaseHandlerTest {
         tmp.unsetId();
         tmp.unsetRevision();
         tmp.setName(tmp.getName().substring(0, 4));
-        String newReleaseId = handler.addRelease(tmp, email1).getId();
+        String newReleaseId = handler.addRelease(tmp, user1).getId();
 
         assertThat(newReleaseId, not(isEmptyOrNullString()));
     }

--- a/backend/src/src-projects/src/test/java/org/eclipse/sw360/projects/ProjectHandlerTest.java
+++ b/backend/src/src-projects/src/test/java/org/eclipse/sw360/projects/ProjectHandlerTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.eclipse.sw360.datahandler.common.SW360Utils.getProjectIds;
@@ -53,10 +54,10 @@ public class ProjectHandlerTest {
     public void setUp() throws Exception {
         List<Project> projects = new ArrayList<>();
 
-        projects.add(new Project().setId("P1").setName("Project1").setBusinessUnit("AB CD EF").setCreatedBy("user1"));
-        projects.add(new Project().setId("P2").setName("Project2").setBusinessUnit("AB CD FE").setCreatedBy("user2"));
+        projects.add(new Project().setId("P1").setName("Project1").setBusinessUnit("AB CD EF").setCreatedBy("user1").setReleaseIdToUsage(Collections.emptyMap()));
+        projects.add(new Project().setId("P2").setName("Project2").setBusinessUnit("AB CD FE").setCreatedBy("user2").setReleaseIdToUsage(Collections.emptyMap()));
         projects.get(1).addToContributors("user1");
-        projects.add(new Project().setId("P3").setName("Project3").setBusinessUnit("AB CD EF").setCreatedBy("user3"));
+        projects.add(new Project().setId("P3").setName("Project3").setBusinessUnit("AB CD EF").setCreatedBy("user3").setReleaseIdToUsage(Collections.emptyMap()));
 
         // Create the database
         TestUtils.createDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -37,6 +37,7 @@ public class PortalConstants {
     public static final Set<String> SET_CLEARING_TEAMS_STRING;
     public static final String LICENSE_IDENTIFIERS;
     public static final String PREFERRED_COUNTRY_CODES;
+    public static final Boolean MAINLINE_STATE_ENABLED_FOR_USER;
 
     // DO NOT CHANGE THIS UNLESS YOU KNOW WHAT YOU ARE DOING !!!
     // - friendly url mapping files must be changed
@@ -510,6 +511,7 @@ public class PortalConstants {
         RELEASE_EXTERNAL_ID_KEYS = CommonUtils.splitToSet(props.getProperty("release.externalkeys", "org.maven.id,com.github.id,com.gitlab.id,purl.id"));
         PROJECTIMPORT_HOSTS = props.getProperty("projectimport.hosts", "");
         PREFERRED_COUNTRY_CODES = props.getProperty("preferred.country.codes", "DE,AT,CH,US");
+        MAINLINE_STATE_ENABLED_FOR_USER = Boolean.parseBoolean(props.getProperty("mainline.state.enabled.for.user", "false"));
 
         // SW360 REST API Constants
         API_TOKEN_ENABLE_GENERATOR = Boolean.parseBoolean(props.getProperty("rest.apitoken.generator.enable", "false"));

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -692,6 +692,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
         String releaseId = request.getParameter(RELEASE_ID);
         final User user = UserCacheHolder.getUserFromRequest(request);
         request.setAttribute(DOCUMENT_TYPE, SW360Constants.TYPE_RELEASE);
+        request.setAttribute(IS_USER_AT_LEAST_CLEARING_ADMIN, PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user));
 
         if (isNullOrEmpty(id) && isNullOrEmpty(releaseId)) {
             throw new PortletException("Component or Release ID not set!");
@@ -763,6 +764,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
         String releaseId = request.getParameter(RELEASE_ID);
         request.setAttribute(DOCUMENT_TYPE, SW360Constants.TYPE_RELEASE);
         final User user = UserCacheHolder.getUserFromRequest(request);
+        request.setAttribute(IS_USER_AT_LEAST_CLEARING_ADMIN, PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user));
 
         if (isNullOrEmpty(releaseId)) {
             throw new PortletException("Release ID not set!");

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -607,6 +607,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
     @SuppressWarnings("Duplicates")
     private void serveNewTableRowLinkedRelease(ResourceRequest request, ResourceResponse response, String[] linkedIds) throws IOException, PortletException {
         final User user = UserCacheHolder.getUserFromRequest(request);
+        request.setAttribute(IS_USER_AT_LEAST_CLEARING_ADMIN, PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user));
 
         List<ReleaseLink> linkedReleases = new ArrayList<>();
         try {
@@ -1159,6 +1160,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
         Project project;
         Set<Project> usingProjects;
         int allUsingProjectCount = 0;
+        request.setAttribute(IS_USER_AT_LEAST_CLEARING_ADMIN, PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user));
 
         if (id != null) {
 
@@ -1217,6 +1219,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
     private void prepareProjectDuplicate(RenderRequest request) {
         User user = UserCacheHolder.getUserFromRequest(request);
         String id = request.getParameter(PROJECT_ID);
+        request.setAttribute(IS_USER_AT_LEAST_CLEARING_ADMIN, PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user));
         setDefaultRequestAttributes(request);
 
         try {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/editRelease.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/editRelease.jsp
@@ -57,6 +57,9 @@
 
     <core_rt:set var="addMode" value="${empty release.id}"/>
     <core_rt:set var="cotsMode" value="<%=component.componentType == ComponentType.COTS%>"/>
+
+    <jsp:useBean id="isUserAtLeastClearingAdmin" type="java.lang.Boolean" scope="request" />
+    <core_rt:set var="mainlineStateEnabledForUserRole" value='<%=PortalConstants.MAINLINE_STATE_ENABLED_FOR_USER%>'/>
 </c:catch>
 
 <%--These variables are used as a trick to allow referencing enum values in EL expressions below--%>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/editReleaseInformation.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/editReleaseInformation.jspf
@@ -136,6 +136,9 @@
                 <label for="mainline_state">Release Mainline State</label>
                 <select class="form-control" id="mainline_state"
                         name="<portlet:namespace/><%=Release._Fields.MAINLINE_STATE%>"
+                    <core_rt:if test="${not isUserAtLeastClearingAdmin and not mainlineStateEnabledForUserRole}" >
+                        disabled="disabled"
+                    </core_rt:if>
                 >
                     <sw360:DisplayEnumOptions type="<%=MainlineState.class%>" selected="${release.mainlineState}"/>
                 </select>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/edit.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/edit.jsp
@@ -55,6 +55,7 @@
     <jsp:useBean id="attachments" type="java.util.Set<org.eclipse.sw360.datahandler.thrift.attachments.Attachment>" scope="request"/>
     <jsp:useBean id="defaultLicenseInfoHeaderText" class="java.lang.String" scope="request" />
     <jsp:useBean id="defaultObligationsText" class="java.lang.String" scope="request" />
+    <jsp:useBean id="isUserAtLeastClearingAdmin" type="java.lang.Boolean" scope="request" />
 
     <core_rt:set  var="addMode"  value="${empty project.id}" />
     <core_rt:set  var="pageName"  value="<%= request.getParameter("pagename") %>" />
@@ -234,6 +235,7 @@ require(['jquery', 'modules/dialog', 'modules/listgroup', 'modules/validation', 
     function submitForm() {
         disableLicenseInfoHeaderTextIfNecessary();
         disableObligationsTextIfNecessary();
+        $('#LinkedReleasesInfo tbody tr #mainlineState').prop('disabled', false);
         $('#projectEditForm').submit();
     }
 

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/ajax/linkedReleasesAjax.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/ajax/linkedReleasesAjax.jsp
@@ -20,8 +20,10 @@
 <%@ page import="org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship" %>
 <%@ page import="org.eclipse.sw360.datahandler.thrift.ReleaseRelationship" %>
 <%@ page import="org.eclipse.sw360.datahandler.thrift.MainlineState" %>
+<%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 
 <jsp:useBean id="releaseList" type="java.util.List<org.eclipse.sw360.datahandler.thrift.components.ReleaseLink>"  scope="request"/>
+<core_rt:set var="mainlineStateEnabledForUserRole" value='<%=PortalConstants.MAINLINE_STATE_ENABLED_FOR_USER%>'/>
 <core_rt:forEach items="${releaseList}" var="releaseLink" varStatus="loop">
     <core_rt:set var="uuid" value="${releaseLink.id}"/>
     <tr id="releaseLinkRow${uuid}" >
@@ -57,6 +59,9 @@
             <div class="form-group">
                 <select class="form-control" id="mainlineState"
                         name="<portlet:namespace/><%=Project._Fields.RELEASE_ID_TO_USAGE%><%=ProjectReleaseRelationship._Fields.MAINLINE_STATE%>"
+                        <core_rt:if test="${not isUserAtLeastClearingAdmin and not mainlineStateEnabledForUserRole}" >
+                            disabled="disabled"
+                        </core_rt:if>
                 >
                     <sw360:DisplayEnumOptions type="<%=MainlineState.class%>" selected="${releaseLink.mainlineState}"/>
                 </select>


### PR DESCRIPTION
Summary: Changes of the Project/Release Mainline State is only allowed for the role Clearing Admin.

**Steps to test:**

  **_Scenario 1:_**
```
1. Login with USER role.
2. Go to Projects tab and edit a Project which is having linked releases.
3. Select "Linked Releases And Projects" on left.
4. Verify that "Project Mainline State" drop-down is disabled. 
5. Click on "click to add Release" -> search for a release and add it to the "Linked Releases".
6. Verify that "Project Mainline State" drop-down is disabled. 
```

**Result:**
`1. User should not be able to change the "Project Mainline State" drop-down. in "Linked release and projects" tab.`



**_Scenario 2:_**
```
1. Login with USER role.
2. Go to Components tab and edit a component which is having release ("Release Overview" tab).
3. Select any release under that component.
4. Verify that "Release Mainline State" drop-down is disabled in "summary" tab. 
```
**Result:**
`1. User should not be able to change the "Release Mainline State" drop-down in "summary" tab.`

_**Verify the same for ADMIN and/or CLEARING_ADMIN**_
`Also, repeat the above mentioned test scenario 1 and 2 by logging in with ADMIN or CLEARING_ADMIN role, and Admin should have ability/permission to change the Project/Release Main State drop-down status.`

closes : #503 and #280 
Signed-off-by: Abdul Kapti <abdul.mannankapti@siemens.com>