### PR TITLE
feat(Projects): display 'uploadedBy' & 'Relation' in Attachment Usages tab

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentUsages.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentUsages.jspf
@@ -41,10 +41,12 @@
     >
     <thead>
     <tr>
-        <th colspan="5" class="headlabel">Linked Releases And Projects</th>
+        <th colspan="7" class="headlabel">Linked Releases And Projects</th>
     </tr>
     <tr>
         <th rowspan="2">Name</th>
+        <th rowspan="2">Relation</th>
+        <th rowspan="2">Uploaded By</th>
         <th rowspan="2">Type</th>
         <th colspan="3">Used in</th>
     </tr>
@@ -58,7 +60,7 @@
     <%@include file="/html/projects/includes/attachmentUsagesRows.jspf"%>
     <core_rt:if test="${projectList.size() == 1 and empty projectList.get(0).linkedReleases}">
         <tr>
-            <td colspan="5">No linked releases or projects</td>
+            <td colspan="7">No linked releases or projects</td>
         </tr>
     </core_rt:if>
     </tbody>

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentUsagesRows.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/attachmentUsagesRows.jspf
@@ -40,6 +40,9 @@
                 /></a>
             </td>
             <td>
+            	<sw360:DisplayEnum value="${projectLink.relation}"/>
+            </td>
+            <td>
             </td>
             <td>
             </td>
@@ -61,6 +64,9 @@
                 </a>
             </td>
             <td>
+            	<sw360:DisplayEnum value="${releaseLink.releaseRelationship}"/>
+            </td>
+            <td>
             </td>
             <td>
             </td>
@@ -73,10 +79,19 @@
         <core_rt:forEach items="${releaseLink.attachments}" var="attachment" varStatus="attachmentloop">
             <tr data-tt-id="${releaseLink.nodeId}_${attachment.attachmentContentId}" data-tt-branch="false"
                 data-tt-parent-id="${releaseLink.nodeId}"
+                title="Created On: ${attachment.createdOn} &#10; Status: ${attachment.checkStatus}
+                <core_rt:if test="${attachment.checkStatus != 'NOTCHECKED'}">
+	            	&#10; Checked By: ${attachment.checkedBy} &#10; Checked On: ${attachment.checkedOn}
+                </core_rt:if>"
             >
                 <td>
                     <sw360:out value="${attachment.filename}" maxChar="60"/>
                     <%--<sw360:DisplayDownloadAttachmentFile attachment="${attachment}" contextType="release" contextId="${releaseLink.id}"/>--%>
+                </td>
+                <td>
+                </td>
+                <td>
+                    <sw360:out value="${attachment.createdBy}"/>
                 </td>
                 <td>
                     <sw360:DisplayEnumShort value="${attachment.attachmentType}"/>


### PR DESCRIPTION
**Summary:** changes to display 'uploaded By' and 'Project/Release Relation' in Attachment Usages tab under project portlet.

**Steps to test:**
```
- Login to SW360, and open project portal

- Select a Project which is having 'Linked Release / Projects'

- Go to 'Attachment Usages' tab, and expand the Release/Project.

- You should see 'Relation' for each release / project, and 'uploaded by' for each attachment.

- Additional attachment info should be displayed on mouse hover for each attachment table row.
```
closes: #370 
Signed-off-by: Abdul Kapti <abdul.mannankapti@siemens.com>