### PR TITLE
Fix(Project UI): Removed 'Unknown' from Project Clearing Team dropdown

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -38,6 +38,7 @@ public class PortalConstants {
     public static final String LICENSE_IDENTIFIERS;
     public static final String PREFERRED_COUNTRY_CODES;
     public static final Boolean MAINLINE_STATE_ENABLED_FOR_USER;
+    public static final Boolean IS_CLEARING_TEAM_UNKNOWN_ENABLED;
 
     // DO NOT CHANGE THIS UNLESS YOU KNOW WHAT YOU ARE DOING !!!
     // - friendly url mapping files must be changed
@@ -516,6 +517,7 @@ public class PortalConstants {
         PROJECTIMPORT_HOSTS = props.getProperty("projectimport.hosts", "");
         PREFERRED_COUNTRY_CODES = props.getProperty("preferred.country.codes", "DE,AT,CH,US");
         MAINLINE_STATE_ENABLED_FOR_USER = Boolean.parseBoolean(props.getProperty("mainline.state.enabled.for.user", "false"));
+        IS_CLEARING_TEAM_UNKNOWN_ENABLED = Boolean.parseBoolean(props.getProperty("clearing.team.unknown.enabled", "true"));
 
         // SW360 REST API Constants
         API_TOKEN_ENABLE_GENERATOR = Boolean.parseBoolean(props.getProperty("rest.apitoken.generator.enable", "false"));

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/administrationEdit.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/administrationEdit.jspf
@@ -12,6 +12,7 @@
 <%@page import="org.eclipse.sw360.datahandler.thrift.projects.ProjectClearingState"%>
 <%@page import="org.eclipse.sw360.datahandler.thrift.projects.ProjectState"%>
 <%@page import="org.eclipse.sw360.datahandler.thrift.projects.Project" %>
+<core_rt:set var="isUnknownCTeamEnabled" value='<%=PortalConstants.IS_CLEARING_TEAM_UNKNOWN_ENABLED%>'/>
 
 <table class="table edit-table three-columns" id="ProjectClearingInfo" title="Clearing">
     <thead>
@@ -38,10 +39,12 @@
                 <label for="clearingTeam">Clearing team</label>
                 <select class="form-control" id="clearingTeam"
                         name="<portlet:namespace/><%=Project._Fields.CLEARING_TEAM%>">
-                    <option value="<%=CLEARING_TEAM_UNKNOWN%>"
-                            <core_rt:if test='${empty project.clearingTeam}'>
-                                selected="selected"
-                            </core_rt:if>><%=CLEARING_TEAM_UNKNOWN%></option>
+                        <core_rt:if test="${isUnknownCTeamEnabled}">
+                            <option value="<%=CLEARING_TEAM_UNKNOWN%>"
+                                <core_rt:if test='${empty project.clearingTeam}'>
+                                    selected="selected"
+                                </core_rt:if>><%=CLEARING_TEAM_UNKNOWN%></option>
+                        </core_rt:if>
                     <core_rt:forEach items="${clearingTeamsStringSet}" var="entry">
                         <option value="${entry}" class="textlabel stackedLabel"
                             <core_rt:if test='${project.clearingTeam == entry}'>

--- a/frontend/sw360-portlet/src/main/resources/sw360.properties
+++ b/frontend/sw360-portlet/src/main/resources/sw360.properties
@@ -62,6 +62,8 @@
 
 #project.externalkeys=internal.id
 
+#clearing.team.unknown.enabled=true
+
 ## used in the projectimport-portlet UI, comma separated list of hosts
 ## 	Example: https://some.host.domain,https://some.other.host.domain
 #projectimport.hosts=


### PR DESCRIPTION
**Summary:** removed `Unknown` option from the Project Clearing Team drop down.

**Steps to test:**
```
- Login to SW360, and open project portal

- Edit any Project listed under Project tab.

- Go to 'Administration' tab, and check the "Clearing Team" drop down.

- You should not see 'Unknown' option in drop down.
```

closes: #563 

Signed-off-by: Abdul Kapti <abdul.mannankapti@siemens.com>