### PR TITLE
fix(Project): Only users with Admin access should be allowed to edit a closed project

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
@@ -19,6 +19,7 @@ public class ErrorMessages {
 
     public static final String PROJECT_NOT_ADDED = "Project could not be added.";
     public static final String PROJECT_DUPLICATE = "A project with the same name and version already exists.";
+    public static final String CLOSED_UPDATE_NOT_ALLOWED = "User cannot edit a closed project";
     public static final String COMPONENT_NOT_ADDED = "Component could not be added.";
     public static final String COMPONENT_DUPLICATE = "A component with the same name already exists.";
     public static final String RELEASE_NOT_ADDED = "Release could not be added.";
@@ -53,6 +54,7 @@ public class ErrorMessages {
     public static final ImmutableList<String> allErrorMessages = ImmutableList.<String>builder()
             .add(PROJECT_NOT_ADDED)
             .add(PROJECT_DUPLICATE)
+            .add(CLOSED_UPDATE_NOT_ALLOWED)
             .add(COMPONENT_NOT_ADDED)
             .add(COMPONENT_DUPLICATE)
             .add(RELEASE_NOT_ADDED)

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -71,6 +71,7 @@ public class PortalConstants {
 
     public static final String IS_USER_AT_LEAST_CLEARING_ADMIN = "isUserAtLeastClearingAdmin";
     public static final String IS_USER_AT_LEAST_ECC_ADMIN = "isUserAtLeastECCAdmin";
+    public static final String IS_USER_ADMIN = "isUserAdmin";
 
     //! Specialized keys for licenses
     public static final String KEY_LICENSE_DETAIL = "licenseDetail";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
@@ -274,6 +274,9 @@ abstract public class Sw360Portlet extends MVCPortlet {
         case FAILED_SANITY_CHECK:
             setSW360SessionError(request, ErrorMessages.UPDATE_FAILED_SANITY_CHECK);
             break;
+        case CLOSED_UPDATE_NOT_ALLOWED:
+            setSW360SessionError(request, ErrorMessages.CLOSED_UPDATE_NOT_ALLOWED);
+            break;
         case DUPLICATE:
         case DUPLICATE_ATTACHMENT:
             // just break to not throw an exception, error message has to be set by caller

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -46,6 +46,7 @@ import org.eclipse.sw360.datahandler.thrift.licenseinfo.*;
 import org.eclipse.sw360.datahandler.thrift.projects.*;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.*;
 import org.eclipse.sw360.exporter.ProjectExporter;
@@ -804,8 +805,10 @@ public class ProjectPortlet extends FossologyAwarePortlet {
     }
 
     private void prepareStandardView(RenderRequest request) throws IOException {
+        User user = UserCacheHolder.getUserFromRequest(request);
         List<Organization> organizations = UserUtils.getOrganizations(request);
         request.setAttribute(PortalConstants.ORGANIZATIONS, organizations);
+        request.setAttribute(IS_USER_ADMIN, PermissionUtils.isUserAtLeast(UserGroup.SW360_ADMIN, user) ? "Yes" : "No");
         for (Project._Fields filteredField : projectFilteredFields) {
             String parameter = request.getParameter(filteredField.toString());
             request.setAttribute(filteredField.getFieldName(), nullToEmpty(parameter));
@@ -909,6 +912,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
 
                 addProjectBreadcrumb(request, response, project);
                 request.setAttribute(PROJECT_OBLIGATIONS, SW360Utils.getProjectObligations(project));
+                request.setAttribute(IS_USER_ADMIN, PermissionUtils.isUserAtLeast(UserGroup.SW360_ADMIN, user) ? "Yes" : "No");
 
             } catch (TException e) {
                 log.error("Error fetching project from backend!", e);

--- a/frontend/sw360-portlet/src/main/webapp/css/sw360.css
+++ b/frontend/sw360-portlet/src/main/webapp/css/sw360.css
@@ -717,3 +717,7 @@ textarea.broader {
     vertical-align: middle;
     line-height: 50px;
 }
+
+.editdisabled{
+  opacity: 0.4;
+}

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/detail.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/detail.jsp
@@ -44,7 +44,11 @@
     <div id="header"></div>
     <p class="pageHeader"><span class="pageHeaderBigSpan">Project: <sw360:ProjectName project="${project}"/></span>
         <span class="pull-right">
-        <input type="button" id="edit" value="Edit" class="addButton">
+        <input type="button" id="edit" value="Edit" class="addButton"
+            <c:if test = "${(project.clearingState eq 'CLOSED') && (isUserAdmin != 'Yes')}">
+                disabled="disabled"
+            </c:if>
+        </input>
     </span>
     </p>
 

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/view.jsp
@@ -279,12 +279,18 @@
                                            +" alt='SelectClearing' title='send to Fossology'>";
                     </core_rt:otherwise>
                 </core_rt:choose>
+                var editProject;
+
+                if(row.cState == 'CLOSED' && ${isUserAdmin != 'Yes'}) {
+                    editProject = "<img class='editdisabled' src='<%=request.getContextPath()%>/images/edit.png' alt='Edit' title='Only Admin can edit a closed project'>";
+                } else {
+                    editProject = renderLinkTo(makeProjectUrl(id, '<%=PortalConstants.PAGENAME_EDIT%>'),"",
+                                          "<img src='<%=request.getContextPath()%>/images/edit.png' alt='Edit' title='Edit'>");
+                }
+
                 return sendingToFossology +
                         "<span id='projectAction" + id + "'></span>"
-                    + renderLinkTo(
-                        makeProjectUrl(id, '<%=PortalConstants.PAGENAME_EDIT%>'),
-                        "",
-                        "<img src='<%=request.getContextPath()%>/images/edit.png' alt='Edit' title='Edit'>")
+                    + editProject
                     + renderLinkTo(
                         makeProjectUrl(id, '<%=PortalConstants.PAGENAME_DUPLICATE%>'),
                         "",

--- a/libraries/lib-datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/sw360.thrift
@@ -28,6 +28,7 @@ enum RequestStatus {
     DUPLICATE = 5,
     DUPLICATE_ATTACHMENT = 6,
     ACCESS_DENIED = 7,
+    CLOSED_UPDATE_NOT_ALLOWED = 8,
 }
 
 enum RemoveModeratorRequestStatus {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -75,7 +75,9 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
     public RequestStatus updateProject(Project project, User sw360User) throws TException {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
         RequestStatus requestStatus = sw360ProjectClient.updateProject(project, sw360User);
-        if (requestStatus != RequestStatus.SUCCESS) {
+        if (requestStatus != RequestStatus.CLOSED_UPDATE_NOT_ALLOWED) {
+            throw new RuntimeException("User cannot modify a closed project");
+        } else if (requestStatus != RequestStatus.SUCCESS) {
             throw new RuntimeException("sw360 project with name '" + project.getName() + " cannot be updated.");
         }
         return requestStatus;


### PR DESCRIPTION
- Only Admin should be allowed to edit a closed project.
- Added restriction, if the user is not admin and project clearing state is "Closed" then 
  user will not be allowed to edit the project.

closes : #567 
