### PR TITLE
 feat(client-management): added support to dynamically manage oauth clients

### DIFF
--- a/rest/authorization-server/pom.xml
+++ b/rest/authorization-server/pom.xml
@@ -99,6 +99,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.restdocs</groupId>
             <artifactId>spring-restdocs-core</artifactId>
             <version>${spring-restdocs.version}</version>
@@ -120,6 +125,17 @@
             <groupId>org.eclipse.sw360</groupId>
             <artifactId>rest-common</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ektorp</groupId>
+            <artifactId>org.ektorp</artifactId>
+            <version>${ektorp.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>net.sourceforge.findbugs</groupId>
+                <artifactId>annotations</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <dependencyManagement>

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/StringTransformer.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/StringTransformer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver;
+
+public class StringTransformer {
+    
+    /**
+     * Depending on the first parameter this method returns:
+     * <ul>
+     *   <li>null: null</li>
+     *   <li>String[] with at least one element: first element</li>
+     *   <li>String[] with no element: ""</li>
+     *   <li>other: string value of parameter</li>
+     * </ul>
+     * 
+     * @param object object to transform into a single string
+     * 
+     * @return the transformed string
+     */
+    public static String transformIntoString(Object object) {
+        if(object == null) {
+            return null;
+        }
+
+        if(object instanceof String[]) {
+            if(((String[]) object).length > 0) {
+                return ((String[])object)[0];
+            } else {
+                return "";
+            }
+        }
+
+        return object.toString();
+    }
+}

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/Sw360AuthorizationServer.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/Sw360AuthorizationServer.java
@@ -11,10 +11,11 @@
 
 package org.eclipse.sw360.rest.authserver;
 
-import org.apache.log4j.Logger;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.rest.common.Sw360CORSFilter;
+
+import org.apache.log4j.Logger;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -22,6 +23,7 @@ import org.springframework.boot.web.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Import;
 
 import javax.crypto.SealedObject;
+
 import java.io.IOException;
 import java.util.Properties;
 
@@ -35,18 +37,17 @@ public class Sw360AuthorizationServer extends SpringBootServletInitializer {
 
     private static final String PROPERTIES_FILE_PATH = "/sw360.properties";
     private static final String DEFAULT_WRITE_ACCESS_USERGROUP = UserGroup.SW360_ADMIN.name();
+    private static final String DEFAULT_ADMIN_ACCESS_USERGROUP = UserGroup.SW360_ADMIN.name();
 
     public static final String CONFIG_ACCESS_TOKEN_VALIDITY_SECONDS;
     public static final UserGroup CONFIG_WRITE_ACCESS_USERGROUP;
-    public static final String CONFIG_CLIENT_ID;
-    public static final SealedObject CONFIG_CLIENT_SECRET;
+    public static final UserGroup CONFIG_ADMIN_ACCESS_USERGROUP;
 
     static {
         Properties props = CommonUtils.loadProperties(Sw360AuthorizationServer.class, PROPERTIES_FILE_PATH);
         CONFIG_WRITE_ACCESS_USERGROUP = UserGroup.valueOf(props.getProperty("rest.write.access.usergroup", DEFAULT_WRITE_ACCESS_USERGROUP));
+        CONFIG_ADMIN_ACCESS_USERGROUP = UserGroup.valueOf(props.getProperty("rest.admin.access.usergroup", DEFAULT_ADMIN_ACCESS_USERGROUP));
         CONFIG_ACCESS_TOKEN_VALIDITY_SECONDS = props.getProperty("rest.access.token.validity.seconds", null);
-        CONFIG_CLIENT_ID = props.getProperty("rest.security.client.id", null);
-        CONFIG_CLIENT_SECRET = getConfigClientSecret(props);
     }
 
     private static SealedObject getConfigClientSecret(Properties props) {

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/persistence/OAuthClientEntity.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/persistence/OAuthClientEntity.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver.client.persistence;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.ektorp.support.CouchDbDocument;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.client.BaseClientDetails;
+import org.springframework.security.oauth2.provider.client.Jackson2ArrayOrStringDeserializer;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+public class OAuthClientEntity extends CouchDbDocument implements ClientDetails {
+
+    private BaseClientDetails delegate;
+
+    private String description;
+
+    public OAuthClientEntity() {
+        this.delegate = new BaseClientDetails();
+    }
+
+    @Override
+    @JsonProperty("client_id")
+    public String getClientId() {
+        return delegate.getClientId();
+    }
+
+    @JsonProperty("client_id")
+    public void setClientId(String clientId) {
+        delegate.setClientId(clientId);
+    }
+
+    @Override
+    @JsonProperty("client_secret")
+    public String getClientSecret() {
+        return delegate.getClientSecret();
+    }
+
+    @JsonProperty("client_secret")
+    public void setClientSecret(String clientSecret) {
+        delegate.setClientSecret(clientSecret);
+    }
+
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonProperty("description")
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    @JsonProperty("resource_ids")
+    @JsonDeserialize(using = Jackson2ArrayOrStringDeserializer.class)
+    public Set<String> getResourceIds() {
+        return delegate.getResourceIds();
+    }
+
+    @JsonProperty("resource_ids")
+    public void setResourceIds(Set<String> clientSecret) {
+        delegate.setResourceIds(clientSecret);
+    }
+
+    @Override
+    @JsonProperty("authorized_grant_types")
+    @JsonDeserialize(using = Jackson2ArrayOrStringDeserializer.class)
+    public Set<String> getAuthorizedGrantTypes() {
+        return delegate.getAuthorizedGrantTypes();
+    }
+
+    @JsonProperty("authorized_grant_types")
+    public void setAuthorizedGrantTypes(Set<String> authorizedGrantTypes) {
+        delegate.setAuthorizedGrantTypes(authorizedGrantTypes);
+    }
+
+    @Override
+    public Collection<GrantedAuthority> getAuthorities() {
+        return delegate.getAuthorities();
+    }
+
+    public void setAuthorities(Collection<GrantedAuthority> authorities) {
+        delegate.setAuthorities(authorities);
+    }
+
+    @JsonProperty("authorities")
+    public Set<String> getAuthoritiesAsStrings() {
+        return AuthorityUtils.authorityListToSet(delegate.getAuthorities());
+    }
+
+    @JsonProperty("authorities")
+    @JsonDeserialize(using = Jackson2ArrayOrStringDeserializer.class)
+    public void setAuthoritiesAsStrings(Set<String> values) {
+        delegate.setAuthorities(AuthorityUtils.createAuthorityList(values.toArray(new String[values.size()])));
+    }
+
+    @Override
+    @JsonProperty("scope")
+    @JsonDeserialize(using = Jackson2ArrayOrStringDeserializer.class)
+    public Set<String> getScope() {
+        return delegate.getScope();
+    }
+
+    @JsonProperty("scope")
+    public void setScope(Set<String> scope) {
+        delegate.setScope(scope);
+    }
+
+    @Override
+    @JsonProperty("redirect_uri")
+    @JsonDeserialize(using = Jackson2ArrayOrStringDeserializer.class)
+    public Set<String> getRegisteredRedirectUri() {
+        return delegate.getRegisteredRedirectUri();
+    }
+
+    @JsonProperty("redirect_uri")
+    public void setRegisteredRedirectUri(Set<String> registeredRedirectUri) {
+        delegate.setRegisteredRedirectUri(registeredRedirectUri);
+    }
+
+    @Override
+    @JsonProperty("access_token_validity")
+    public Integer getAccessTokenValiditySeconds() {
+        return delegate.getAccessTokenValiditySeconds();
+    }
+
+    @JsonProperty("access_token_validity")
+    public void setAccessTokenValiditySeconds(Integer accessTokenValiditySeconds) {
+        delegate.setAccessTokenValiditySeconds(accessTokenValiditySeconds);
+    }
+
+    @Override
+    @JsonProperty("refresh_token_validity")
+    public Integer getRefreshTokenValiditySeconds() {
+        return delegate.getRefreshTokenValiditySeconds();
+    }
+
+    @JsonProperty("refresh_token_validity")
+    public void setRefreshTokenValiditySeconds(Integer refreshTokenValiditySeconds) {
+        delegate.setRefreshTokenValiditySeconds(refreshTokenValiditySeconds);
+    }
+
+    @JsonProperty("autoapprove")
+    public Set<String> getAutoApproveScopes() {
+        return delegate.getAutoApproveScopes();
+    }
+
+    @JsonProperty("autoapprove")
+    public void setAutoApproveScopes(Set<String> autoApproveScopes) {
+        delegate.setAutoApproveScopes(autoApproveScopes);
+    }
+
+    @Override
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalInformation() {
+        return delegate.getAdditionalInformation();
+    }
+
+    @JsonAnySetter
+    public void addAdditionalInformation(String key, Object value) {
+        delegate.addAdditionalInformation(key, value);
+    }
+
+    @Override
+    public boolean isSecretRequired() {
+        return delegate.isSecretRequired();
+    }
+
+    @Override
+    public boolean isScoped() {
+        return delegate.isScoped();
+    }
+
+    @Override
+    public boolean isAutoApprove(String scope) {
+        return delegate.isAutoApprove(scope);
+    }
+
+}

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/persistence/OAuthClientRepository.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/persistence/OAuthClientRepository.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver.client.persistence;
+
+import org.ektorp.ViewQuery;
+import org.ektorp.http.StdHttpClient;
+import org.ektorp.impl.StdCouchDbConnector;
+import org.ektorp.impl.StdCouchDbInstance;
+import org.ektorp.support.CouchDbRepositorySupport;
+import org.ektorp.support.View;
+import org.ektorp.support.Views;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.MalformedURLException;
+import java.util.List;
+
+/**
+ * This repository can perform CRUD operations on a CouchDB for
+ * {@link OAuthClientEntity}s. The necessary configuration for the CouchDB
+ * connection has to be available to Spring's {@link Value} infrastructure.
+ */
+@Component
+@Views({
+        @View(name = "all", map = "function(doc) { emit(null, doc._id); }"),
+        @View(name = "byId", map = "function(doc) { emit(doc._id, doc); }"),
+        @View(name = "byClientId", map = "function(doc) { emit(doc.client_id, doc); }")
+})
+public class OAuthClientRepository extends CouchDbRepositorySupport<OAuthClientEntity> {
+
+    protected OAuthClientRepository(
+            @Value("${couchdb.url}") final String dbUrl,
+            @Value("${couchdb.database}") final String dbName,
+            @Value("${couchdb.username:#{null}}") final String dbUsername,
+            @Value("${couchdb.password:#{null}}") final String dbPassword) throws MalformedURLException {
+
+        super(OAuthClientEntity.class, new StdCouchDbConnector(dbName,
+                        new StdCouchDbInstance(
+                                new StdHttpClient.Builder()
+                                        .url(dbUrl)
+                                        .username(dbUsername)
+                                        .password(dbPassword)
+                                        .build()
+                                )
+                        )
+                );
+
+        initStandardDesignDocument();
+    }
+
+    public OAuthClientEntity getByClientId(String clientId) {
+        ViewQuery query = createQuery("byClientId");
+        query.setIgnoreNotFound(true);
+        query.key(clientId);
+
+        List<OAuthClientEntity> clients = db.queryView(query, OAuthClientEntity.class);
+        if (clients.size() < 1) {
+            log.warn("No clients found for clientId <{}>.", clientId);
+            return null;
+        } else if (clients.size() > 1) {
+            log.warn("More than one client found ({}) for clientId <{}>.", clients.size(), clientId);
+            return clients.get(0);
+        } else {
+            log.debug("Client found for clientId <{}>", clientId);
+            return clients.get(0);
+        }
+    }
+
+}

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
@@ -73,13 +73,15 @@ public class OAuthClientController {
             }
         } else {
             clientEntity = new OAuthClientEntity();
-            clientEntity.setId(UUID.randomUUID().toString().replace("-", ""));
+
+            // store entity to get a new id
+            repo.add(clientEntity);
+
             clientEntity.setClientId(clientEntity.getId());
             clientEntity.setClientSecret(UUID.randomUUID().toString());
         }
 
         updateClientEntityFromResource(clientEntity, clientResource);
-
         repo.update(clientEntity);
 
         return new ResponseEntity<OAuthClientResource>(

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientController.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver.client.rest;
+
+import com.google.common.collect.Sets;
+
+import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientEntity;
+import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientRepository;
+import org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority;
+
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * This REST controller can be accessed by users having the authority
+ * {@link Sw360GrantedAuthority#ADMIN}. Such users can perform CRUD operations
+ * on the configured {@link OAuthClientResource}s via these REST endpoints.
+ */
+@Controller
+@RequestMapping(path = "/" + OAuthClientController.ENDPOINT_URL)
+@PreAuthorize("hasAuthority('ADMIN')")
+public class OAuthClientController {
+
+    public static final String ENDPOINT_URL = "client-management";
+
+    @Value("${security.oauth2.resource.id}")
+    private String resourceId;
+
+    @Autowired
+    private OAuthClientRepository repo;
+
+    @RequestMapping(method = RequestMethod.GET, path = "")
+    public ResponseEntity<List<OAuthClientResource>> getAllClients() {
+        List<OAuthClientResource> clientResources;
+
+        List<OAuthClientEntity> clients = repo.getAll();
+        if (clients == null) {
+            clients = new ArrayList<>();
+        }
+
+        clientResources = clients.stream().map(OAuthClientResource::new).collect(Collectors.toList());
+
+        return new ResponseEntity<List<OAuthClientResource>>(clientResources, HttpStatus.OK);
+    }
+
+    @RequestMapping(method = RequestMethod.POST, path = "", consumes = "application/json", produces = "application/json")
+    public ResponseEntity<?> createOrUpdateClient(@RequestBody OAuthClientResource clientResource) {
+        OAuthClientEntity clientEntity = null;
+
+        if (StringUtils.isNotEmpty(clientResource.getClientId())) {
+            clientEntity = repo.getByClientId(clientResource.getClientId());
+            if (clientEntity == null) {
+                return new ResponseEntity<String>("No client found for given clientId " + clientResource.getClientId(),
+                        HttpStatus.BAD_REQUEST);
+            }
+        } else {
+            clientEntity = new OAuthClientEntity();
+            clientEntity.setId(UUID.randomUUID().toString().replace("-", ""));
+            clientEntity.setClientId(clientEntity.getId());
+            clientEntity.setClientSecret(UUID.randomUUID().toString());
+        }
+
+        updateClientEntityFromResource(clientEntity, clientResource);
+
+        repo.update(clientEntity);
+
+        return new ResponseEntity<OAuthClientResource>(
+                new OAuthClientResource(repo.getByClientId(clientEntity.getClientId())), HttpStatus.OK);
+    }
+
+    @RequestMapping(method = RequestMethod.DELETE, path = "/{clientId}", consumes = "application/json", produces = "application/json")
+    public ResponseEntity<?> deleteClient(@PathVariable("clientId") String clientId) {
+        OAuthClientEntity clientEntity = null;
+
+        if (StringUtils.isNotEmpty(clientId)) {
+            clientEntity = repo.getByClientId(clientId);
+            if (clientEntity == null) {
+                return new ResponseEntity<String>("No client found for given clientId " + clientId,
+                        HttpStatus.BAD_REQUEST);
+            }
+
+            repo.remove(clientEntity);
+        }
+
+        return new ResponseEntity<OAuthClientResource>(new OAuthClientResource(clientEntity), HttpStatus.OK);
+    }
+
+    private void updateClientEntityFromResource(OAuthClientEntity clientEntity, OAuthClientResource clientResource) {
+        // updateable properties (clientId and clientSecret cannot be changed)
+        clientEntity.setDescription(clientResource.getDescription());
+        clientEntity.setAuthoritiesAsStrings(clientResource.getAuthorities());
+        clientEntity.setScope(clientResource.getScope());
+        clientEntity.setAccessTokenValiditySeconds(clientResource.getAccessTokenValidity());
+        clientEntity.setRefreshTokenValiditySeconds(clientResource.getRefreshTokenValidity());
+
+        // static properties
+        clientEntity.setAuthorizedGrantTypes(
+                Stream.of("client_credentials", "password", "refresh_token").collect(Collectors.toSet()));
+        clientEntity.setAutoApproveScopes(Collections.singleton("true"));
+        clientEntity.setResourceIds(Sets.newHashSet(resourceId));
+        clientEntity.setRegisteredRedirectUri(null);
+    }
+}

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientResource.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientResource.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver.client.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientEntity;
+
+import java.util.Set;
+
+public class OAuthClientResource {
+
+    @JsonProperty("description")
+    private String description;
+
+    @JsonProperty("client_id")
+    private String clientId;
+
+    @JsonProperty("client_secret")
+    private String clientSecret;
+
+    @JsonProperty("authorities")
+    private Set<String> authorities;
+
+    @JsonProperty("scope")
+    private Set<String> scope;
+
+    @JsonProperty("access_token_validity")
+    private Integer accessTokenValidity;
+
+    @JsonProperty("refresh_token_validity")
+    private Integer refreshTokenValidity;
+
+    public OAuthClientResource() {
+        // if needed by frameworks
+    }
+
+    public OAuthClientResource(OAuthClientEntity clientEntity) {
+        this.description = clientEntity.getDescription();
+        this.clientId = clientEntity.getClientId();
+        this.clientSecret = clientEntity.getClientSecret();
+        this.authorities = clientEntity.getAuthoritiesAsStrings();
+        this.scope = clientEntity.getScope();
+        this.accessTokenValidity = clientEntity.getAccessTokenValiditySeconds();
+        this.refreshTokenValidity = clientEntity.getRefreshTokenValiditySeconds();
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public Set<String> getAuthorities() {
+        return authorities;
+    }
+
+    public Set<String> getScope() {
+        return scope;
+    }
+
+    public Integer getAccessTokenValidity() {
+        return accessTokenValidity;
+    }
+
+    public Integer getRefreshTokenValidity() {
+        return refreshTokenValidity;
+    }
+
+}

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/service/Sw360ClientDetailsService.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/client/service/Sw360ClientDetailsService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver.client.service;
+
+import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientRepository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.ClientDetailsService;
+import org.springframework.security.oauth2.provider.ClientRegistrationException;
+
+/**
+ * This is our implementation of a {@link ClientDetailsService} which is able to
+ * use the {@link OAuthClientRepository}.
+ */
+public class Sw360ClientDetailsService implements ClientDetailsService {
+
+    @Autowired
+    private OAuthClientRepository clientRepo;
+
+    @Override
+    public ClientDetails loadClientByClientId(String clientId) throws ClientRegistrationException {
+        ClientDetails client = clientRepo.getByClientId(clientId);
+        if (client == null) {
+            throw new ClientRegistrationException("No client found for clientId " + clientId);
+        }
+
+        return client;
+    }
+
+}

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360AuthorizationServerConfiguration.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360AuthorizationServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017-2019. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -11,12 +11,20 @@
 
 package org.eclipse.sw360.rest.authserver.security;
 
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.rest.authserver.security.basicauth.Sw360LiferayAuthenticationProvider;
+import org.eclipse.sw360.rest.authserver.security.customheaderauth.Sw360CustomHeaderAuthenticationFilter;
+import org.eclipse.sw360.rest.authserver.security.customheaderauth.Sw360CustomHeaderAuthenticationProvider;
+import org.eclipse.sw360.rest.authserver.security.customheaderauth.Sw360CustomHeaderUserDetailsProvider;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.oauth2.config.annotation.configurers.ClientDetailsServiceConfigurer;
 import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerConfigurerAdapter;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
@@ -28,19 +36,35 @@ import org.springframework.security.oauth2.provider.token.store.JwtTokenStore;
 import org.springframework.security.oauth2.provider.token.store.KeyStoreKeyFactory;
 
 import javax.annotation.PostConstruct;
+import javax.servlet.Filter;
+
 import java.io.IOException;
 
-import static org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer.*;
+import static org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer.CONFIG_ACCESS_TOKEN_VALIDITY_SECONDS;
+import static org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer.CONFIG_CLIENT_ID;
+import static org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer.CONFIG_CLIENT_SECRET;
 import static org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority.BASIC;
 import static org.eclipse.sw360.rest.authserver.security.Sw360SecurityEncryptor.decrypt;
 
+/**
+ * This class configures the oauth2 authorization server specialities for the
+ * authorization parts of this server. Only exception is that the
+ * {@link AuthenticationManager} is shared with the standard security and this
+ * one is configured with our oauth2 {@link AuthenticationProvider}s in
+ * {@link Sw360WebSecurityConfiguration}.
+ */
 @Configuration
 @EnableAuthorizationServer
 public class Sw360AuthorizationServerConfiguration extends AuthorizationServerConfigurerAdapter {
-    private final AuthenticationManager authenticationManager;
 
     @Value("${security.oauth2.client.client-id}")
     private String clientId;
+
+    @Value("${security.oauth2.client.client-secret}")
+    private String clientSecret;
+
+    @Value("${security.oauth2.client.scope}")
+    private String[] scopes;
 
     @Value("${security.oauth2.client.authorized-grant-types}")
     private String[] authorizedGrantTypes;
@@ -48,19 +72,11 @@ public class Sw360AuthorizationServerConfiguration extends AuthorizationServerCo
     @Value("${security.oauth2.client.resource-ids}")
     private String resourceIds;
 
-    @Value("${security.oauth2.client.scope}")
-    private String[] scopes;
-
-    @Value("${security.oauth2.client.client-secret}")
-    private String clientSecret;
-
     @Value("${security.oauth2.client.access-token-validity-seconds}")
     private Integer accessTokenValiditySeconds;
 
     @Autowired
-    public Sw360AuthorizationServerConfiguration(AuthenticationManager authenticationManager) {
-        this.authenticationManager = authenticationManager;
-    }
+    private AuthenticationManager authenticationManager;
 
     @PostConstruct
     public void postSw360AuthorizationServerConfiguration() throws IOException {
@@ -78,6 +94,7 @@ public class Sw360AuthorizationServerConfiguration extends AuthorizationServerCo
     @Override
     public void configure(AuthorizationServerEndpointsConfigurer endpoints) throws Exception {
         endpoints
+                .allowedTokenEndpointRequestMethods(HttpMethod.GET, HttpMethod.POST)
                 .tokenStore(tokenStore())
                 .tokenEnhancer(jwtAccessTokenConverter())
                 .authenticationManager(authenticationManager);
@@ -87,7 +104,8 @@ public class Sw360AuthorizationServerConfiguration extends AuthorizationServerCo
     public void configure(AuthorizationServerSecurityConfigurer oauthServer) throws Exception {
         String serverAuthority = BASIC.getAuthority();
         oauthServer.tokenKeyAccess("isAnonymous() || hasAuthority('" + serverAuthority + "')")
-                .checkTokenAccess("hasAuthority('" + serverAuthority + "')");
+                .checkTokenAccess("hasAuthority('" + serverAuthority + "')")
+                .addTokenEndpointAuthenticationFilter(sw360CustomHeaderAuthenticationFilter());
     }
 
     @Override
@@ -114,5 +132,30 @@ public class Sw360AuthorizationServerConfiguration extends AuthorizationServerCo
         JwtAccessTokenConverter jwtAccessTokenConverter = new JwtAccessTokenConverter();
         jwtAccessTokenConverter.setKeyPair(keyStoreKeyFactory.getKeyPair("jwt"));
         return jwtAccessTokenConverter;
+    }
+
+    @Bean
+    protected Filter sw360CustomHeaderAuthenticationFilter() {
+        return new Sw360CustomHeaderAuthenticationFilter();
+    }
+
+    @Bean
+    protected Sw360LiferayAuthenticationProvider sw360LiferayAuthenticationProvider() {
+        return new Sw360LiferayAuthenticationProvider();
+    }
+
+    @Bean
+    protected Sw360CustomHeaderAuthenticationProvider sw360CustomHeaderAuthenticationProvider() {
+        return new Sw360CustomHeaderAuthenticationProvider();
+    }
+
+    @Bean
+    protected Sw360CustomHeaderUserDetailsProvider principalProvider() {
+        return new Sw360CustomHeaderUserDetailsProvider();
+    }
+
+    @Bean
+    protected ThriftClients thriftClients() {
+        return new ThriftClients();
     }
 }

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360AuthorizationServerConfiguration.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360AuthorizationServerConfiguration.java
@@ -80,12 +80,12 @@ public class Sw360AuthorizationServerConfiguration extends AuthorizationServerCo
     @Bean
     public UserDetailsService userDetailsService() {
         return new Sw360UserDetailsService(sw360UserDetailsProvider, sw360ClientDetailsService(),
-                sw360UserAndClientAuthoritiesMerger());
+                sw360UserAndClientAuthoritiesCalculator());
     }
 
     @Bean
-    public Sw360UserAndClientAuthoritiesMerger sw360UserAndClientAuthoritiesMerger() {
-        return new Sw360UserAndClientAuthoritiesMerger();
+    public Sw360GrantedAuthoritiesCalculator sw360UserAndClientAuthoritiesCalculator() {
+        return new Sw360GrantedAuthoritiesCalculator();
     }
 
     @Bean

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360GrantedAuthority.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360GrantedAuthority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017, 2019. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -31,7 +31,13 @@ public enum Sw360GrantedAuthority implements GrantedAuthority {
     * WRITE
     *    authorized with clientName/clientSecret and valid sw360 user with rest api write privileges
     */
-    WRITE;
+    WRITE,
+
+    /*
+     * ADMIN
+     *    authorized and valid sw360 user with auth server administration privileges
+     */
+    ADMIN;
 
     @Override
     public String getAuthority() {

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360UserAndClientAuthoritiesMerger.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360UserAndClientAuthoritiesMerger.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver.security;
+
+import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer;
+
+import org.apache.log4j.Logger;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.provider.ClientDetails;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority.READ;
+
+/**
+ * Class only offers one single but very important method. It can calculate the
+ * correct intersection between user and client authorities! Therefore it has to
+ * know how to map the sw360 user groups on rest authorities. This logic is also
+ * centralized here implicitly.
+ */
+public class Sw360UserAndClientAuthoritiesMerger {
+
+    private final Logger log = Logger.getLogger(this.getClass());
+
+    public List<GrantedAuthority> mergeAuthoritiesOf(User user, ClientDetails clientDetails) {
+        List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+        grantedAuthorities.add(new SimpleGrantedAuthority(READ.getAuthority()));
+
+        if (!Objects.isNull(user)) {
+            if (PermissionUtils.isUserAtLeast(Sw360AuthorizationServer.CONFIG_WRITE_ACCESS_USERGROUP, user)) {
+                grantedAuthorities.add(new SimpleGrantedAuthority(Sw360GrantedAuthority.WRITE.getAuthority()));
+            }
+            if (PermissionUtils.isUserAtLeast(Sw360AuthorizationServer.CONFIG_ADMIN_ACCESS_USERGROUP, user)) {
+                grantedAuthorities.add(new SimpleGrantedAuthority(Sw360GrantedAuthority.ADMIN.getAuthority()));
+            }
+        }
+
+        if (!Objects.isNull(clientDetails)) {
+            Set<String> clientScopes = clientDetails.getScope();
+
+            log.debug("User " + user.email + " has authorities " + grantedAuthorities + " while used client "
+                    + clientDetails.getClientId() + " has scopes " + clientScopes
+                    + ". Setting intersection as granted authorities for access token!");
+
+            grantedAuthorities = grantedAuthorities.stream()
+                    .filter(ga -> clientScopes.contains(ga.toString()))
+                    .collect(Collectors.toList());
+        }
+
+        return grantedAuthorities;
+    }
+}

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360UserDetailsProvider.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360UserDetailsProvider.java
@@ -8,7 +8,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.sw360.rest.authserver.security.customheaderauth;
+package org.eclipse.sw360.rest.authserver.security;
 
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -23,7 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * This user details provider is able to query the sw360 user thrift service to
  * check if a user identified by an email address or an external id exists.
  */
-public class Sw360CustomHeaderUserDetailsProvider {
+public class Sw360UserDetailsProvider {
 
     private final Logger log = Logger.getLogger(this.getClass());
 

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360UserDetailsService.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360UserDetailsService.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver.security;
+
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.authserver.client.service.Sw360ClientDetailsService;
+
+import org.apache.log4j.Logger;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.ClientRegistrationException;
+
+/**
+ * A {@link UserDetailsService} that should only be necessary in the
+ * refresh_token workflow (but therefore needs to be configured for all oauth2
+ * endpoints).
+ */
+public class Sw360UserDetailsService implements UserDetailsService {
+
+    private final Logger log = Logger.getLogger(this.getClass());
+
+    private Sw360UserDetailsProvider userProvider;
+
+    private Sw360ClientDetailsService clientProvider;
+
+    private Sw360UserAndClientAuthoritiesMerger authoritiesMerger;
+
+    public Sw360UserDetailsService(Sw360UserDetailsProvider userProvider, Sw360ClientDetailsService clientProvider,
+            Sw360UserAndClientAuthoritiesMerger authoritiesMerger) {
+        this.userProvider = userProvider;
+        this.clientProvider = clientProvider;
+        this.authoritiesMerger = authoritiesMerger;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        UserDetails result = null;
+
+        Authentication clientAuthentication = SecurityContextHolder.getContext().getAuthentication();
+        if (clientAuthentication != null && clientAuthentication instanceof UsernamePasswordAuthenticationToken) {
+            String clientId = ((org.springframework.security.core.userdetails.User) clientAuthentication.getPrincipal())
+                    .getUsername();
+            try {
+                ClientDetails clientDetails = clientProvider.loadClientByClientId(clientId);
+                log.debug("Sw360ClientDetailsService returned client " + clientDetails + " for id " + clientId
+                        + " from authentication details.");
+
+                User user = userProvider.provideUserDetails(username, null);
+                log.debug("Sw360UserDetailsProvider returned user " + user);
+
+                if (clientDetails != null && user != null) {
+                    result = new org.springframework.security.core.userdetails.User(user.getEmail(),
+                            "PreAuthenticatedPassword", authoritiesMerger.mergeAuthoritiesOf(user, clientDetails));
+                }
+            } catch (ClientRegistrationException e) {
+                log.warn("No valid client for id " + clientId + " could be found. It is possible that it is "
+                        + "locked, expired, disabled, or invalid for any other reason.");
+                throw new UsernameNotFoundException("We cannot provide UserDetails for an invalid client: ", e);
+            }
+        } else {
+            log.warn("Called in unwanted case: " + clientAuthentication);
+        }
+
+        if (result != null) {
+            return result;
+        } else {
+            throw new UsernameNotFoundException("No user with username " + username + " found in sw360 users.");
+        }
+    }
+
+}

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360UserDetailsService.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360UserDetailsService.java
@@ -36,13 +36,13 @@ public class Sw360UserDetailsService implements UserDetailsService {
 
     private Sw360ClientDetailsService clientProvider;
 
-    private Sw360UserAndClientAuthoritiesMerger authoritiesMerger;
+    private Sw360GrantedAuthoritiesCalculator authoritiesCalculator;
 
     public Sw360UserDetailsService(Sw360UserDetailsProvider userProvider, Sw360ClientDetailsService clientProvider,
-            Sw360UserAndClientAuthoritiesMerger authoritiesMerger) {
+            Sw360GrantedAuthoritiesCalculator authoritiesMerger) {
         this.userProvider = userProvider;
         this.clientProvider = clientProvider;
-        this.authoritiesMerger = authoritiesMerger;
+        this.authoritiesCalculator = authoritiesMerger;
     }
 
     @Override
@@ -63,7 +63,7 @@ public class Sw360UserDetailsService implements UserDetailsService {
 
                 if (clientDetails != null && user != null) {
                     result = new org.springframework.security.core.userdetails.User(user.getEmail(),
-                            "PreAuthenticatedPassword", authoritiesMerger.mergeAuthoritiesOf(user, clientDetails));
+                            "PreAuthenticatedPassword", authoritiesCalculator.mergedAuthoritiesOf(user, clientDetails));
                 }
             } catch (ClientRegistrationException e) {
                 log.warn("No valid client for id " + clientId + " could be found. It is possible that it is "

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360WebSecurityConfiguration.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/Sw360WebSecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017, 2019. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -11,35 +11,68 @@
 
 package org.eclipse.sw360.rest.authserver.security;
 
+import org.eclipse.sw360.rest.authserver.security.basicauth.Sw360LiferayAuthenticationProvider;
+import org.eclipse.sw360.rest.authserver.security.customheaderauth.Sw360CustomHeaderAuthenticationProvider;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.AuthenticationManagerConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
+/**
+ * This class configures the standard spring security for this server. Only
+ * exception is that the {@link AuthenticationManager} is shared with the oauth2
+ * security and this one is configured with the oauth2
+ * {@link AuthenticationProvider}s from
+ * {@link Sw360AuthorizationServerConfiguration}.
+ */
 @Configuration
 @EnableWebSecurity
 public class Sw360WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
-    private final Sw360AuthenticationProvider sw360AuthenticationProvider;
+    @Autowired
+    private Sw360LiferayAuthenticationProvider sw360LiferayAuthenticationProvider;
 
-    public Sw360WebSecurityConfiguration(Sw360AuthenticationProvider sw360AuthenticationProvider) {
-        this.sw360AuthenticationProvider = sw360AuthenticationProvider;
-    }
-
-    @Override
-    protected void configure(AuthenticationManagerBuilder authenticationManagerBuilder) {
-        authenticationManagerBuilder.authenticationProvider(this.sw360AuthenticationProvider);
-    }
+    @Autowired
+    private Sw360CustomHeaderAuthenticationProvider sw360CustomHeaderAuthenticationProvider;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
                 .authorizeRequests()
-                .antMatchers(HttpMethod.OPTIONS).permitAll() // some JS frameworks make HTTP OPTIONS requests
-                .anyRequest().authenticated()
-                .and().httpBasic()
-                .and().csrf().disable();
+                .antMatchers(HttpMethod.OPTIONS)
+                    .permitAll() // some JS frameworks make HTTP OPTIONS requests
+                .anyRequest()
+                    .authenticated()
+                .and()
+                    .httpBasic()
+                .and()
+                    .csrf().disable();
     }
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder authenticationManagerBuilder) {
+        authenticationManagerBuilder
+                .authenticationProvider(sw360LiferayAuthenticationProvider)
+                .authenticationProvider(sw360CustomHeaderAuthenticationProvider);
+    }
+
+    /**
+     * We have to publish our configured authentication manager because otherwise
+     * some boot default manager will be populated from
+     * {@link AuthenticationManagerConfiguration}.
+     */
+    @Bean(name = "authenticationManager")
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
 }

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/basicauth/Sw360LiferayAuthenticationProvider.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/basicauth/Sw360LiferayAuthenticationProvider.java
@@ -11,7 +11,7 @@
 package org.eclipse.sw360.rest.authserver.security.basicauth;
 
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.eclipse.sw360.rest.authserver.security.Sw360UserAndClientAuthoritiesMerger;
+import org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthoritiesCalculator;
 import org.eclipse.sw360.rest.authserver.security.Sw360UserDetailsProvider;
 
 import org.apache.commons.lang.StringUtils;
@@ -43,7 +43,7 @@ import java.util.Objects;
  * In addition it supports the special password grant flow of spring in
  * retrieving information about the oauth client that has initiated the request
  * and cutting the user authorities to those of the client in such case by using
- * the {@link Sw360UserAndClientAuthoritiesMerger}.
+ * the {@link Sw360GrantedAuthoritiesCalculator}.
  */
 public class Sw360LiferayAuthenticationProvider implements AuthenticationProvider {
 
@@ -67,7 +67,7 @@ public class Sw360LiferayAuthenticationProvider implements AuthenticationProvide
     private Sw360UserDetailsProvider sw360CustomHeaderUserDetailsProvider;
 
     @Autowired
-    private Sw360UserAndClientAuthoritiesMerger sw360UserAndClientAuthoritiesMerger;
+    private Sw360GrantedAuthoritiesCalculator sw360UserAndClientAuthoritiesCalculator;
 
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
@@ -85,7 +85,7 @@ public class Sw360LiferayAuthenticationProvider implements AuthenticationProvide
                 if (!Objects.isNull(user)) {
                     ClientDetails clientDetails = extractClient(authentication);
                     return new UsernamePasswordAuthenticationToken(userIdentifier, password,
-                            sw360UserAndClientAuthoritiesMerger.mergeAuthoritiesOf(user, clientDetails));
+                            sw360UserAndClientAuthoritiesCalculator.mergedAuthoritiesOf(user, clientDetails));
                 }
             }
         }

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationFilter.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationFilter.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver.security.customheaderauth;
+
+import org.eclipse.sw360.datahandler.thrift.users.User;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.common.util.OAuth2Utils;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.TokenRequest;
+import org.springframework.security.oauth2.provider.password.ResourceOwnerPasswordTokenGranter;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+
+import java.io.IOException;
+
+/**
+ * Grant type 'password' for OAuth has an interesting implementation in spring
+ * security: The user for BasicAuth is the client with its secret. After that
+ * one has been authenticated via the ClientDetailsStore (currently inMemory,
+ * later from CouchDB), the method
+ * org.springframework.security.oauth2.provider.password.ResourceOwnerPasswordTokenGranter.getOAuth2Authentication(ClientDetails,
+ * TokenRequest) is exchanging the current {@link Authentication} object and
+ * setting a new one from the credentials given via request params "username"
+ * and "password". These credentials are validated again as well by an
+ * {@link AuthenticationManager} that can contain different
+ * {@link AuthenticationProvider}s.
+ *
+ * So what we are doing for our custom header flow is to retrieve the client
+ * information from request parameters and expect an already authenticated user
+ * id in a configurable header. We then create an {@link Authentication} object
+ * for the client and set the request params for the user from the header. In
+ * this way the standard oauth workflow can take place. We just need to add a
+ * {@link Sw360CustomHeaderAuthenticationProvider} that only uses the given
+ * username from the proxy and another custom request parameter to know that the
+ * user has already been authenticated and create the correct authentication
+ * object from these information.
+ *
+ * It is important that the authenticating webserver is removing all configured
+ * headers for this workflow that might already be set by a client (as usual).
+ * These are the ones given in the configuration file.
+ */
+public class Sw360CustomHeaderAuthenticationFilter extends GenericFilterBean {
+
+    private final Logger log = Logger.getLogger(this.getClass());
+
+    /**
+     * Has to match username extraction in
+     * {@link ResourceOwnerPasswordTokenGranter#getOAuth2Authentication(ClientDetails, TokenRequest)}
+     */
+    private static final String PARAMETER_NAME_USERNAME = "username";
+
+    /**
+     * Not available as constant in {@link OAuth2Utils}...
+     */
+    private static final String PARAMETER_NAME_CLIENT_SECRET = "client_secret";
+
+    @Value("${security.customheader.headername.email:#{null}}")
+    private String customHeaderHeadernameEmail;
+
+    @Value("${security.customheader.headername.extid:#{null}}")
+    private String customHeaderHeadernameExtid;
+
+    @Value("${security.customheader.headername.intermediateauthstore:#{null}}")
+    private String customHeaderHeadernameIntermediateAuthStore;
+
+    private boolean active;
+
+    @Autowired
+    private Sw360CustomHeaderUserDetailsProvider sw360CustomHeaderUserDetailsProvider;
+
+    @PostConstruct
+    public void postSw360CustomHeaderAuthenticationFilterConstruction() {
+        if (StringUtils.isEmpty(customHeaderHeadernameEmail) || StringUtils.isEmpty(customHeaderHeadernameExtid)
+                || StringUtils.isEmpty(customHeaderHeadernameIntermediateAuthStore)) {
+            log.warn("Filter is NOT active! Some configuration is missing. Needed config keys:\n"
+                    + "- security.customheader.headername.email\n"
+                    + "- security.customheader.headername.extid\n"
+                    + "- security.customheader.headername.intermediateauthstore");
+            active = false;
+        } else {
+            log.info("Filter is active!");
+            active = true;
+        }
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        if (active) {
+            CustomHeaderAuthRequestDetails requestDetails = extractRequestDetails((HttpServletRequest) request);
+            if (canAuthenticate(requestDetails)) {
+
+                ServletRequest wrappedRequest = doAuthenticate((HttpServletRequest) request, requestDetails);
+                if (wrappedRequest != null) {
+                    chain.doFilter(wrappedRequest, response);
+                    return;
+                }
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private CustomHeaderAuthRequestDetails extractRequestDetails(HttpServletRequest request) {
+        CustomHeaderAuthRequestDetails result = new CustomHeaderAuthRequestDetails();
+
+        result.currentUser = SecurityContextHolder.getContext().getAuthentication();
+        result.customHeaderEmail = StringUtils.defaultIfEmpty(request.getHeader(customHeaderHeadernameEmail), "");
+        result.customHeaderExtId = StringUtils.defaultIfEmpty(request.getHeader(customHeaderHeadernameExtid), "");
+        result.customParamClientId = request.getParameter(OAuth2Utils.CLIENT_ID);
+        result.customParamClientSecret = request.getParameter(PARAMETER_NAME_CLIENT_SECRET);
+        result.grantType = request.getParameter(OAuth2Utils.GRANT_TYPE);
+
+        return result;
+    }
+
+    private boolean canAuthenticate(CustomHeaderAuthRequestDetails requestDetails) {
+        // we want to be active only for grant type 'password' requests
+        if (!requestDetails.grantType.equals("password")) {
+            log.debug("Cannot create authentication object because grant type is not password!");
+            return false;
+        }
+
+        // if there is already authentication information available, do nothing
+        if (requestDetails.currentUser != null) {
+            log.debug("Cannot create authentication object because there is already one!");
+            return false;
+        }
+
+        // without any auth header, this authentication makes no sense
+        if (StringUtils.isEmpty(requestDetails.customHeaderEmail)
+                && StringUtils.isEmpty(requestDetails.customHeaderExtId)) {
+            log.debug("Cannot create authentication object because user identifying headers from proxy are missing!");
+            return false;
+        }
+
+        // without client info, this authentication makes no sense
+        if (StringUtils.isEmpty(requestDetails.customParamClientId)
+                || StringUtils.isEmpty(requestDetails.customParamClientSecret)) {
+            log.debug("Cannot create authentication object because client identifying request parameters are missing!");
+            return false;
+        }
+
+        return true;
+    }
+
+    private ServletRequest doAuthenticate(HttpServletRequest request, CustomHeaderAuthRequestDetails requestDetails) {
+        Sw360CustomHeaderServletRequestWrapper requestResult = null;
+        Authentication authResult = null;
+
+        User userDetails = sw360CustomHeaderUserDetailsProvider.provideUserDetails(requestDetails.customHeaderEmail, requestDetails.customHeaderExtId);
+        if (userDetails != null) {
+
+            // first create our request wrapper to be able to add params
+            requestResult = new Sw360CustomHeaderServletRequestWrapper(request);
+            requestResult.addParameter(PARAMETER_NAME_USERNAME, new String[] { userDetails.getEmail() });
+            requestResult.addParameter(customHeaderHeadernameIntermediateAuthStore,
+                    new String[] { userDetails.getExternalid() });
+
+            // then create authentication and add to security context
+            authResult = new UsernamePasswordAuthenticationToken(requestDetails.customParamClientId,
+                    requestDetails.customParamClientSecret);
+            SecurityContextHolder.getContext().setAuthentication(authResult);
+
+            log.debug("Created authentication object for client " + requestDetails.customParamClientId
+                    + " and added username " + userDetails.getEmail()
+                    + " as pre authenticated user to the request parameters.");
+        }
+
+        return requestResult;
+    }
+
+    private static class CustomHeaderAuthRequestDetails {
+        public Authentication currentUser;
+        public String customHeaderEmail;
+        public String customHeaderExtId;
+        public String customParamClientId;
+        public String customParamClientSecret;
+        public String grantType;
+    }
+}

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationFilter.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationFilter.java
@@ -90,6 +90,9 @@ public class Sw360CustomHeaderAuthenticationFilter extends GenericFilterBean {
     @Value("${security.customheader.headername.intermediateauthstore:#{null}}")
     private String customHeaderHeadernameIntermediateAuthStore;
 
+    @Value("${security.customheader.headername.enabled:#{false}}")
+    private boolean customHeaderEnabled;
+
     private boolean active;
 
     @Autowired
@@ -97,16 +100,29 @@ public class Sw360CustomHeaderAuthenticationFilter extends GenericFilterBean {
 
     @PostConstruct
     public void postSw360CustomHeaderAuthenticationFilterConstruction() {
+        if(!customHeaderEnabled) {
+            active = false;
+            log.info("AuthenticationFilter is NOT active!");
+            return;
+        }
+
+        log.info("NOTE: Custom Header Authentication is enabled with the following configuration: \n" +
+            "  - email header      : " + customHeaderHeadernameEmail + "\n" +
+            "  - external id header: " + customHeaderHeadernameExtid + "\n" +
+            "  - internal header   : " + customHeaderHeadernameIntermediateAuthStore + "\n" +
+            "!!! BE SURE THAT THESE HEADRES ARE FILTERED BY YOUR PROXY! EACH CLIENT THAT IS ABLE TO SEND THESE HEADERS CAN LOG IN AS ANY PRINCIPAL !!!"
+        );
+
         if (StringUtils.isEmpty(customHeaderHeadernameEmail) || StringUtils.isEmpty(customHeaderHeadernameExtid)
                 || StringUtils.isEmpty(customHeaderHeadernameIntermediateAuthStore)) {
-            log.info("Filter is NOT active! If you want to activate it, please provide a complete configuration. "
+            log.info("AuthenticationFilter is NOT active due to incomplete configuration. "
                     + "Needed config keys:\n"
                     + "- security.customheader.headername.email\n"
                     + "- security.customheader.headername.extid\n"
                     + "- security.customheader.headername.intermediateauthstore");
             active = false;
         } else {
-            log.info("Filter is active!");
+            log.info("AuthenticationFilter is active!");
             active = true;
         }
     }

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationProvider.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationProvider.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver.security.customheaderauth;
+
+import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer;
+import org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.common.util.OAuth2Utils;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.ClientDetailsService;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+import javax.annotation.PostConstruct;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * This {@link AuthenticationProvider} is specialised on requests where the
+ * {@link Sw360CustomHeaderAuthenticationFilter} made sure that the user has
+ * already been authenticated by some external proxy that set some headers to
+ * let us know about the authentication.
+ *
+ * In addition it is special because it calculates the granted authorities for
+ * the user depending on the user's authorities given by his groups and the
+ * client's scopes. The result will be the intersection between these two lists.
+ */
+public class Sw360CustomHeaderAuthenticationProvider implements AuthenticationProvider {
+
+    private final Logger log = Logger.getLogger(this.getClass());
+
+    @Value("${security.customheader.headername.intermediateauthstore:#{null}}")
+    private String customHeaderHeadernameIntermediateAuthStore;
+
+    private boolean active;
+
+    @Autowired
+    private Sw360CustomHeaderUserDetailsProvider sw360CustomHeaderUserDetailsProvider;
+
+    @Autowired
+    private ClientDetailsService clientDetailsService;
+
+    @PostConstruct
+    public void postSw360CustomHeaderAuthenticationProviderConstruction() {
+        if (StringUtils.isEmpty(customHeaderHeadernameIntermediateAuthStore)) {
+            log.warn("AuthenticationProvider is NOT active! Some configuration is missing. Needed config keys:\n"
+                    + "- security.customheader.headername.intermediateauthstore");
+            active = false;
+        } else {
+            log.info("AuthenticationProvider is active!");
+            active = true;
+        }
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        // check if the marker header of our filter is available
+        if (authentication.getDetails() instanceof Map<?, ?>
+                && ((Map<?, ?>) authentication.getDetails()).containsKey(customHeaderHeadernameIntermediateAuthStore)) {
+            Map<?, ?> authDetails = ((Map<?, ?>) authentication.getDetails());
+
+            // get user details
+            String email = (String) authentication.getPrincipal();
+            String externalId = (String) authDetails.get(customHeaderHeadernameIntermediateAuthStore);
+            User userDetails = sw360CustomHeaderUserDetailsProvider.provideUserDetails(email, externalId);
+
+            // calculate user authorities
+            List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+            grantedAuthorities.add(new SimpleGrantedAuthority(Sw360GrantedAuthority.READ.getAuthority()));
+            if (userDetails != null && PermissionUtils
+                    .isUserAtLeast(Sw360AuthorizationServer.CONFIG_WRITE_ACCESS_USERGROUP, userDetails)) {
+                grantedAuthorities.add(new SimpleGrantedAuthority(Sw360GrantedAuthority.WRITE.getAuthority()));
+            }
+
+            // keep only intersection of user authorities and client scopes
+            String clientId = (String) authDetails.get(OAuth2Utils.CLIENT_ID);
+            ClientDetails clientDetails = clientDetailsService.loadClientByClientId(clientId);
+            Set<String> clientScopes = clientDetails.getScope();
+
+            log.debug("User " + email + " has authorities " + grantedAuthorities + " while used client " + clientId
+                    + " has scopes " + clientScopes
+                    + ". Setting intersection as granted authorities for access token!");
+
+            grantedAuthorities = grantedAuthorities.stream().map(GrantedAuthority::toString)
+                    .filter(gas -> clientScopes.contains(gas))
+                    .map(gas -> Sw360GrantedAuthority.valueOf(gas)).collect(Collectors.toList());
+
+            return new PreAuthenticatedAuthenticationToken(email, "N/A", grantedAuthorities);
+        }
+        return null;
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return active && authentication.equals(UsernamePasswordAuthenticationToken.class);
+    }
+
+}

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationProvider.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderAuthenticationProvider.java
@@ -14,6 +14,8 @@ import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer;
 import org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority;
+import org.eclipse.sw360.rest.authserver.security.Sw360UserAndClientAuthoritiesMerger;
+import org.eclipse.sw360.rest.authserver.security.Sw360UserDetailsProvider;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -28,15 +30,17 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.common.util.OAuth2Utils;
 import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.ClientDetailsService;
+import org.springframework.security.oauth2.provider.ClientRegistrationException;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 
 import javax.annotation.PostConstruct;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
- * This {@link AuthenticationProvider} is specialised on requests where the
+ * This {@link AuthenticationProvider} is specialized on requests where the
  * {@link Sw360CustomHeaderAuthenticationFilter} made sure that the user has
  * already been authenticated by some external proxy that set some headers to
  * let us know about the authentication.
@@ -44,6 +48,9 @@ import java.util.stream.Collectors;
  * In addition it is special because it calculates the granted authorities for
  * the user depending on the user's authorities given by his groups and the
  * client's scopes. The result will be the intersection between these two lists.
+ * Of course this is only done for an oauth request and not for normal ones
+ * (that have nothing to do with clients). And in fact he uses for this task the
+ * {@link Sw360UserAndClientAuthoritiesMerger}.
  */
 public class Sw360CustomHeaderAuthenticationProvider implements AuthenticationProvider {
 
@@ -52,13 +59,16 @@ public class Sw360CustomHeaderAuthenticationProvider implements AuthenticationPr
     @Value("${security.customheader.headername.intermediateauthstore:#{null}}")
     private String customHeaderHeadernameIntermediateAuthStore;
 
-    private boolean active;
-
     @Autowired
-    private Sw360CustomHeaderUserDetailsProvider sw360CustomHeaderUserDetailsProvider;
+    private Sw360UserDetailsProvider sw360CustomHeaderUserDetailsProvider;
 
     @Autowired
     private ClientDetailsService clientDetailsService;
+
+    @Autowired
+    private Sw360UserAndClientAuthoritiesMerger sw360UserAndClientAuthoritiesMerger;
+
+    private boolean active;
 
     @PostConstruct
     public void postSw360CustomHeaderAuthenticationProviderConstruction() {
@@ -73,6 +83,12 @@ public class Sw360CustomHeaderAuthenticationProvider implements AuthenticationPr
     }
 
     @Override
+    public boolean supports(Class<?> authentication) {
+        return active
+                && (authentication.equals(UsernamePasswordAuthenticationToken.class) || authentication.equals(PreAuthenticatedAuthenticationToken.class));
+    }
+
+    @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         // check if the marker header of our filter is available
         if (authentication.getDetails() instanceof Map<?, ?>
@@ -81,38 +97,82 @@ public class Sw360CustomHeaderAuthenticationProvider implements AuthenticationPr
 
             // get user details
             String email = (String) authentication.getPrincipal();
-            String externalId = (String) authDetails.get(customHeaderHeadernameIntermediateAuthStore);
+            Object externalIds = authDetails.get(customHeaderHeadernameIntermediateAuthStore);
+            String externalId;
+            if (externalIds != null && externalIds instanceof String[]) {
+                externalId = ((String[]) externalIds)[0];
+            } else {
+                externalId = (String) externalIds;
+            }
             User userDetails = sw360CustomHeaderUserDetailsProvider.provideUserDetails(email, externalId);
 
-            // calculate user authorities
             List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
-            grantedAuthorities.add(new SimpleGrantedAuthority(Sw360GrantedAuthority.READ.getAuthority()));
-            if (userDetails != null && PermissionUtils
-                    .isUserAtLeast(Sw360AuthorizationServer.CONFIG_WRITE_ACCESS_USERGROUP, userDetails)) {
-                grantedAuthorities.add(new SimpleGrantedAuthority(Sw360GrantedAuthority.WRITE.getAuthority()));
+            if (authentication instanceof UsernamePasswordAuthenticationToken) {
+                // if we have a UsernamePasswordAuthenticationToken, then we have an OAuth
+                // request in which case we only want to keep intersection of user authorities
+                // and client scopes
+                grantedAuthorities = handleOAuthAuthentication(authDetails, userDetails);
+            } else {
+                // if we have a PreAuthenticationToken (no other case possible, see supports()
+                // method), then we have a normal REST request in which case we can grant all
+                // authorities calculated from the user profile, so calculate user authorities
+                grantedAuthorities = handleRestAuthentication(email, userDetails);
             }
-
-            // keep only intersection of user authorities and client scopes
-            String clientId = (String) authDetails.get(OAuth2Utils.CLIENT_ID);
-            ClientDetails clientDetails = clientDetailsService.loadClientByClientId(clientId);
-            Set<String> clientScopes = clientDetails.getScope();
-
-            log.debug("User " + email + " has authorities " + grantedAuthorities + " while used client " + clientId
-                    + " has scopes " + clientScopes
-                    + ". Setting intersection as granted authorities for access token!");
-
-            grantedAuthorities = grantedAuthorities.stream().map(GrantedAuthority::toString)
-                    .filter(gas -> clientScopes.contains(gas))
-                    .map(gas -> Sw360GrantedAuthority.valueOf(gas)).collect(Collectors.toList());
 
             return new PreAuthenticatedAuthenticationToken(email, "N/A", grantedAuthorities);
         }
+
         return null;
     }
 
-    @Override
-    public boolean supports(Class<?> authentication) {
-        return active && authentication.equals(UsernamePasswordAuthenticationToken.class);
+    private List<GrantedAuthority> handleOAuthAuthentication(Map<?, ?> authDetails, User userDetails) {
+        List<GrantedAuthority> grantedAuthorities;
+
+        Object clientIds = authDetails.get(OAuth2Utils.CLIENT_ID);
+        String clientId;
+        if (clientIds != null && clientIds instanceof String[]) {
+            clientId = ((String[]) clientIds)[0];
+        } else {
+            clientId = (String) clientIds;
+        }
+
+        ClientDetails clientDetails = null;
+        try {
+            clientDetails = clientDetailsService.loadClientByClientId(clientId);
+
+            log.debug("Found client " + clientDetails + " for id " + clientId + " in authentication details.");
+
+            grantedAuthorities = sw360UserAndClientAuthoritiesMerger.mergeAuthoritiesOf(userDetails,
+                    clientDetails);
+        } catch (ClientRegistrationException e) {
+            log.warn("No valid client for id " + clientId + " could be found. It is possible that it is locked,"
+                    + " expired, disabled, or invalid for any other reason. So absolutely no authorities granted!");
+
+            grantedAuthorities = new ArrayList<>();
+        }
+
+        return grantedAuthorities;
+    }
+
+    private List<GrantedAuthority> handleRestAuthentication(String email, User userDetails) {
+        List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+        grantedAuthorities.add(new SimpleGrantedAuthority(Sw360GrantedAuthority.READ.getAuthority()));
+
+        if (userDetails != null) {
+            if (PermissionUtils.isUserAtLeast(Sw360AuthorizationServer.CONFIG_WRITE_ACCESS_USERGROUP,
+                    userDetails)) {
+                grantedAuthorities.add(new SimpleGrantedAuthority(Sw360GrantedAuthority.WRITE.getAuthority()));
+            }
+            if (PermissionUtils.isUserAtLeast(Sw360AuthorizationServer.CONFIG_ADMIN_ACCESS_USERGROUP,
+                    userDetails)) {
+                grantedAuthorities.add(new SimpleGrantedAuthority(Sw360GrantedAuthority.ADMIN.getAuthority()));
+            }
+        }
+
+        log.debug("User " + email + " has authorities " + grantedAuthorities
+                + " which he will be granted during this request!");
+
+        return grantedAuthorities;
     }
 
 }

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderServletRequestWrapper.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderServletRequestWrapper.java
@@ -17,9 +17,7 @@ import org.springframework.security.web.savedrequest.Enumerator;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * This {@link HttpServletRequestWrapper} is able to extend the parameter list
@@ -32,7 +30,10 @@ import java.util.Map;
  * {@link Sw360CustomHeaderAuthenticationProvider} from our
  * {@link Sw360CustomHeaderAuthenticationFilter} which is only possible via
  * request params that are added by the standard flow to the authentication
- * details in {@link Authentication#getDetails()}.
+ * details in {@link Authentication#getDetails()}. This additional parameters
+ * come in handy for normal pre-authenticated requests as well.
+ *
+ * Think about if this class should return only unmodifiable values.
  */
 public class Sw360CustomHeaderServletRequestWrapper extends HttpServletRequestWrapper {
 
@@ -69,14 +70,11 @@ public class Sw360CustomHeaderServletRequestWrapper extends HttpServletRequestWr
 
     @Override
     public String getParameter(String name) {
-        String result = null;
         String[] allValues = addableParameterMap.get(name);
 
-        if (allValues != null && allValues.length > 0) {
-            result = allValues[0];
-        }
-
-        return result;
+        return Arrays.stream(allValues)
+                .findFirst()
+                .orElse(null);
     }
 
 }

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderServletRequestWrapper.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderServletRequestWrapper.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver.security.customheaderauth;
+
+import org.apache.log4j.Logger;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.savedrequest.Enumerator;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This {@link HttpServletRequestWrapper} is able to extend the parameter list
+ * of the wrapped request object (which is not possible on standard
+ * {@link HttpServletRequest}s because normally one wants to have exactly the
+ * request params as they are coming from the client / proxy). This is necessary
+ * because we want to be part of the standard oauth 2 workflow of spring with
+ * our custom header pre authentication chain. And in this workflow we need to
+ * pass additional information to our
+ * {@link Sw360CustomHeaderAuthenticationProvider} from our
+ * {@link Sw360CustomHeaderAuthenticationFilter} which is only possible via
+ * request params that are added by the standard flow to the authentication
+ * details in {@link Authentication#getDetails()}.
+ */
+public class Sw360CustomHeaderServletRequestWrapper extends HttpServletRequestWrapper {
+
+    private final Logger log = Logger.getLogger(this.getClass());
+
+    private final Map<String, String[]> addableParameterMap;
+
+    public Sw360CustomHeaderServletRequestWrapper(HttpServletRequest request) {
+        super(request);
+
+        addableParameterMap = new HashMap<String, String[]>(request.getParameterMap());
+    }
+
+    public void addParameter(String name, String[] values) {
+        log.debug("Added parameter with key " + name + " to parameter map of request " + getRequest());
+
+        addableParameterMap.put(name, values);
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        return addableParameterMap;
+    }
+
+    @Override
+    public Enumeration<String> getParameterNames() {
+        return new Enumerator<>(addableParameterMap.keySet());
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        return addableParameterMap.get(name);
+    }
+
+    @Override
+    public String getParameter(String name) {
+        String result = null;
+        String[] allValues = addableParameterMap.get(name);
+
+        if (allValues != null && allValues.length > 0) {
+            result = allValues[0];
+        }
+
+        return result;
+    }
+
+}

--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderUserDetailsProvider.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/customheaderauth/Sw360CustomHeaderUserDetailsProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver.security.customheaderauth;
+
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserService;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * This user details provider is able to query the sw360 user thrift service to
+ * check if a user identified by an email address or an external id exists.
+ */
+public class Sw360CustomHeaderUserDetailsProvider {
+
+    private final Logger log = Logger.getLogger(this.getClass());
+
+    @Autowired
+    private ThriftClients thriftClients;
+
+    public User provideUserDetails(String email, String extId) {
+        User result = null;
+
+        log.debug("Looking up user with email <" + email + "> and external id <" + extId + ">.");
+
+        User user = getUserByEmailOrExternalId(email, extId);
+        if (user != null) {
+            log.debug("Found user with email <" + email + "> and external id <" + extId + "> in UserService.");
+            result = user;
+        } else {
+            log.warn("No user found with email <" + email + "> and external id <" + extId + "> in UserService.");
+        }
+
+        return result;
+    }
+
+    private User getUserByEmailOrExternalId(String email, String externalId) {
+        // client should be put into threadlocal some day after this pattern proofed
+        // itself
+        UserService.Iface client = thriftClients.makeUserClient();
+        try {
+            if (StringUtils.isNotEmpty(email) || StringUtils.isNotEmpty(externalId)) {
+                return client.getByEmailOrExternalId(email, externalId);
+            }
+        } catch (TException e) {
+            // do nothing
+        }
+        return null;
+    }
+}

--- a/rest/authorization-server/src/main/resources/application-dev.yml
+++ b/rest/authorization-server/src/main/resources/application-dev.yml
@@ -1,5 +1,5 @@
 #
-# Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+# Copyright Siemens AG, 2017, 2019. Part of the SW360 Portal Project.
 #
 # All rights reserved. This configuration file is provided to you under the
 # terms and conditions of the Eclipse Distribution License v1.0 which
@@ -7,11 +7,9 @@
 # http://www.eclipse.org/org/documents/edl-v10.php
 #
 
-sw360:
-  test-user-id: mockedserviceuser@sw360.org
-  test-user-password: sw360-admin-password
+couchdb:
+  database: sw360_test_oauthclients
 
-security:
-  oauth2:
-    client:
-      scope: READ
+sw360:
+  test-user-id: mockedserviceadminuser@sw360.org
+  test-user-password: sw360-admin-password

--- a/rest/authorization-server/src/main/resources/application-dev.yml
+++ b/rest/authorization-server/src/main/resources/application-dev.yml
@@ -8,5 +8,10 @@
 #
 
 sw360:
-  test-user-id: admin@sw360.org
+  test-user-id: mockedserviceuser@sw360.org
   test-user-password: sw360-admin-password
+
+security:
+  oauth2:
+    client:
+      scope: READ

--- a/rest/authorization-server/src/main/resources/application.yml
+++ b/rest/authorization-server/src/main/resources/application.yml
@@ -17,13 +17,22 @@ sw360:
     allowed-origin: ${SW360_CORS_ALLOWED_ORIGIN:#{null}}
 
 security:
+  customheader:
+    headername:
+      # Attention: please make sure that the proxy is removing there headers
+      # if they are coming from anywhere else then the authentication server
+      intermediateauthstore: custom-header-auth-marker
+      email: authenticated-email
+      extid: authenticated-extid
+      # also available - at least in saml pre auth - are "givenname", "surname" and "department"
+
   oauth2:
     resource:
       id: sw360-REST-API
     client:
       client-id: trusted-sw360-client
       client-secret: sw360-secret
+      scope: BASIC, READ, WRITE
       resource-ids: sw360-REST-API
       authorized-grant-types: client_credentials,password
       access-token-validity-seconds: 3600
-      scope: all

--- a/rest/authorization-server/src/main/resources/application.yml
+++ b/rest/authorization-server/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 #
-# Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+# Copyright Siemens AG, 2017, 2019. Part of the SW360 Portal Project.
 #
 # All rights reserved. This configuration file is provided to you under the
 # terms and conditions of the Eclipse Distribution License v1.0 which
@@ -9,6 +9,18 @@
 
 server:
   port: 8090
+
+couchdb:
+  url: http://sw360couchdb:5984
+  database: sw360oauthclients
+  # if your couchdb does not use authentication, pls just don't use the settings for username and password
+  #username:
+  #password:
+
+spring:
+  jackson:
+    serialization:
+      indent_output: true
 
 sw360:
   sw360-portal-server-url: ${SW360_PORTAL_SERVER_URL:http://127.0.0.1:8080}
@@ -29,10 +41,3 @@ security:
   oauth2:
     resource:
       id: sw360-REST-API
-    client:
-      client-id: trusted-sw360-client
-      client-secret: sw360-secret
-      scope: BASIC, READ, WRITE
-      resource-ids: sw360-REST-API
-      authorized-grant-types: client_credentials,password
-      access-token-validity-seconds: 3600

--- a/rest/authorization-server/src/main/resources/application.yml
+++ b/rest/authorization-server/src/main/resources/application.yml
@@ -11,7 +11,7 @@ server:
   port: 8090
 
 couchdb:
-  url: http://sw360couchdb:5984
+  url: http://localhost:5984
   database: sw360oauthclients
   # if your couchdb does not use authentication, pls just don't use the settings for username and password
   #username:
@@ -31,6 +31,8 @@ sw360:
 security:
   customheader:
     headername:
+      # You have to enable authorization by headers explicitly here
+      enabled: false
       # Attention: please make sure that the proxy is removing there headers
       # if they are coming from anywhere else then the authentication server
       intermediateauthstore: custom-header-auth-marker

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsBasicAuthTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsBasicAuthTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver;
+
+import org.junit.Before;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+
+import java.io.IOException;
+
+/**
+ * A POST request for an access token with grant type 'client_credentials' and
+ * basic auth should be possible.
+ */
+public class GrantTypeClientCredentialsBasicAuthTest extends GrantTypeClientCredentialsTestBase {
+
+    @Before
+    public void before() throws IOException {
+        String url = "http://localhost:" + String.valueOf(port) + "/oauth/token?grant_type=" + PARAMETER_GRANT_TYPE
+                + "&client_id=" + clientId;
+
+        responseEntity = new TestRestTemplate(clientId, clientSecret).postForEntity(url, null, String.class);
+    }
+}

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsBasicAuthTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsBasicAuthTest.java
@@ -24,8 +24,9 @@ public class GrantTypeClientCredentialsBasicAuthTest extends GrantTypeClientCred
     @Before
     public void before() throws IOException {
         String url = "http://localhost:" + String.valueOf(port) + "/oauth/token?grant_type=" + PARAMETER_GRANT_TYPE
-                + "&client_id=" + clientId;
+                + "&client_id=" + testClient.getClientId();
 
-        responseEntity = new TestRestTemplate(clientId, clientSecret).postForEntity(url, null, String.class);
+        responseEntity = new TestRestTemplate(testClient.getClientId(), testClient.getClientSecret()).postForEntity(url,
+                null, String.class);
     }
 }

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsCustomHeaderAuthTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsCustomHeaderAuthTest.java
@@ -30,12 +30,13 @@ public class GrantTypeClientCredentialsCustomHeaderAuthTest extends IntegrationT
     @Test
     public void should_not_login_with_custom_header() throws IOException {
         String url = "http://localhost:" + String.valueOf(port)
-                + "/oauth/token?grant_type=client_credentials&client_id=" + clientId + "&client_secret=" + clientSecret;
+                + "/oauth/token?grant_type=client_credentials&client_id=" + testClient.getClientId() + "&client_secret="
+                + testClient.getClientSecret();
 
         // since we do not have a proxy that sets the header during test, we set it
         // already on client-side
         HttpHeaders headers = new HttpHeaders();
-        headers.add("authenticated-email", testUser.email);
+        headers.add("authenticated-email", adminTestUser.email);
 
         responseEntity = new TestRestTemplate().postForEntity(url, new HttpEntity<>(headers), String.class);
 

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsCustomHeaderAuthTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsCustomHeaderAuthTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver;
+
+import org.junit.Test;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * A POST request for an access token with grant type 'client_credentials' and
+ * custom auth header should NOT be possible.
+ */
+public class GrantTypeClientCredentialsCustomHeaderAuthTest extends IntegrationTestBase {
+
+    @Test
+    public void should_not_login_with_custom_header() throws IOException {
+        String url = "http://localhost:" + String.valueOf(port)
+                + "/oauth/token?grant_type=client_credentials&client_id=" + clientId + "&client_secret=" + clientSecret;
+
+        // since we do not have a proxy that sets the header during test, we set it
+        // already on client-side
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("authenticated-email", testUser.email);
+
+        responseEntity = new TestRestTemplate().postForEntity(url, new HttpEntity<>(headers), String.class);
+
+        assertThat(responseEntity.getStatusCode(), is(HttpStatus.UNAUTHORIZED));
+    }
+
+}

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsTestBase.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypeClientCredentialsTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017, 2019. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -11,12 +11,8 @@
 
 package org.eclipse.sw360.rest.authserver;
 
-
-import org.junit.Before;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 
 import java.io.IOException;
 
@@ -24,33 +20,22 @@ import static org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority.B
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class ClientCredentialsGrantTest extends IntegrationTestBase {
+public abstract class GrantTypeClientCredentialsTestBase extends IntegrationTestBase {
 
-    private ResponseEntity<String> responseEntity;
-
-    private final String PARAMETER_GRANT_TYPE = "client_credentials";
-
-    @Value("${security.oauth2.client.client-id}")
-    private String clientId;
-
-    @Before
-    public void before() throws IOException {
-        String parameters = "client_id=%s&grant_type=%s";
-        responseEntity = getTokenWithParameters(String.format(parameters, clientId, PARAMETER_GRANT_TYPE));
-    }
+    protected final String PARAMETER_GRANT_TYPE = "client_credentials";
 
     @Test
     public void should_connect_to_authorization_server_with_client_credentials() {
-        assertThat(HttpStatus.OK, is(responseEntity.getStatusCode()));
+        assertThat(responseEntity.getStatusCode(), is(HttpStatus.OK));
     }
 
     @Test
     public void should_get_expected_response_headers() throws IOException {
-        checkResponseBody(responseEntity);
+        checkResponseBody();
     }
 
     @Test
     public void should_get_expected_jwt_attributes() throws IOException {
-        checkJwtClaims(responseEntity, BASIC.getAuthority());
+        checkJwtClaims(BASIC.getAuthority());
     }
 }

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordBasicAuthTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordBasicAuthTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.sw360.rest.authserver;
 
 import org.junit.Before;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 
 import java.io.IOException;
@@ -22,18 +21,13 @@ import java.io.IOException;
  */
 public class GrantTypePasswordBasicAuthTest extends GrantTypePasswordTestBase {
 
-    @Value("${sw360.test-user-id}")
-    protected String testUserId;
-
-    @Value("${sw360.test-user-password}")
-    protected String testUserPassword;
-
     @Before
     public void before() throws IOException {
         String url = "http://localhost:" + String.valueOf(port) + "/oauth/token?grant_type=" + PARAMETER_GRANT_TYPE
-                + "&username=" + testUserId + "&password=" + testUserPassword;
+                + "&username=" + adminTestUser.email + "&password=password-not-checked-in-test-without-liferay";
 
-        responseEntity = new TestRestTemplate(clientId, clientSecret).postForEntity(url, null, String.class);
+        responseEntity = new TestRestTemplate(testClient.getClientId(), testClient.getClientSecret()).postForEntity(url,
+                null, String.class);
     }
 
 }

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordBasicAuthTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordBasicAuthTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver;
+
+import org.junit.Before;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+
+import java.io.IOException;
+
+/**
+ * A POST request for an access token with grant type 'password' and basic auth
+ * should be possible.
+ */
+public class GrantTypePasswordBasicAuthTest extends GrantTypePasswordTestBase {
+
+    @Value("${sw360.test-user-id}")
+    protected String testUserId;
+
+    @Value("${sw360.test-user-password}")
+    protected String testUserPassword;
+
+    @Before
+    public void before() throws IOException {
+        String url = "http://localhost:" + String.valueOf(port) + "/oauth/token?grant_type=" + PARAMETER_GRANT_TYPE
+                + "&username=" + testUserId + "&password=" + testUserPassword;
+
+        responseEntity = new TestRestTemplate(clientId, clientSecret).postForEntity(url, null, String.class);
+    }
+
+}

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordCustomHeaderGetTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordCustomHeaderGetTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver;
+
+import org.junit.Before;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+
+import java.io.IOException;
+
+/**
+ * A GET request for an access token with grant type 'password' and custom auth
+ * header should be possible.
+ */
+public class GrantTypePasswordCustomHeaderGetTest extends GrantTypePasswordTestBase {
+
+    @Before
+    public void before() throws IOException {
+        String url = "http://localhost:" + String.valueOf(port) + "/oauth/token?grant_type=" + PARAMETER_GRANT_TYPE
+                + "&client_id=" + clientId + "&client_secret=" + clientSecret;
+
+        // since we do not have a proxy that sets the header during test, we set it
+        // already on client-side
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("authenticated-email", testUser.email);
+
+        responseEntity = new TestRestTemplate().exchange(url, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+    }
+}

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordCustomHeaderGetTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordCustomHeaderGetTest.java
@@ -27,12 +27,12 @@ public class GrantTypePasswordCustomHeaderGetTest extends GrantTypePasswordTestB
     @Before
     public void before() throws IOException {
         String url = "http://localhost:" + String.valueOf(port) + "/oauth/token?grant_type=" + PARAMETER_GRANT_TYPE
-                + "&client_id=" + clientId + "&client_secret=" + clientSecret;
+                + "&client_id=" + testClient.getClientId() + "&client_secret=" + testClient.getClientSecret();
 
         // since we do not have a proxy that sets the header during test, we set it
         // already on client-side
         HttpHeaders headers = new HttpHeaders();
-        headers.add("authenticated-email", testUser.email);
+        headers.add("authenticated-email", adminTestUser.email);
 
         responseEntity = new TestRestTemplate().exchange(url, HttpMethod.GET, new HttpEntity<>(headers), String.class);
     }

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordCustomHeaderPostTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordCustomHeaderPostTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver;
+
+import org.junit.Before;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+
+import java.io.IOException;
+
+/**
+ * A POST request for an access token with grant type 'password' and custom auth
+ * header should be possible.
+ */
+public class GrantTypePasswordCustomHeaderPostTest extends GrantTypePasswordTestBase {
+
+    @Before
+    public void before() throws IOException {
+        String url = "http://localhost:" + String.valueOf(port) + "/oauth/token?grant_type=" + PARAMETER_GRANT_TYPE
+                + "&client_id=" + clientId + "&client_secret=" + clientSecret;
+
+        // since we do not have a proxy that sets the header during test, we set it
+        // already on client-side
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("authenticated-email", testUser.email);
+
+        responseEntity = new TestRestTemplate().postForEntity(url, new HttpEntity<>(headers), String.class);
+    }
+}

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordCustomHeaderPostTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordCustomHeaderPostTest.java
@@ -26,12 +26,12 @@ public class GrantTypePasswordCustomHeaderPostTest extends GrantTypePasswordTest
     @Before
     public void before() throws IOException {
         String url = "http://localhost:" + String.valueOf(port) + "/oauth/token?grant_type=" + PARAMETER_GRANT_TYPE
-                + "&client_id=" + clientId + "&client_secret=" + clientSecret;
+                + "&client_id=" + testClient.getClientId() + "&client_secret=" + testClient.getClientSecret();
 
         // since we do not have a proxy that sets the header during test, we set it
         // already on client-side
         HttpHeaders headers = new HttpHeaders();
-        headers.add("authenticated-email", testUser.email);
+        headers.add("authenticated-email", adminTestUser.email);
 
         responseEntity = new TestRestTemplate().postForEntity(url, new HttpEntity<>(headers), String.class);
     }

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordTestBase.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordTestBase.java
@@ -39,6 +39,6 @@ public abstract class GrantTypePasswordTestBase extends IntegrationTestBase {
     @Test
     public void should_get_expected_jwt_attributes() throws IOException {
         JsonNode jwtClaimsJsonNode = checkJwtClaims(READ.getAuthority());
-        assertThat(jwtClaimsJsonNode.get("user_name").asText(), is(testUser.email));
+        assertThat(jwtClaimsJsonNode.get("user_name").asText(), is(adminTestUser.email));
     }
 }

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordTestBase.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/GrantTypePasswordTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017, 2019. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -12,11 +12,9 @@
 package org.eclipse.sw360.rest.authserver;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.junit.Before;
+
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 
 import java.io.IOException;
 
@@ -24,24 +22,9 @@ import static org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority.R
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class ResourceOwnerCredentialsGrantTest extends IntegrationTestBase {
+public abstract class GrantTypePasswordTestBase extends IntegrationTestBase {
 
-    @Value("${local.server.port}")
-    private int port;
-
-    @Value("${sw360.test-user-id}")
-    private String testUserId;
-
-    @Value("${sw360.test-user-password}")
-    private String testUserPassword;
-
-    private ResponseEntity<String> responseEntity;
-
-    @Before
-    public void before() throws IOException {
-        String parameters = "grant_type=password&username=%s&password=%s";
-        responseEntity = getTokenWithParameters(String.format(parameters, testUserId, testUserPassword));
-    }
+    protected final String PARAMETER_GRANT_TYPE = "password";
 
     @Test
     public void should_connect_to_authorization_server_with_resource_owner_credentials() {
@@ -50,12 +33,12 @@ public class ResourceOwnerCredentialsGrantTest extends IntegrationTestBase {
 
     @Test
     public void should_get_expected_response_headers() throws IOException {
-        checkResponseBody(responseEntity);
+        checkResponseBody();
     }
 
     @Test
     public void should_get_expected_jwt_attributes() throws IOException {
-        JsonNode jwtClaimsJsonNode = checkJwtClaims(responseEntity, READ.getAuthority());
-        assertThat(jwtClaimsJsonNode.get("user_name").asText(), is(testUserId));
+        JsonNode jwtClaimsJsonNode = checkJwtClaims(READ.getAuthority());
+        assertThat(jwtClaimsJsonNode.get("user_name").asText(), is(testUser.email));
     }
 }

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/IntegrationTestBase.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/IntegrationTestBase.java
@@ -22,7 +22,7 @@ import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientRepositor
 import org.eclipse.sw360.rest.authserver.client.service.Sw360ClientDetailsService;
 import org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority;
 import org.eclipse.sw360.rest.authserver.security.basicauth.Sw360LiferayAuthenticationProvider;
-
+import org.apache.commons.lang.StringUtils;
 import org.apache.thrift.TException;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -59,7 +59,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Sw360AuthorizationServer.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles({"dev"})
+@ActiveProfiles({"dev", "test"})
 public abstract class IntegrationTestBase {
 
     @Value("${local.server.port}")
@@ -216,6 +216,8 @@ public abstract class IntegrationTestBase {
         } else {
             actualAuthorities.add(authoritiesJsonNode.asText());
         }
+        System.out.println("ACTUAL: " + actualAuthorities);
+        System.out.println("EXPECTED: " + StringUtils.join(expectedAuthority, ", "));
         assertThat(actualAuthorities, containsInAnyOrder(expectedAuthority));
 
         return jwtClaimsJsonNode;

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/IntegrationTestBase.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/IntegrationTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2017, 2019. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *
@@ -13,64 +13,108 @@ package org.eclipse.sw360.rest.authserver;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.eclipse.sw360.datahandler.thrift.users.UserService;
+import org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority;
+
+import org.apache.thrift.TException;
+import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.jwt.Jwt;
 import org.springframework.security.jwt.JwtHelper;
+import org.springframework.security.web.FilterChainProxy;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer.CONFIG_CLIENT_ID;
 import static org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer.CONFIG_CLIENT_SECRET;
 import static org.eclipse.sw360.rest.authserver.security.Sw360SecurityEncryptor.decrypt;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Sw360AuthorizationServer.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles({"dev"})
-abstract public class IntegrationTestBase {
+public abstract class IntegrationTestBase {
 
     @Value("${local.server.port}")
     protected int port;
 
     @Value("${security.oauth2.client.client-id}")
-    private String clientId;
+    protected String clientId;
 
     @Value("${security.oauth2.client.client-secret}")
-    private String clientSecret;
+    protected String clientSecret;
 
-    protected ResponseEntity<String> getTokenWithParameters(String parameters) throws IOException {
-        String url = "http://localhost:" + port + "/oauth/token?" + parameters;
-        clientId = CONFIG_CLIENT_ID != null ? CONFIG_CLIENT_ID : clientId;
-        clientSecret = CONFIG_CLIENT_SECRET != null ? decrypt(CONFIG_CLIENT_SECRET) : clientSecret;
-        return new TestRestTemplate(clientId, clientSecret).postForEntity(url, null, String.class);
+    @Autowired
+    protected FilterChainProxy springSecurityFilterChain;
+
+    @MockBean
+    protected ThriftClients thriftClients;
+
+    protected User testUser;
+
+    protected ResponseEntity<String> responseEntity;
+
+    protected String getClientId() {
+        return CONFIG_CLIENT_ID != null ? CONFIG_CLIENT_ID : clientId;
     }
 
-    protected void checkResponseBody(ResponseEntity<String> responseEntity) throws IOException {
+    protected String getClientSecret() throws IOException {
+        return CONFIG_CLIENT_SECRET != null ? decrypt(CONFIG_CLIENT_SECRET) : clientSecret;
+    }
+
+    @Before
+    public void setup() throws TException {
+        testUser = new User("mockedserviceuser@sw360.org", "qa");
+        testUser.externalid = "service-mocked-by-mockito";
+        testUser.fullname = "Mocked Service User";
+        testUser.givenname = "Mocked";
+        testUser.lastname = "Service User";
+        testUser.userGroup = UserGroup.ADMIN;
+
+        UserService.Client mockedUserService = mock(UserService.Client.class);
+        when(mockedUserService.getByEmailOrExternalId(eq(testUser.email), anyString())).thenReturn(testUser);
+
+        when(thriftClients.makeUserClient()).thenReturn(mockedUserService);
+    }
+
+    protected void checkResponseBody() throws IOException {
         String responseBody = responseEntity.getBody();
 
-        assertThat(HttpStatus.OK, is(responseEntity.getStatusCode()));
+        assertThat(responseEntity.getStatusCode(), is(HttpStatus.OK));
 
         JsonNode responseBodyJsonNode = new ObjectMapper().readTree(responseBody);
 
         assertThat(responseBodyJsonNode.get("token_type").asText(), is("bearer"));
-        assertThat(responseBodyJsonNode.get("scope").asText(), is("all"));
+        assertThat(responseBodyJsonNode.get("scope").asText(), is(Sw360GrantedAuthority.READ.toString()));
         assertThat(responseBodyJsonNode.has("access_token"), is(true));
         assertThat(responseBodyJsonNode.has("expires_in"), is(true));
         assertThat(responseBodyJsonNode.has("jti"), is(true));
     }
 
-    protected JsonNode checkJwtClaims(ResponseEntity<String> responseEntity, String expectedAuthority) throws IOException {
+    protected JsonNode checkJwtClaims(String... expectedAuthority) throws IOException {
         String responseBody = responseEntity.getBody();
 
-        assertThat(HttpStatus.OK, is(responseEntity.getStatusCode()));
+        assertThat(responseEntity.getStatusCode(), is(HttpStatus.OK));
 
         JsonNode responseBodyJsonNode = new ObjectMapper().readTree(responseBody);
         assertThat(responseBodyJsonNode.has("access_token"), is(true));
@@ -82,12 +126,27 @@ abstract public class IntegrationTestBase {
         assertThat(jwtClaimsJsonNode.get("aud").get(0).asText(), is("sw360-REST-API"));
         assertThat(jwtClaimsJsonNode.get("client_id").asText(), is("trusted-sw360-client"));
 
-        JsonNode scopeNode = jwtClaimsJsonNode.get("scope");
-        assertThat(scopeNode.get(0).asText(), is("all"));
-        assertThat(scopeNode.size(), is(1));
+        JsonNode scopesNode = jwtClaimsJsonNode.get("scope");
+        List<String> actualScopes = new ArrayList<>();
+        if (scopesNode.isArray()) {
+            for (final JsonNode scopeNode : scopesNode) {
+                actualScopes.add(scopeNode.asText());
+            }
+        } else {
+            actualScopes.add(scopesNode.asText());
+        }
+        assertThat(actualScopes, containsInAnyOrder(Sw360GrantedAuthority.READ.toString()));
 
         JsonNode authoritiesJsonNode = jwtClaimsJsonNode.get("authorities");
-        assertThat(authoritiesJsonNode.get(0).asText(), is(expectedAuthority));
+        List<String> actualAuthorities = new ArrayList<>();
+        if (authoritiesJsonNode.isArray()) {
+            for (final JsonNode authorityTextNode : authoritiesJsonNode) {
+                actualAuthorities.add(authorityTextNode.asText());
+            }
+        } else {
+            actualAuthorities.add(authoritiesJsonNode.asText());
+        }
+        assertThat(actualAuthorities, containsInAnyOrder(expectedAuthority));
 
         return jwtClaimsJsonNode;
     }

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/IntegrationTestBase.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/IntegrationTestBase.java
@@ -8,43 +8,50 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-
 package org.eclipse.sw360.rest.authserver;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
 
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.thrift.users.UserService;
+import org.eclipse.sw360.rest.authserver.client.persistence.OAuthClientRepository;
+import org.eclipse.sw360.rest.authserver.client.service.Sw360ClientDetailsService;
 import org.eclipse.sw360.rest.authserver.security.Sw360GrantedAuthority;
+import org.eclipse.sw360.rest.authserver.security.basicauth.Sw360LiferayAuthenticationProvider;
 
 import org.apache.thrift.TException;
 import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.jwt.Jwt;
 import org.springframework.security.jwt.JwtHelper;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.client.BaseClientDetails;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer.CONFIG_CLIENT_ID;
-import static org.eclipse.sw360.rest.authserver.Sw360AuthorizationServer.CONFIG_CLIENT_SECRET;
-import static org.eclipse.sw360.rest.authserver.security.Sw360SecurityEncryptor.decrypt;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -58,43 +65,106 @@ public abstract class IntegrationTestBase {
     @Value("${local.server.port}")
     protected int port;
 
-    @Value("${security.oauth2.client.client-id}")
-    protected String clientId;
-
-    @Value("${security.oauth2.client.client-secret}")
-    protected String clientSecret;
-
     @Autowired
     protected FilterChainProxy springSecurityFilterChain;
 
     @MockBean
     protected ThriftClients thriftClients;
 
-    protected User testUser;
+    @MockBean
+    protected Sw360ClientDetailsService sw360ClientDetailsService;
+
+    @MockBean
+    protected OAuthClientRepository clientRepo;
+
+    @Mock
+    protected RestTemplateBuilder restTemplateBuilder;
+
+    @Autowired
+    @InjectMocks
+    protected Sw360LiferayAuthenticationProvider provider;
+
+    protected User adminTestUser;
+
+    protected User normalTestUser;
+
+    protected ClientDetails testClient;
 
     protected ResponseEntity<String> responseEntity;
 
-    protected String getClientId() {
-        return CONFIG_CLIENT_ID != null ? CONFIG_CLIENT_ID : clientId;
-    }
-
-    protected String getClientSecret() throws IOException {
-        return CONFIG_CLIENT_SECRET != null ? decrypt(CONFIG_CLIENT_SECRET) : clientSecret;
-    }
-
     @Before
     public void setup() throws TException {
-        testUser = new User("mockedserviceuser@sw360.org", "qa");
-        testUser.externalid = "service-mocked-by-mockito";
-        testUser.fullname = "Mocked Service User";
-        testUser.givenname = "Mocked";
-        testUser.lastname = "Service User";
-        testUser.userGroup = UserGroup.ADMIN;
-
+        setupTestUser();
         UserService.Client mockedUserService = mock(UserService.Client.class);
-        when(mockedUserService.getByEmailOrExternalId(eq(testUser.email), anyString())).thenReturn(testUser);
-
+        when(mockedUserService.getByEmailOrExternalId(eq(adminTestUser.email), anyString())).thenReturn(adminTestUser);
+        when(mockedUserService.getByEmailOrExternalId(eq(normalTestUser.email), anyString()))
+                .thenReturn(normalTestUser);
         when(thriftClients.makeUserClient()).thenReturn(mockedUserService);
+
+        setupTestClient();
+        when(sw360ClientDetailsService.loadClientByClientId(anyString())).thenReturn(testClient);
+
+        setupLiferayMocks();
+    }
+
+    private void setupTestUser() {
+        adminTestUser = new User("mockedserviceadminuser@sw360.org", "qa-admin");
+        adminTestUser.externalid = "service-mocked-by-mockito-admin";
+        adminTestUser.fullname = "Mocked Service Admin User";
+        adminTestUser.givenname = "Mocked";
+        adminTestUser.lastname = "Service Admin User";
+        adminTestUser.userGroup = UserGroup.SW360_ADMIN;
+
+        normalTestUser = new User("mockedservicenormaluser@sw360.org", "qa-normal");
+        normalTestUser.externalid = "service-mocked-by-mockito-normal";
+        normalTestUser.fullname = "Mocked Service Normal User";
+        normalTestUser.givenname = "Mocked";
+        normalTestUser.lastname = "Service Normal User";
+        normalTestUser.userGroup = UserGroup.USER;
+    }
+
+    private void setupTestClient() {
+        testClient = new BaseClientDetails("trusted-sw360-client", "sw360-REST-API",
+                Sw360GrantedAuthority.READ.getAuthority(), "client_credentials,password",
+                Sw360GrantedAuthority.BASIC.getAuthority());
+        ((BaseClientDetails) testClient).setClientSecret("sw360-secret");
+        ((BaseClientDetails) testClient).setAutoApproveScopes(Sets.newHashSet("true"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setupLiferayMocks() {
+        // this setup is more complex! Since we can only mock the RestTemplateBuilder,
+        // which is used in other parts of the application and tests as well, we have to
+        // create a mock and inject that one only in the correct class and cannot just
+        // use @MockBean which would exchange it in the application context. In addition
+        // we want two different responses (happy case and error case) which is why we
+        // need to exchange the builder after a call to withBasicAuth() because we only
+        // know at this location if we are in the happy case or in the error case
+
+        // preparation for good case
+        ResponseEntity<String> mockedResponseEntity = mock(ResponseEntity.class);
+        when(mockedResponseEntity.getBody()).thenReturn("4711");
+
+        RestTemplate mockedRestTemplate = mock(RestTemplate.class);
+        when(mockedRestTemplate.postForEntity(anyString(), anyObject(), eq(String.class)))
+                .thenReturn(mockedResponseEntity);
+
+        RestTemplateBuilder mockedRTB = mock(RestTemplateBuilder.class);
+        when(restTemplateBuilder.basicAuthorization(eq(adminTestUser.email), anyString())).thenReturn(mockedRTB);
+        when(restTemplateBuilder.basicAuthorization(eq(normalTestUser.email), anyString())).thenReturn(mockedRTB);
+        when(mockedRTB.build()).thenReturn(mockedRestTemplate);
+
+        // preparation for bad case
+        ResponseEntity<String> mockedResponseEntityFail = mock(ResponseEntity.class);
+        when(mockedResponseEntityFail.getBody()).thenReturn("Some auth exception");
+
+        RestTemplate mockedRestTemplateFail = mock(RestTemplate.class);
+        when(mockedRestTemplateFail.postForEntity(anyString(), anyObject(), eq(String.class)))
+                .thenReturn(mockedResponseEntityFail);
+
+        RestTemplateBuilder mockedRTBFail = mock(RestTemplateBuilder.class);
+        when(restTemplateBuilder.basicAuthorization(eq("my-unknown-user"), anyString())).thenReturn(mockedRTBFail);
+        when(mockedRTBFail.build()).thenReturn(mockedRestTemplateFail);
     }
 
     protected void checkResponseBody() throws IOException {

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/client/persistence/OAuthClientRepositoryTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/client/persistence/OAuthClientRepositoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver.client.persistence;
+
+import org.eclipse.sw360.rest.authserver.IntegrationTestBase;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Of course it would be possible to test only the repo down to the db without
+ * the spring context. But this way we use the convenience of springs property
+ * loading and overwriting in tests.
+ *
+ * Currently we are only testing the setup anyway, since we do not have custom
+ * repo logic yet - beside the ektorp supported CRUD logic.
+ *
+ * ATTENTION: This test should be executed manually when a couchdb is running.
+ * Make sure to not have the OAuthClientRepository as Mockito mock in the
+ * context.
+ */
+public class OAuthClientRepositoryTest extends IntegrationTestBase {
+
+    @Autowired
+    private OAuthClientRepository uut;
+
+    @Before
+    public void setup() {
+        uut.getAll().stream().forEach(uut::remove);
+    }
+
+    // just to satisfy subclass expectations of JUnit
+    @Test
+    public void testNoop() {
+        assertTrue(true);
+    }
+
+    // @Test
+    public void testInsertNewClient() {
+        // given:
+        String clientId = "foo";
+        OAuthClientEntity client = new OAuthClientEntity();
+        client.setId(clientId);
+
+        // when:
+        uut.add(client);
+
+        // then:
+        List<OAuthClientEntity> actualClients = uut.getAll();
+        assertThat(actualClients.size(), is(1));
+        assertThat(actualClients.get(0).getId(), is(clientId));
+    }
+
+}

--- a/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientControllerTest.java
+++ b/rest/authorization-server/src/test/java/org/eclipse/sw360/rest/authserver/client/rest/OAuthClientControllerTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.authserver.client.rest;
+
+import com.google.common.collect.Lists;
+
+import org.eclipse.sw360.rest.authserver.IntegrationTestBase;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import org.springframework.web.client.RestClientException;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+public class OAuthClientControllerTest extends IntegrationTestBase {
+
+    @Autowired
+    private TestRestTemplate template;
+
+    @Test
+    public void testGetAll_basicAuth_unknownUser_fail() throws RestClientException, URISyntaxException {
+        // given:
+        when(clientRepo.getAll()).thenReturn(null);
+
+        // when:
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(Lists.newArrayList(MediaType.APPLICATION_JSON));
+
+        responseEntity = template.withBasicAuth("my-unknown-user", "my-unknown-password").exchange(
+                new RequestEntity<String>(headers, HttpMethod.GET, new URI("/client-management")), String.class);
+
+        // then:
+        assertThat(responseEntity.getStatusCode(), is(HttpStatus.UNAUTHORIZED));
+    }
+
+    @Test
+    public void testGetAll_basicAuth_admin_success() throws RestClientException, URISyntaxException {
+        // given:
+        when(clientRepo.getAll()).thenReturn(null);
+
+        // when:
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(Lists.newArrayList(MediaType.APPLICATION_JSON));
+
+        responseEntity = template.withBasicAuth(adminTestUser.email, "password-not-checked-in-test-without-liferay")
+                .exchange(new RequestEntity<String>(headers, HttpMethod.GET, new URI("/client-management")),
+                        String.class);
+
+        // then:
+        assertThat(responseEntity.getStatusCode(), is(HttpStatus.OK));
+    }
+
+    @Test
+    public void testGetAll_basicAuth_normal_fail() throws RestClientException, URISyntaxException {
+        // given:
+        when(clientRepo.getAll()).thenReturn(null);
+
+        // when:
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(Lists.newArrayList(MediaType.APPLICATION_JSON));
+
+        responseEntity = template.withBasicAuth(normalTestUser.email, "password-not-checked-in-test-without-liferay")
+                .exchange(new RequestEntity<String>(headers, HttpMethod.GET, new URI("/client-management")),
+                        String.class);
+
+        // then:
+        assertThat(responseEntity.getStatusCode(), is(HttpStatus.FORBIDDEN));
+    }
+
+    @Test
+    public void testGetAll_headerAuth_unknownUser_fail() throws RestClientException, URISyntaxException {
+        // given:
+        when(clientRepo.getAll()).thenReturn(null);
+
+        // when:
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(Lists.newArrayList(MediaType.APPLICATION_JSON));
+        headers.set("authenticated-email", "my-unknown-user");
+
+        responseEntity = template.exchange(
+                new RequestEntity<String>(headers, HttpMethod.GET, new URI("/client-management")), String.class);
+
+        // then:
+        assertThat(responseEntity.getStatusCode(), is(HttpStatus.UNAUTHORIZED));
+    }
+
+    @Test
+    public void testGetAll_headerAuth_admin_success() throws RestClientException, URISyntaxException {
+        // given:
+        when(clientRepo.getAll()).thenReturn(null);
+
+        // when:
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(Lists.newArrayList(MediaType.APPLICATION_JSON));
+        headers.set("authenticated-email", adminTestUser.email);
+
+        responseEntity = template.exchange(
+                new RequestEntity<String>(headers, HttpMethod.GET, new URI("/client-management")), String.class);
+
+        // then:
+        assertThat(responseEntity.getStatusCode(), is(HttpStatus.OK));
+    }
+
+    @Test
+    public void testGetAll_headerAuth_normal_fail() throws RestClientException, URISyntaxException {
+        // given:
+        when(clientRepo.getAll()).thenReturn(null);
+
+        // when:
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(Lists.newArrayList(MediaType.APPLICATION_JSON));
+        headers.set("authenticated-email", normalTestUser.email);
+
+        responseEntity = template.exchange(
+                new RequestEntity<String>(headers, HttpMethod.GET, new URI("/client-management")), String.class);
+
+        // then:
+        assertThat(responseEntity.getStatusCode(), is(HttpStatus.FORBIDDEN));
+    }
+}

--- a/rest/authorization-server/src/test/resources/application-test.yml
+++ b/rest/authorization-server/src/test/resources/application-test.yml
@@ -1,0 +1,14 @@
+#
+# Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+#
+# All rights reserved. This configuration file is provided to you under the
+# terms and conditions of the Eclipse Distribution License v1.0 which
+# accompanies this distribution, and is available at
+# http://www.eclipse.org/org/documents/edl-v10.php
+#
+
+security:
+  customheader:
+    headername:
+      # You have to enable authorization by headers explicitly here
+      enabled: true


### PR DESCRIPTION
* added sso authentication support to standard requests
* added liferay authentication support to standard requests
* added REST service for basic oauth client management
* added couchdb persistence for oauth client management
* removed single static configurable oauth client
* added some tests and javadoc

For SSO users (basic auth liferay users can use other tools as well, but
can also use this workflow):
1. open a browser with developer tools
2. open
    ```
    https://<sw360domain>/authorization/client-management
    ```
3. to add a new client, enter the following javascript in the dev tools
console
    ```
    xmlHttpRequest = new XMLHttpRequest();
    xmlHttpRequest.open('POST', '/authorization/client-management', false);
    xmlHttpRequest.setRequestHeader('Content-Type', 'application/json');
    xmlHttpRequest.setRequestHeader('Accept', 'application/json');
    xmlHttpRequest.send(JSON.stringify(
      {
        "description" : "my first test client",
        "authorities" : [ "BASIC" ],
        "scope" : [ "READ" ],
        "access_token_validity" : 3600,
        "refresh_token_validity" : 3600
      }
    ));
    console.log(xmlHttpRequest.responseText);
    ```
4. to manipulate an existing client, do the same but add the clientid to
the data object
    ```
        "client_id" : "9e358ca832ce4ce99a770c7bd0f8e066"
    ```
5. to remove an existing client, enter the following javascript in the
dev tools console
    ```
    xmlHttpRequest = new XMLHttpRequest();
    xmlHttpRequest.open('DELETE', '/authorization/client-management/9e358ca832ce4ce99a770c7bd0f8e066', false);
    xmlHttpRequest.setRequestHeader('Content-Type', 'application/json');
    xmlHttpRequest.setRequestHeader('Accept', 'application/json');
    xmlHttpRequest.send();
    console.log(xmlHttpRequest.responseText);
    ```
This way the session cookie of the SSO login will be used for the REST
calls. This might also be possible in postman or curl or similar tools if
you want to try to copy cookies (depending also on the SSO configuration).

Be aware that this PR contains also the commit of PR #545 since this one needs the changes from there. So please review both at the same time or first merge #545 to get a cleaner diff (or just check the commit bcc664b).

closes #543 
closes #542 

Signed-off-by: Andreas Klett <andreas.klett@scansation.de>