### PR TITLE
feat(attachment-usages): Take over the attachment usages from the original project.

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -175,6 +175,7 @@ public class PortalConstants {
     public static final String MANUAL_ATTACHMENT_USAGES = "manualAttUsages";
     public static final String PROJECT_PATH = "projectPath";
     public static final String PROJECT_PATHS = "projectPaths";
+    public static final String SOURCE_PROJECT_ID = "sourceProjectId";
 
 
     public static final String FOSSOLOGY_FINGER_PRINTS = "fingerPrints";

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
@@ -33,6 +33,9 @@
 
 <portlet:actionURL var="updateURL" name="update">
     <portlet:param name="<%=PortalConstants.PROJECT_ID%>" value="${project.id}" />
+    <c:if test="${not empty sourceProjectId}">
+        <portlet:param name="sourceProjectId" value="${sourceProjectId}" />
+    </c:if>
 </portlet:actionURL>
 
 <portlet:actionURL var="deleteAttachmentsOnCancelURL" name='<%=PortalConstants.ATTACHMENT_DELETE_ON_CANCEL%>'>


### PR DESCRIPTION
- Fetched the attachment usages of the original project.
- Persisted the same by associating the new project(cloned project) id to it.

closes #573 

Signed-off-by: Smruti Sahoo <smruti.sahoo@siemens.com>