### PR TITLE
feat(ui/rest): User confirmation before updating records with duplicate attachments

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -404,8 +404,6 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         assertNotNull(actual, "Could not find component to update!");
         if (changeWouldResultInDuplicate(actual, component)) {
             return RequestStatus.DUPLICATE;
-        } else if (duplicateAttachmentExist(component)) {
-            return RequestStatus.DUPLICATE_ATTACHMENT;
         } else if (makePermission(actual, user).isActionAllowed(RequestedAction.WRITE)) {
             // Nested releases and attachments should not be updated by this method
             if (actual.isSetReleaseIds()) {
@@ -431,14 +429,6 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
         return isDuplicate(after);
     }
-
-    private boolean duplicateAttachmentExist(Component component) {
-    	if(component.attachments != null && !component.attachments.isEmpty()) {
-            return AttachmentConnector.isDuplicateAttachment(component.attachments);
-        }
-        return false;
-    }
-
 
     private void updateComponentInternal(Component updated, Component current, User user) {
         // Update the database with the component
@@ -633,8 +623,6 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
         if (actual.equals(release)) {
             return RequestStatus.SUCCESS;
-        } else if (duplicateAttachmentExist(release)) {
-            return RequestStatus.DUPLICATE_ATTACHMENT;
         } else if (changeWouldResultInDuplicate(actual, release)) {
             return RequestStatus.DUPLICATE;
         } else {
@@ -684,13 +672,6 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
         return isDuplicate(after);
        }
-
-    private boolean duplicateAttachmentExist(Release release) {
-        if (release.attachments != null && !release.attachments.isEmpty()) {
-            return AttachmentConnector.isDuplicateAttachment(release.attachments);
-        }
-        return false;
-    }
 
     private void deleteAttachmentUsagesOfUnlinkedReleases(Release updated, Release actual) throws SW360Exception {
         Source usedBy = Source.releaseId(updated.getId());

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -194,8 +194,6 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
         if (changeWouldResultInDuplicate(actual, project)) {
             return RequestStatus.DUPLICATE;
-        } else if (duplicateAttachmentExist(project)) {
-            return RequestStatus.DUPLICATE_ATTACHMENT;
         } else if (!changePassesSanityCheck(project, actual)){
             return RequestStatus.FAILED_SANITY_CHECK;
         } else if (makePermission(actual, user).isActionAllowed(RequestedAction.WRITE)) {
@@ -221,13 +219,6 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         }
 
         return isDuplicate(after);
-    }
-
-    private boolean duplicateAttachmentExist(Project project) {
-        if(project.attachments != null && !project.attachments.isEmpty()) {
-            return AttachmentConnector.isDuplicateAttachment(project.attachments);
-        }
-        return false;
     }
 
     private void deleteAttachmentUsagesOfUnlinkedReleases(Project updated, Project actual) throws SW360Exception {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -313,6 +313,9 @@ public class PortalConstants {
     public static final String LOAD_LICENSE_INFO_ATTACHMENT_USAGE = "LoadLicenseInfoAttachmentUsage";
     public static final String LOAD_SOURCE_PACKAGE_ATTACHMENT_USAGE = "LoadSourcePackageAttachmentUsage";
     public static final String LOAD_PROJECT_LIST = "load_project_list";
+    public static final String CHECK_DUPLICATE_ATTACHMENT = "check_duplicate_attachments";
+    public static final String CHECK_DUPLICATE_ATTACHMENT_RELEASE = "check_duplicate_attachments_release";
+    public static final String CHECK_DUPLICATE_ATTACHMENT_COMPONENT = "check_duplicate_attachments_component";
 
     //component actions
     public static final String ADD_VENDOR = "add_vendor";

--- a/frontend/sw360-portlet/src/main/webapp/html/components/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/edit.jsp
@@ -23,6 +23,10 @@
 <%-- the following is needed by liferay to display error messages--%>
 <%@ include file="/html/utils/includes/errorKeyToMessage.jspf"%>
 
+<portlet:resourceURL var="checkDuplicateAttachmentAjaxUrl">
+    <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.CHECK_DUPLICATE_ATTACHMENT_COMPONENT%>'/>
+    <portlet:param name="<%=PortalConstants.COMPONENT_ID%>" value="${component.id}" />
+</portlet:resourceURL>
 
 <portlet:actionURL var="updateComponentURL" name="updateComponent">
     <portlet:param name="<%=PortalConstants.COMPONENT_ID%>" value="${component.id}"/>
@@ -161,7 +165,7 @@
         /* baseUrl also used in method in require block */
         baseUrl = '<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>';
 
-require(['jquery', 'modules/sw360Validate', 'modules/autocomplete', 'modules/confirm', 'components/includes/vendors/searchVendor'  ], function($, sw360Validate, autocomplete, confirm, vendorsearch) {
+require(['jquery', 'modules/sw360Validate', 'modules/autocomplete', 'modules/confirm', 'components/includes/vendors/searchVendor', 'utils/includes/validateAttachments' ], function($, sw360Validate, autocomplete, confirm, vendorsearch, validateAttachments) {
 
     Liferay.on('allPortletsReady', function() {
         var contextpath = '<%=request.getContextPath()%>',
@@ -180,7 +184,7 @@ require(['jquery', 'modules/sw360Validate', 'modules/autocomplete', 'modules/con
             function () {
                 <core_rt:choose>
                 <core_rt:when test="${componentDivAddMode || component.permissions[WRITE]}">
-                $('#componentEditForm').submit();
+                validateAttachments.attachmentValidation('<%=checkDuplicateAttachmentAjaxUrl%>',"componentEditForm","component");
                 </core_rt:when>
                 <core_rt:otherwise>
                 showCommentField();

--- a/frontend/sw360-portlet/src/main/webapp/html/components/editRelease.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/editRelease.jsp
@@ -36,6 +36,11 @@
     <portlet:param name="<%=PortalConstants.RELEASE_ID%>" value="${release.id}"/>
 </portlet:actionURL>
 
+<portlet:resourceURL var="checkDuplicateAttachmentAjaxUrl">
+    <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.CHECK_DUPLICATE_ATTACHMENT_RELEASE%>'/>
+    <portlet:param name="<%=PortalConstants.RELEASE_ID%>" value="${release.id}" />
+</portlet:resourceURL>
+
 <portlet:actionURL var="deleteAttachmentsOnCancelURL" name='<%=PortalConstants.ATTACHMENT_DELETE_ON_CANCEL%>'>
 </portlet:actionURL>
 
@@ -171,7 +176,7 @@
     var sw360Purl = "${componentpurl}";
 </script>
 <script>
-    require(['jquery', 'modules/sw360Validate', 'components/includes/vendors/searchVendor', 'modules/confirm', 'modules/autocomplete', 'modules/tabview', /* jquery-plugins */ 'jquery-ui' ], function($, sw360Validate, vendorsearch, confirm, autocomplete, tabview) {
+    require(['jquery', 'modules/sw360Validate', 'components/includes/vendors/searchVendor', 'modules/confirm', 'modules/autocomplete', 'modules/tabview', 'utils/includes/validateAttachments', /* jquery-plugins */ 'jquery-ui' ], function($, sw360Validate, vendorsearch, confirm, autocomplete, tabview, validateAttachments) {
         document.title = "${component.name} - " + document.title;
 
         tabview.create('myTab');
@@ -186,7 +191,7 @@
                 function() {
                     <core_rt:choose>
                     <core_rt:when test="${addMode || release.permissions[WRITE]}">
-                    $('#releaseEditForm').submit();
+                    validateAttachments.attachmentValidation('<%=checkDuplicateAttachmentAjaxUrl%>',"releaseEditForm","release");
                     </core_rt:when>
                     <core_rt:otherwise>
                     showCommentField();

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
@@ -35,6 +35,11 @@
     <portlet:param name="<%=PortalConstants.PROJECT_ID%>" value="${project.id}" />
 </portlet:actionURL>
 
+<portlet:resourceURL var="checkDuplicateAttachmentAjaxUrl">
+    <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.CHECK_DUPLICATE_ATTACHMENT%>'/>
+    <portlet:param name="<%=PortalConstants.PROJECT_ID%>" value="${project.id}" />
+</portlet:resourceURL>
+
 <portlet:actionURL var="deleteAttachmentsOnCancelURL" name='<%=PortalConstants.ATTACHMENT_DELETE_ON_CANCEL%>'>
 </portlet:actionURL>
 
@@ -144,7 +149,7 @@
 </core_rt:if>
 
 <script>
-require(['jquery', 'modules/sw360Validate', 'modules/confirm', 'modules/tabview' ], function($, sw360Validate, confirm, tabview) {
+require(['jquery', 'modules/sw360Validate', 'modules/confirm', 'modules/tabview', 'utils/includes/validateAttachments' ], function($, sw360Validate, confirm, tabview, validateAttachments) {
     document.title = "${project.name} - " + document.title;
 
     tabview.create('myTab');
@@ -233,7 +238,7 @@ require(['jquery', 'modules/sw360Validate', 'modules/confirm', 'modules/tabview'
     function submitForm() {
         disableLicenseInfoHeaderTextIfNecessary();
         disableObligationsTextIfNecessary();
-        $('#projectEditForm').submit();
+        validateAttachments.attachmentValidation('<%=checkDuplicateAttachmentAjaxUrl%>',"projectEditForm","project");
     }
 
     function disableLicenseInfoHeaderTextIfNecessary() {

--- a/frontend/sw360-portlet/src/main/webapp/js/utils/includes/validateAttachments.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/utils/includes/validateAttachments.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+define('utils/includes/validateAttachments', ['jquery', 'jquery-confirm'], function($) {
+
+function validateAttachment(url, formId, type) {
+        $.ajax({
+            type : 'POST',
+            url : url,
+            cache : false,
+            data : $('#'+formId).serialize(),
+            success : function(response) {
+                if (response.result == true) {
+                    showWarningDialog(formId, type);
+                } else {
+                    $('#'+formId).submit();
+                }
+            }
+        });
+    }
+
+    function showWarningDialog(formId, type) {
+        var message = "Duplicate attachments exist in "+ type + " record. Please confirm to proceed or cancel to make corrections?";
+        return $.confirm({
+                    title : 'Warning',
+                    content : message,
+                    buttons : {
+                        confirm : {
+                            btnClass : 'btn-green',
+                            action : function() {
+                                $('#'+formId).submit();
+                            }
+                        },
+                        cancel : {
+                            btnClass : 'btn-red',
+                        }
+                    }
+                });
+    }
+
+    return {
+        attachmentValidation:validateAttachment
+    }
+});

--- a/rest/resource-server/src/docs/asciidoc/components.adoc
+++ b/rest/resource-server/src/docs/asciidoc/components.adoc
@@ -157,6 +157,15 @@ A `POST` request is used to upload attachment to component
 |Attachment content id
 |===
 
+[red]#Request Parameter#
+|===
+|Path |Type |Description
+
+|allowDuplicateAttachment
+|Boolean
+|Please pass `true` to allow duplicate attachments in the component.
+|===
+
 [red]#Response structure#
 |===
 |Complete Component will be returned

--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -123,6 +123,15 @@ A `POST` request is used to upload attachment to project
 |Attachment content id
 |===
 
+[red]#Request Parameter#
+|===
+|Path |Type |Description
+
+|allowDuplicateAttachment
+|Boolean
+|Please pass `true` to allow duplicate attachments in the project.
+|===
+
 [red]#Response structure#
 |===
 |Complete Project will be returned

--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -103,6 +103,15 @@ A `POST` request is used to upload attachment to release
 |Attachment content id
 |===
 
+[red]#Request Parameter#
+|===
+|Path |Type |Description
+
+|allowDuplicateAttachment
+|Boolean
+|Please pass `true` to allow duplicate attachments in the release.
+|===
+
 [red]#Response structure#
 |===
 |Complete Release will be returned

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
@@ -47,6 +47,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -185,5 +186,11 @@ public class Sw360AttachmentService {
             attachmentResources.add(attachmentResource);
         }
         return new Resources<>(attachmentResources);
+    }
+
+    public boolean isDuplicateAttachment(Set<Attachment> attachments) {
+        boolean duplicateSha1 = attachments.parallelStream().collect(Collectors.groupingBy(Attachment::getSha1)).size() < attachments.size();
+        boolean duplicateFileName = attachments.parallelStream().collect(Collectors.groupingBy(Attachment::getFilename)).size() < attachments.size();
+        return (duplicateSha1 || duplicateFileName);
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -423,9 +423,13 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                 .contentType(MediaTypes.HAL_JSON)
                 .content(this.objectMapper.writeValueAsString(updateComponent))
                 .header("Authorization", "Bearer " + accessToken)
+                .param("allowDuplicateAttachment", "true")
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
+                        requestParameters(
+                                parameterWithName("allowDuplicateAttachment").description("Please pass as `true` to allow duplicate attachments.")
+                        ),
                         links(
                                 linkWithRel("self").description("The <<resources-components,Component resource>>")
                         ),

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -46,6 +46,8 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ReleaseSpecTest extends TestRestDocsSpecBase {
@@ -253,11 +255,14 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                 .contentType(MediaTypes.HAL_JSON)
                 .content(this.objectMapper.writeValueAsString(updateRelease))
                 .header("Authorization", "Bearer" + accessToken)
+                .param("allowDuplicateAttachment", "true")
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
-                        links(
-                                linkWithRel("self").description("The <<resources-release,Release resource>>"),
+                        requestParameters(
+                                parameterWithName("allowDuplicateAttachment").description("Please pass as `true` to allow duplicate attachments.")
+                        ),
+                        links(linkWithRel("self").description("The <<resources-release,Release resource>>"),
                                 linkWithRel("sw360:component").description("The link to the corresponding component"),
                                 linkWithRel("curies").description("The curies for documentation")
                         ),


### PR DESCRIPTION
* Added a confirm dialog box to confirm with user before updating the record(release, project, component) which containes duplicate   attachment.
* Same validation is done at the REST side as well, if the client tries to upload duplicate attachment to the record(release, project, component), then it will give an error response with warning message. In case client wants to add duplicate attachment, then client needs to send additional flag with as a request parameter(`?allowDuplicateAttachment=true`) to achieve the same.

Signed-off-by: Smruti Sahoo <smruti.sahoo@siemens.com>

closes: #533 