### PR TITLE
fix(Project UI): Fixed "Set To Default Text" feature for project license info header

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/administrationEdit.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/administrationEdit.jspf
@@ -187,7 +187,7 @@
         <td>
             <textarea name="<portlet:namespace/><%=Project._Fields.LICENSE_INFO_HEADER_TEXT%>" rows="5"
                       class="projectLicenseInfoHeaderText broader" id="licenseInfoHeaderText"
-                      data-defaulttext="${defaultLicenseInfoHeaderText}"><sw360:DisplayLicenseInfoHeader
+                      data-defaulttext="<c:out value='${defaultLicenseInfoHeaderText}'/>"><sw360:DisplayLicenseInfoHeader
                     project="${project}" defaultText="${defaultLicenseInfoHeaderText}"/></textarea>
             <input id="setToDefaultLicenseInfoHeaderTextButton" type="button" class="addButton pull-right"
                    value="Set To Default Text">
@@ -225,4 +225,3 @@
 
     });
 </script>
-


### PR DESCRIPTION
Issue: Under Project>>Administration, if user click on "Set To default text" of License info header then License info header text will display only till first double quote.

Reason: When html encounters the first double quote then it considers that as end of default text and display only till that point.
Fixed the issue by using the text area value in side java script which is  formatted as per html.

Closes : #559 
