### PR TITLE
feat(Release): added new field 'comment' in release summary

### DIFF
--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseInformation.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/editReleaseInformation.jspf
@@ -133,6 +133,14 @@
                                    description="Moderators" multiUsers="true" readonly="false"/>
         </td>
     </tr>
+    <tr>
+        <td colspan="3">
+            <label class="textlabel stackedLabel" for="release_comment">Comment</label>
+            <textarea class="toplabelledInput" id="release_comment" name="<portlet:namespace/><%=Release._Fields.COMMENT%>" rows="4" cols="30"
+                      style="width: 97%; height: 25px; resize:both;"
+                      placeholder="Enter Comments"><sw360:out value="${release.comment}"/></textarea>
+        </td>
+    </tr>
 </table>
 
 <script>

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/summaryRelease.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/summaryRelease.jspf
@@ -12,6 +12,7 @@
 <%@ taglib prefix="tags" tagdir="/WEB-INF/tags" %>
 
 <core_rt:if test="${release != null}">
+    <div class="up_Summary" id="up_Summary"><p><sw360:out value="${release.comment}" maxChar="500"/></p></div>
     <table class="table info_table" id="ReleaseDetailOverview">
         <thead>
         <tr>

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -184,6 +184,7 @@ struct Release {
     12: optional Repository repository, // Repository where the release is maintained
     16: optional MainlineState mainlineState, // enum: specific, open, mainline, phaseout
     17: optional ClearingState clearingState, // TODO we probably need to map by clearing team?
+    18: optional string comment, // comments specific to release
 
     // FOSSology Information
     20: optional string fossologyId,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -382,7 +382,8 @@ class JacksonCustomizations {
                 "contributorsIterator",
                 "rolesSize",
                 "setRoles",
-                "setCreatorDepartment"
+                "setCreatorDepartment",
+                "setComment"
         })
         static abstract class ReleaseMixin extends Release {
             @Override

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -114,6 +114,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         release.setExternalIds(Collections.singletonMap("mainline-id-component", "1432"));
         release.setAttachments(attachmentList);
         release.setLanguages(new HashSet<>(Arrays.asList("C++", "Java")));
+        release.setComment("The commenct specific to this release");
         releaseList.add(release);
 
         Release release2 = new Release();
@@ -131,6 +132,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         release2.setMainlineState(MainlineState.MAINLINE);
         release2.setExternalIds(Collections.singletonMap("mainline-id-component", "4876"));
         release2.setLanguages(new HashSet<>(Arrays.asList("C++", "Java")));
+        release2.setComment("The commenct specific to this release");
         releaseList.add(release2);
 
         given(this.releaseServiceMock.getReleasesForUser(anyObject())).willReturn(releaseList);
@@ -221,6 +223,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("downloadurl").description("the download url of the release"),
                                 fieldWithPath("externalIds").description("When releases are imported from other tools, the external ids can be stored here"),
                                 fieldWithPath("languages").description("The language of the component"),
+                                fieldWithPath("comment").description("The release comment"),
                                 fieldWithPath("_embedded.sw360:moderators").description("An array of all release moderators with email and link to their <<resources-user-get,User resource>>"),
                                 fieldWithPath("_embedded.sw360:attachments").description("An array of all release attachments and link to their <<resources-attachment-get,Attachment resource>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")
@@ -273,6 +276,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("downloadurl").description("the download url of the release"),
                                 fieldWithPath("externalIds").description("When releases are imported from other tools, the external ids can be stored here"),
                                 fieldWithPath("languages").description("The language of the component"),
+                                fieldWithPath("comment").description("The release comment"),
                                 fieldWithPath("_embedded.sw360:moderators").description("An array of all release moderators with email and link to their <<resources-user-get,User resource>>"),
                                 fieldWithPath("_embedded.sw360:attachments").description("An array of all release attachments and link to their <<resources-attachment-get,Attachment resource>>"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")


### PR DESCRIPTION
**Summary:**
Added new field "**comment**" (text-area) in release summary [Component -> Release Overview -> Summary]
Added rest API  (GET, POST and PATCH) support and documentation for the field.

**Steps to test:**
- Create new Component or Edit existing Component and then go to "Release Overview".
- Create a new Release or Open the existing release (is present).
- User should be able to see and edit the new field "`comment`" in "`Release Summary`" tab.
- User should be able to add/update the field value while creating/updating the release via rest end point.

closes : #571 

Signed-off-by: Abdul Kapti <abdul.mannankapti@siemens.com>