### PR TITLE
ci(pmd): enable PMD for static code analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,9 @@ matrix:
     - name: mvn validate
       env: MVN_ARGS="validate"
       before_install:
+    - name: mvn pmd:pmd
+      env: MVN_ARGS="pmd:pmd"
+      before_install:
     - name: mvn dependency:analyze
       env: MVN_ARGS="dependency:analyze -DfailOnWarning"
       install: mvn package -DskipTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,11 +46,13 @@ matrix:
       env: MVN_ARGS="validate"
       before_install:
     - name: pmd for already refactored packages
-      env: MVN_ARGS="-DskipTests -Ppmd -pl libraries/lib-datahandler"
+      env: MVN_ARGS="install -DskipTests -Ppmd -pl build-configuration;libraries/lib-datahandler"
       before_install:
+        - ./scripts/install-thrift.sh --no-cleanup
     - name: pmd for whole project
-      env: MVN_ARGS="-DskipTests -Ppmd"
+      env: MVN_ARGS="install -DskipTests -Ppmd"
       before_install:
+        - ./scripts/install-thrift.sh --no-cleanup
     - name: mvn dependency:analyze
       env: MVN_ARGS="dependency:analyze -DfailOnWarning"
       install: mvn package -DskipTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,11 @@ matrix:
     - name: mvn validate
       env: MVN_ARGS="validate"
       before_install:
-    - name: mvn pmd:pmd
-      env: MVN_ARGS="pmd:pmd"
+    - name: pmd for already refactored packages
+      env: MVN_ARGS="-DskipTests -Ppmd -pl libraries/lib-datahandler"
+      before_install:
+    - name: pmd for whole project
+      env: MVN_ARGS="-DskipTests -Ppmd"
       before_install:
     - name: mvn dependency:analyze
       env: MVN_ARGS="dependency:analyze -DfailOnWarning"
@@ -62,4 +65,5 @@ matrix:
     #   script: scripts/compileWithDocker.sh
   allow_failures:
     - name: mvn dependency:analyze
+    - name: pmd for whole project
 

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -12,6 +12,8 @@
 package org.eclipse.sw360.moderation.db;
 
 import com.google.common.collect.Sets;
+import org.apache.log4j.Logger;
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
@@ -37,8 +39,6 @@ import org.eclipse.sw360.datahandler.thrift.users.UserService;
 import org.eclipse.sw360.licenses.db.LicenseDatabaseHandler;
 import org.eclipse.sw360.mail.MailConstants;
 import org.eclipse.sw360.mail.MailUtil;
-import org.apache.log4j.Logger;
-import org.apache.thrift.TException;
 import org.ektorp.http.HttpClient;
 import org.jetbrains.annotations.NotNull;
 
@@ -466,7 +466,7 @@ public class ModerationDatabaseHandler {
         request.setTimestamp(System.currentTimeMillis());
         request.setModerationState(ModerationState.PENDING);
         request.setRequestDocumentDelete(isDeleteRequest);
-        request.setModerators(Sets.filter(moderators, notEmptyOrNull()));
+        request.setModerators(Sets.filter(moderators, notEmptyOrNull()::apply));
         request.setRequestingUserDepartment(user.getDepartment());
 
         fillRequestWithCommentOfUser(request, user);;

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -466,7 +466,9 @@ public class ModerationDatabaseHandler {
         request.setTimestamp(System.currentTimeMillis());
         request.setModerationState(ModerationState.PENDING);
         request.setRequestDocumentDelete(isDeleteRequest);
-        request.setModerators(Sets.filter(moderators, notEmptyOrNull()::apply));
+        request.setModerators(moderators.stream()
+                .filter(notEmptyOrNull())
+                .collect(Collectors.toSet()));
         request.setRequestingUserDepartment(user.getDepartment());
 
         fillRequestWithCommentOfUser(request, user);;

--- a/backend/utils/src/main/java/org/eclipse/sw360/attachments/db/RemoteAttachmentDownloader.java
+++ b/backend/utils/src/main/java/org/eclipse/sw360/attachments/db/RemoteAttachmentDownloader.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-import static org.eclipse.sw360.datahandler.common.CommonUtils.closeQuietly;
 import static org.eclipse.sw360.datahandler.common.Duration.durationOf;
 import static java.lang.String.format;
 import static org.apache.log4j.Logger.getLogger;
@@ -65,9 +64,7 @@ public class RemoteAttachmentDownloader {
             log.info(format("retrieving attachment (%s) {filename=%s}", attachmentContentId, attachmentContent.getFilename()));
             log.debug("url is " + attachmentContent.getRemoteUrl());
 
-            InputStream content = null;
-            try {
-                content = attachmentConnector.unsafeGetAttachmentStream(attachmentContent);
+            try (InputStream content = attachmentConnector.unsafeGetAttachmentStream(attachmentContent)) {
                 if (content == null) {
                     log.error("null content retrieving attachment " + attachmentContentId);
                     continue;
@@ -79,10 +76,8 @@ public class RemoteAttachmentDownloader {
                 } catch (IOException e) {
                     log.error("attachment was downloaded but somehow not available in database " + attachmentContentId, e);
                 }
-            } catch (SW360Exception e) {
+            } catch (SW360Exception | IOException e) {
                 log.error("cannot retrieve attachment " + attachmentContentId, e);
-            } finally {
-                closeQuietly(content, log);
             }
         }
 

--- a/backend/utils/src/test/java/org/eclipse/sw360/attachments/db/RemoteAttachmentDownloaderTest.java
+++ b/backend/utils/src/test/java/org/eclipse/sw360/attachments/db/RemoteAttachmentDownloaderTest.java
@@ -54,7 +54,7 @@ import static org.junit.Assume.assumeThat;
  */
 public class RemoteAttachmentDownloaderTest {
 
-    private static final String url = DatabaseSettings.COUCH_DB_URL;
+    private static final String dbURL = DatabaseSettings.COUCH_DB_URL;
     private static final String dbName = DatabaseSettings.COUCH_DB_ATTACHMENTS;
 
     private AttachmentConnector attachmentConnector;
@@ -81,7 +81,7 @@ public class RemoteAttachmentDownloaderTest {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         for (String id : garbage) {
             repository.remove(id);
         }
@@ -89,7 +89,7 @@ public class RemoteAttachmentDownloaderTest {
 
     @Test
     public void testIntegration() throws Exception {
-        AttachmentContent attachmentContent = saveRemoteAttachment(url);
+        AttachmentContent attachmentContent = saveRemoteAttachment(dbURL);
 
         assertThat(retrieveRemoteAttachments(DatabaseSettings.getConfiguredHttpClient(), dbName, downloadTimeout), is(1));
 
@@ -113,12 +113,7 @@ public class RemoteAttachmentDownloaderTest {
         ExecutorService executor = newSingleThreadExecutor();
 
         try {
-            Future<Integer> future = executor.submit(new Callable<Integer>() {
-                @Override
-                public Integer call() throws Exception {
-                    return retrieveRemoteAttachments(DatabaseSettings.getConfiguredHttpClient(), dbName, downloadTimeout);
-                }
-            });
+            Future<Integer> future = executor.submit(() -> retrieveRemoteAttachments(DatabaseSettings.getConfiguredHttpClient(), dbName, downloadTimeout));
 
             try {
                 Integer downloadedSuccessfully = future.get(1, TimeUnit.MINUTES);
@@ -138,7 +133,7 @@ public class RemoteAttachmentDownloaderTest {
     @Test
     public void testWithBrokenURL() throws Exception {
         AttachmentContent attachmentContent = saveRemoteAttachment(TestUtils.BLACK_HOLE_ADDRESS);
-        AttachmentContent attachmentGood = saveRemoteAttachment(url);
+        AttachmentContent attachmentGood = saveRemoteAttachment(dbURL);
 
         assertThat(repository.getOnlyRemoteAttachments(), hasSize(2));
         assertThat(retrieveRemoteAttachments(DatabaseSettings.getConfiguredHttpClient(), dbName, downloadTimeout), is(1));

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/datatables/DataTablesUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/datatables/DataTablesUtils.java
@@ -27,7 +27,7 @@ public class DataTablesUtils {
         ImmutableList.Builder<Map<String, String[]>> builder = ImmutableList.builder();
         Set<String> parametersName = parametersMap.keySet();
 
-        while (Iterables.any(parametersName, startsWith("[" + i + "]"))) {
+        while (parametersName.stream().anyMatch(startsWith("[" + i + "]"))) {
             builder.add(unprefix(parametersMap, "[" + i + "]"));
             i++;
         }

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/utils/TypeMappings.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/utils/TypeMappings.java
@@ -11,9 +11,6 @@
  */
 package org.eclipse.sw360.exporter.utils;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.*;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
@@ -27,7 +24,10 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.InputStream;
 import java.util.*;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.eclipse.sw360.exporter.utils.ConvertRecord.putToTodos;
 
@@ -38,100 +38,56 @@ import static org.eclipse.sw360.exporter.utils.ConvertRecord.putToTodos;
 public class TypeMappings {
 
     @NotNull
-    public static <T> Predicate<T> containedWithAddIn(final Set<T> knownIds) {
-        return new Predicate<T>() {
-            @Override
-            public boolean apply(T input) {
-                return knownIds.add(input);
-            }
-        };
+    private static <T> Predicate<T> containedWithAddIn(final Set<T> knownIds) {
+        return knownIds::add;
     }
 
-    public static <T, U> ImmutableList<T> getElementsWithIdentifiersNotInMap(Function<T, U> getIdentifier, Map<U, T> theMap, List<T> candidates) {
-        return FluentIterable.from(candidates).filter(
-                CommonUtils.afterFunction(getIdentifier::apply).is(containedWithAddIn(Sets.newHashSet(theMap.keySet()))::apply)::apply).toList();
-    }
-
-    public static <T, U> ImmutableList<T> getElementsWithIdentifiersNotInSet(Function<T, U> getIdentifier, Set<U> theSet, List<T> candidates) {
-        return FluentIterable.from(candidates).filter(
-                CommonUtils.afterFunction(getIdentifier::apply).is(containedWithAddIn(theSet)::apply)::apply).toList();
+    private static <T, U> List<T> getElementsWithIdentifiersNotInMap(Function<T, U> getIdentifier, Map<U, T> theMap, List<T> candidates) {
+        Set<U> keysFromTheMap = theMap.keySet();
+        return candidates.stream()
+                .filter(a -> (containedWithAddIn(keysFromTheMap)).test(getIdentifier.apply(a)))
+                .collect(Collectors.toList());
     }
 
     @NotNull
-    public static Function<License, String> getLicenseIdentifier() {
-        return new Function<License, String>() {
-            @Override
-            public String apply(License input) {
-                return input.getId();
-            }
-        };
+    private static Function<Todo, Integer> getTodoIdentifier() {
+        return todo -> -1;
     }
 
     @NotNull
-    public static Function<Todo, Integer> getTodoIdentifier() {
-        return new Function<Todo, Integer>() {
-            @Override
-            public Integer apply(Todo input) {
-                return -1;
-            }
-        };
+    private static Function<Obligation, Integer> getObligationIdentifier() {
+        return o -> -1;
     }
 
     @NotNull
-    public static Function<Obligation, Integer> getObligationIdentifier() {
-        return new Function<Obligation, Integer>() {
-            @Override
-            public Integer apply(Obligation input) {
-                return input.getObligationId();
-            }
-        };
+    private static Function<LicenseType, Integer> getLicenseTypeIdentifier() {
+        return LicenseType::getLicenseTypeId;
     }
 
     @NotNull
-    public static Function<LicenseType, Integer> getLicenseTypeIdentifier() {
-        return new Function<LicenseType, Integer>() {
-            @Override
-            public Integer apply(LicenseType input) {
-                return input.getLicenseTypeId();
-            }
-        };
+    private static Function<RiskCategory, Integer> getRiskCategoryIdentifier() {
+        return RiskCategory::getRiskCategoryId;
     }
 
     @NotNull
-    public static Function<RiskCategory, Integer> getRiskCategoryIdentifier() {
-        return new Function<RiskCategory, Integer>() {
-            @Override
-            public Integer apply(RiskCategory input) {
-                return input.getRiskCategoryId();
-            }
-        };
-    }
-
-    @NotNull
-    public static Function<Risk, Integer> getRiskIdentifier() {
-        return new Function<Risk, Integer>() {
-            @Override
-            public Integer apply(Risk input) {
-                return input.getRiskId();
-            }
-        };
+    private static Function<Risk, Integer> getRiskIdentifier() {
+        return Risk::getRiskId;
     }
 
     @SuppressWarnings("unchecked")
-    public static <T, U> Function<T, U> getIdentifier(Class<T> clazz, @SuppressWarnings("unused") Class<U> uClass /*used to infer type*/) throws SW360Exception {
+    private static <T, U> Optional<Function<T, U>> getIdentifier(Class<T> clazz, @SuppressWarnings("unused") Class<U> uClass /*used to infer type*/) {
         if (clazz.equals(LicenseType.class)) {
-            return (Function<T, U>) getLicenseTypeIdentifier();
+            return Optional.of((Function<T, U>) getLicenseTypeIdentifier());
         } else if (clazz.equals(Obligation.class)) {
-            return (Function<T, U>) getObligationIdentifier();
+            return Optional.of((Function<T, U>) getObligationIdentifier());
         } else if (clazz.equals(RiskCategory.class)) {
-            return (Function<T, U>) getRiskCategoryIdentifier();
+            return Optional.of((Function<T, U>) getRiskCategoryIdentifier());
         }
-
-        throw new SW360Exception("Unknown Type requested");
+        return Optional.empty();
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> List<T> getAllFromDB(LicenseService.Iface licenseClient, Class<T> clazz) throws TException {
+    private static <T> List<T> getAllFromDB(LicenseService.Iface licenseClient, Class<T> clazz) throws TException {
         if (clazz.equals(LicenseType.class)) {
             return (List<T>) licenseClient.getLicenseTypes();
         } else if (clazz.equals(Obligation.class)) {
@@ -143,7 +99,7 @@ public class TypeMappings {
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> List<T> simpleConvert(List<CSVRecord> records, Class<T> clazz) throws SW360Exception {
+    private static <T> List<T> simpleConvert(List<CSVRecord> records, Class<T> clazz) throws SW360Exception {
         if (clazz.equals(LicenseType.class)) {
             return (List<T>) ConvertRecord.convertLicenseTypes(records);
         } else if (clazz.equals(Obligation.class)) {
@@ -155,7 +111,7 @@ public class TypeMappings {
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> List<T> addAlltoDB(LicenseService.Iface licenseClient, Class<T> clazz, List<T> candidates, User user) throws TException {
+    private static <T> List<T> addAlltoDB(LicenseService.Iface licenseClient, Class<T> clazz, List<T> candidates, User user) throws TException {
         if (candidates != null && !candidates.isEmpty()) {
             if (clazz.equals(LicenseType.class)) {
                 return (List<T>) licenseClient.addLicenseTypes((List<LicenseType>) candidates, user);
@@ -170,18 +126,28 @@ public class TypeMappings {
 
     @NotNull
     public static <T, U> Map<U, T> getIdentifierToTypeMapAndWriteMissingToDatabase(LicenseService.Iface licenseClient, InputStream in, Class<T> clazz, Class<U> uClass, User user) throws TException {
-        Map<U, T> typeMap;
         List<CSVRecord> records = ImportCSV.readAsCSVRecords(in);
         final List<T> recordsToAdd = simpleConvert(records, clazz);
         final List<T> fullList = CommonUtils.nullToEmptyList(getAllFromDB(licenseClient, clazz));
-        typeMap = Maps.newHashMap(Maps.uniqueIndex(fullList, getIdentifier(clazz, uClass)));
-        final ImmutableList<T> filteredList = getElementsWithIdentifiersNotInMap(getIdentifier(clazz, uClass), typeMap, recordsToAdd);
+
+        final Optional<Function<T, U>> getIdentifier = getIdentifier(clazz, uClass);
+        if (! getIdentifier.isPresent()) {
+            return Collections.emptyMap();
+        }
+
+        Map<U, T> typeMap = fullList.stream()
+                .collect(Collectors.toMap(f -> getIdentifier.get().apply(f), Function.identity()));
+        final List<T> filteredList = getElementsWithIdentifiersNotInMap(getIdentifier.get(), typeMap, recordsToAdd);
         List<T> added = null;
         if (filteredList.size() > 0) {
             added = addAlltoDB(licenseClient, clazz, filteredList, user);
         }
-        if (added != null)
-            typeMap.putAll(Maps.uniqueIndex(added, getIdentifier(clazz, uClass)));
+        if (added != null) {
+            final Map<U, T> mapFromAdded = added.stream()
+                    .collect(Collectors.toMap(f -> getIdentifier.get().apply(f), Function.identity()));
+            return Stream.concat(typeMap.entrySet().stream(), mapFromAdded.entrySet().stream())
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
         return typeMap;
     }
 
@@ -190,14 +156,19 @@ public class TypeMappings {
         List<CSVRecord> riskRecords = ImportCSV.readAsCSVRecords(in);
         final List<Risk> risksToAdd = ConvertRecord.convertRisks(riskRecords, riskCategoryMap);
         final List<Risk> risks = CommonUtils.nullToEmptyList(licenseClient.getRisks());
-        Map<Integer, Risk> riskMap = Maps.newHashMap(Maps.uniqueIndex(risks, getRiskIdentifier()));
-        final ImmutableList<Risk> filteredList = getElementsWithIdentifiersNotInMap(getRiskIdentifier(), riskMap, risksToAdd);
+        Map<Integer, Risk> riskMap = risks.stream()
+                .collect(Collectors.toMap(getRiskIdentifier(), Function.identity()));
+        final List<Risk> filteredList = getElementsWithIdentifiersNotInMap(getRiskIdentifier(), riskMap, risksToAdd);
         List<Risk> addedRisks = null;
         if (filteredList.size() > 0) {
             addedRisks = licenseClient.addRisks(filteredList, user);
         }
-        if (addedRisks != null)
-            riskMap.putAll(Maps.uniqueIndex(addedRisks, getRiskIdentifier()));
+        if (addedRisks != null){
+            final Map<Integer, Risk> mapFromAdded = addedRisks.stream()
+                    .collect(Collectors.toMap(getRiskIdentifier(), Function.identity()));
+            return Stream.concat(riskMap.entrySet().stream(), mapFromAdded.entrySet().stream())
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
         return riskMap;
     }
 
@@ -205,17 +176,20 @@ public class TypeMappings {
     public static Map<Integer, Todo> getTodoMapAndWriteMissingToDatabase(LicenseService.Iface licenseClient, Map<Integer, Obligation> obligationMap, Map<Integer, Set<Integer>> obligationTodoMapping, InputStream in, User user) throws TException {
         List<CSVRecord> todoRecords = ImportCSV.readAsCSVRecords(in);
         final List<Todo> todos = CommonUtils.nullToEmptyList(licenseClient.getTodos());
-        Map<Integer, Todo> todoMap = Maps.newHashMap(Maps.uniqueIndex(todos, getTodoIdentifier()));
+        Map<Integer, Todo> todoMap = todos.stream()
+                .collect(Collectors.toMap(getTodoIdentifier(), Function.identity()));
         final List<Todo> todosToAdd = ConvertRecord.convertTodos(todoRecords);
-        final ImmutableList<Todo> filteredTodos = getElementsWithIdentifiersNotInMap(getTodoIdentifier(), todoMap, todosToAdd);
-        final ImmutableMap<Integer, Todo> filteredMap = Maps.uniqueIndex(filteredTodos, getTodoIdentifier());
+        final List<Todo> filteredTodos = getElementsWithIdentifiersNotInMap(getTodoIdentifier(), todoMap, todosToAdd);
+        final Map<Integer, Todo> filteredMap = filteredTodos.stream()
+                .collect(Collectors.toMap(getTodoIdentifier(), Function.identity()));
         putToTodos(obligationMap, filteredMap, obligationTodoMapping);
         //insertCustomProperties
 
         if (filteredTodos.size() > 0) {
             final List<Todo> addedTodos = licenseClient.addTodos(filteredTodos, user);
             if (addedTodos != null) {
-                final ImmutableMap<Integer, Todo> addedTodoMap = Maps.uniqueIndex(addedTodos, getTodoIdentifier());
+                final Map<Integer, Todo> addedTodoMap = addedTodos.stream()
+                        .collect(Collectors.toMap(f -> getTodoIdentifier().apply(f), Function.identity()));
                 todoMap.putAll(addedTodoMap);
             }
         }
@@ -236,9 +210,10 @@ public class TypeMappings {
         }
 
         if (todoMap.values().size() > 0) {
-            final List<Todo> addedTodos = licenseClient.addTodos(todoMap.values().stream().collect(Collectors.toList()), user);
+            final List<Todo> addedTodos = licenseClient.addTodos(new ArrayList<>(todoMap.values()), user);
             if (addedTodos != null) {
-                final ImmutableMap<Integer, Todo> addedTodoMap = Maps.uniqueIndex(addedTodos, getTodoIdentifier());
+                final Map<Integer, Todo> addedTodoMap = addedTodos.stream()
+                        .collect(Collectors.toMap(f -> getTodoIdentifier().apply(f), Function.identity()));
                 todoMap.putAll(addedTodoMap);
             }
         }
@@ -249,15 +224,10 @@ public class TypeMappings {
         List<CSVRecord> records = ImportCSV.readAsCSVRecords(inputStream);
         Optional<CustomProperties> dbCustomProperties = CommonUtils.wrapThriftOptionalReplacement(licenseClient.getCustomProperties(SW360Constants.TYPE_TODO));
         CustomProperties customProperties;
-        if (!dbCustomProperties.isPresent()) {
-            customProperties = new CustomProperties().setDocumentType(SW360Constants.TYPE_TODO);
-        } else {
-            customProperties = dbCustomProperties.get();
-        }
+        customProperties = dbCustomProperties.orElseGet(() -> new CustomProperties().setDocumentType(SW360Constants.TYPE_TODO));
         Map<String, Set<String>> propertyToValuesToAdd = ConvertRecord.convertCustomProperties(records);
         customProperties.setPropertyToValues(CommonUtils.mergeMapIntoMap(propertyToValuesToAdd, customProperties.getPropertyToValues()));
         licenseClient.updateCustomProperties(customProperties, user);
-        Map<Integer, ConvertRecord.PropertyWithValue> propertiesWithValuesById = ConvertRecord.convertCustomPropertiesById(records);
-        return propertiesWithValuesById;
+        return ConvertRecord.convertCustomPropertiesById(records);
     }
 }

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/utils/TypeMappings.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/utils/TypeMappings.java
@@ -14,6 +14,8 @@ package org.eclipse.sw360.exporter.utils;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.*;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.ImportCSV;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
@@ -21,8 +23,6 @@ import org.eclipse.sw360.datahandler.thrift.CustomProperties;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.licenses.*;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.apache.commons.csv.CSVRecord;
-import org.apache.thrift.TException;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.InputStream;
@@ -49,12 +49,12 @@ public class TypeMappings {
 
     public static <T, U> ImmutableList<T> getElementsWithIdentifiersNotInMap(Function<T, U> getIdentifier, Map<U, T> theMap, List<T> candidates) {
         return FluentIterable.from(candidates).filter(
-                CommonUtils.afterFunction(getIdentifier).is(containedWithAddIn(Sets.newHashSet(theMap.keySet())))).toList();
+                CommonUtils.afterFunction(getIdentifier::apply).is(containedWithAddIn(Sets.newHashSet(theMap.keySet()))::apply)::apply).toList();
     }
 
     public static <T, U> ImmutableList<T> getElementsWithIdentifiersNotInSet(Function<T, U> getIdentifier, Set<U> theSet, List<T> candidates) {
         return FluentIterable.from(candidates).filter(
-                CommonUtils.afterFunction(getIdentifier).is(containedWithAddIn(theSet))).toList();
+                CommonUtils.afterFunction(getIdentifier::apply).is(containedWithAddIn(theSet)::apply)::apply).toList();
     }
 
     @NotNull

--- a/libraries/importers/src/main/java/org/eclipse/sw360/importer/ComponentImportUtils.java
+++ b/libraries/importers/src/main/java/org/eclipse/sw360/importer/ComponentImportUtils.java
@@ -18,6 +18,7 @@ import org.apache.commons.csv.CSVRecord;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.ThriftUtils;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
@@ -26,7 +27,6 @@ import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentService;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
-import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vendors.VendorService;
@@ -357,7 +357,7 @@ public class ComponentImportUtils {
                     if (componentCSVRecord.isSetAttachmentContent()) {
                         List<AttachmentContent> attachmentContents = componentCSVRecord.getAttachmentContents();
 
-                        final ImmutableList<String> attachmentURLs = CommonUtils.getAttachmentURLsFromAttachmentContents(attachmentContents);
+                        final List<String> attachmentURLs = CommonUtils.getAttachmentURLsFromAttachmentContents(attachmentContents);
 
                         releaseIdentifierToDownloadURL.put(releaseIdentifier, attachmentURLs);
 

--- a/libraries/lib-datahandler/pom.xml
+++ b/libraries/lib-datahandler/pom.xml
@@ -113,18 +113,28 @@
                     </archive>
                 </configuration>
             </plugin>
-             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <configuration>
-                    <excludeRoots>
-                        <excludeRoot>${project.build.directory}/generated-sources</excludeRoot>
-                        <excludeRoot>${project.build.directory}/generated-test-sources</excludeRoot>
-                    </excludeRoots>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <!-- ################################ static code analysis ################################ -->
+            <id>pmd</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                        <configuration>
+                            <excludeRoots>
+                                <excludeRoot>${project.build.directory}/generated-sources</excludeRoot>
+                                <excludeRoot>${project.build.directory}/generated-test-sources</excludeRoot>
+                            </excludeRoots>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>

--- a/libraries/lib-datahandler/pom.xml
+++ b/libraries/lib-datahandler/pom.xml
@@ -113,6 +113,16 @@
                     </archive>
                 </configuration>
             </plugin>
+             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <configuration>
+                    <excludeRoots>
+                        <excludeRoot>${project.build.directory}/generated-sources</excludeRoot>
+                        <excludeRoot>${project.build.directory}/generated-test-sources</excludeRoot>
+                    </excludeRoots>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/businessrules/ReleaseClearingStateSummaryComputer.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/businessrules/ReleaseClearingStateSummaryComputer.java
@@ -10,19 +10,17 @@
  */
 package org.eclipse.sw360.datahandler.businessrules;
 
-import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStateSummary;
-import org.eclipse.sw360.datahandler.thrift.fossology.FossologyService;
 
 import java.util.List;
 
 /**
  * In earlier days, this computer was important and did a lot of computation.
  * Nowadays, the
- * {@link ComponentService.Iface#updateRelease(Release, org.eclipse.sw360.datahandler.thrift.users.User)}
+ * {@link org.eclipse.sw360.datahandler.thrift.components.ComponentService.Iface#updateRelease(Release, org.eclipse.sw360.datahandler.thrift.users.User)}
  * and the
- * {@link FossologyService.Iface#process(String, org.eclipse.sw360.datahandler.thrift.users.User)}
+ * {@link org.eclipse.sw360.datahandler.thrift.fossology.FossologyService.Iface#process(String, org.eclipse.sw360.datahandler.thrift.users.User)}
  * methods take care of keeping the {@link Release#clearingState} up to date so
  * that this computer really only needs to aggregate the state of all releases.
  */

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/Moderator.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/Moderator.java
@@ -194,7 +194,7 @@ public abstract class Moderator<U extends TFieldIdEnum, T extends TBase<T, U>> {
     protected Map<String, Set<String>> updateCustomMap(Map<String, Set<String>> map, Map<String, Set<String>> addMap, Map<String, Set<String>> deleteMap) {
         Map<String, Set<String>> resultMap = new HashMap<>();
 
-        Set<String> keys = CommonUtils.unifiedKeyset(map, addMap, deleteMap);
+        Set<String> keys = unifiedKeyset(map, addMap, deleteMap);
 
         for(String key: keys){
             resultMap.put(key, new HashSet<>());

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentWrapper.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentWrapper.java
@@ -11,9 +11,14 @@
 
 package org.eclipse.sw360.datahandler.couchdb;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 
+@SuppressWarnings("PMD.UnusedPrivateField")
 public class AttachmentContentWrapper extends DocumentWrapper<AttachmentContent> {
+
+    @JsonProperty("issetBitfield")
+    private byte __isset_bitfield = 0; //TODO set it
 
     /**
      * must have a copy of all fields in @see Attachment

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentWrapper.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentWrapper.java
@@ -11,13 +11,9 @@
 
 package org.eclipse.sw360.datahandler.couchdb;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 
 public class AttachmentContentWrapper extends DocumentWrapper<AttachmentContent> {
-
-    @JsonProperty("issetBitfield")
-    private byte __isset_bitfield = 0; //TODO set it
 
     /**
      * must have a copy of all fields in @see Attachment

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseConnector.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseConnector.java
@@ -222,7 +222,7 @@ public class DatabaseConnector extends StdCouchDbConnector {
      * Returns true if the database contains a document with the given ID.
      */
     public boolean contains(String id) {
-        return (id != null) && super.contains(id);
+        return id != null && super.contains(id);
     }
 
     /**

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseInstance.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseInstance.java
@@ -11,7 +11,6 @@
 package org.eclipse.sw360.datahandler.couchdb;
 
 import org.ektorp.http.HttpClient;
-import org.ektorp.http.StdHttpClient;
 import org.ektorp.impl.StdCouchDbInstance;
 
 import java.net.MalformedURLException;

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseNestedMixIn.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseNestedMixIn.java
@@ -12,7 +12,6 @@ package org.eclipse.sw360.datahandler.couchdb;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import static org.eclipse.sw360.datahandler.common.SW360Constants.KEY_ID;
 import static org.eclipse.sw360.datahandler.common.SW360Constants.KEY_REV;

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ComponentPermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ComponentPermissions.java
@@ -11,7 +11,6 @@
 package org.eclipse.sw360.datahandler.permissions;
 
 import com.google.common.collect.Sets;
-import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/DocumentPermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/DocumentPermissions.java
@@ -70,7 +70,7 @@ public abstract class DocumentPermissions<T> {
         return Collections.emptySet();
     }
 
-    protected boolean isContributor() {
+    private boolean isContributor() {
         return user != null && CommonUtils.contains(user.email, getContributors());
     }
 
@@ -129,8 +129,8 @@ public abstract class DocumentPermissions<T> {
         return isAllowedToDownload(attachment.getId());
     }
 
-    public boolean isAllowedToDownload(String attachmentContentId){
+    private boolean isAllowedToDownload(String attachmentContentId){
         return nullToEmptySet(getAttachmentContentIds()).contains(attachmentContentId) &&
-                isActionAllowed(RequestedAction.READ);
+                isActionAllowed(READ);
     }
 }

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissions.java
@@ -12,10 +12,12 @@ package org.eclipse.sw360.datahandler.permissions;
 
 import com.google.common.collect.ImmutableSet;
 import org.eclipse.sw360.datahandler.thrift.Visibility;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectClearingState;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashSet;
@@ -24,13 +26,10 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Strings.*;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.toSingletonSet;
 import static org.eclipse.sw360.datahandler.common.SW360Utils.getBUFromOrganisation;
-import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.isUserAtLeast;
-import static org.eclipse.sw360.datahandler.thrift.users.UserGroup.ADMIN;
-import static org.eclipse.sw360.datahandler.thrift.users.UserGroup.CLEARING_ADMIN;
 
 /**
  * Created by bodet on 16/02/15.
@@ -58,7 +57,7 @@ public class ProjectPermissions extends DocumentPermissions<Project> {
                 .addAll(toSingletonSet(document.getLeadArchitect()))
                 .build();
         attachmentContentIds = nullToEmptySet(document.getAttachments()).stream()
-                .map(a -> a.getAttachmentContentId())
+                .map(Attachment::getAttachmentContentId)
                 .collect(Collectors.toSet());
     }
 
@@ -94,7 +93,7 @@ public class ProjectPermissions extends DocumentPermissions<Project> {
                     return userIsEquivalentToModeratorInProject(input, user.getEmail());
                 }
                 case BUISNESSUNIT_AND_MODERATORS: {
-                    return isUserInBU(input, user.getDepartment()) || userIsEquivalentToModeratorInProject(input, user.getEmail()) || isUserAtLeast(CLEARING_ADMIN, user);
+                    return isUserInBU(input, user.getDepartment()) || userIsEquivalentToModeratorInProject(input, user.getEmail()) || PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user);
                 }
                 case EVERYONE:
                     return true;
@@ -117,7 +116,7 @@ public class ProjectPermissions extends DocumentPermissions<Project> {
             switch (action) {
                 case WRITE:
                 case ATTACHMENTS:
-                    return isClearingAdminOfOwnGroup() || PermissionUtils.isUserAtLeast(ADMIN, user);
+                    return isClearingAdminOfOwnGroup() || PermissionUtils.isUserAtLeast(UserGroup.ADMIN, user);
                 case DELETE:
                 case USERS:
                 case CLEARING:

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ReleasePermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ReleasePermissions.java
@@ -11,7 +11,6 @@
 package org.eclipse.sw360.datahandler.permissions;
 
 import com.google.common.collect.Sets;
-import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceComparatorGenerator.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceComparatorGenerator.java
@@ -12,8 +12,6 @@
 
 package org.eclipse.sw360.datahandler.resourcelists;
 
-import org.apache.thrift.TBase;
-import org.apache.thrift.TFieldIdEnum;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceListController.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/resourcelists/ResourceListController.java
@@ -12,7 +12,6 @@
 
 package org.eclipse.sw360.datahandler.resourcelists;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;

--- a/pom.xml
+++ b/pom.xml
@@ -375,26 +375,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <!-- ################################ static code analysis ################################ -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.12.0</version>
-                <configuration>
-                    <printFailingErrors>true</printFailingErrors>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>pmd</goal>
-                            <goal>cpd</goal>
-                            <goal>cpd-check</goal>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
@@ -462,6 +442,32 @@
                                 </execution>
                             </executions>
                         </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- ################################ static code analysis ################################ -->
+            <id>pmd</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                        <version>3.12.0</version>
+                        <configuration>
+                            <printFailingErrors>true</printFailingErrors>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>pmd</goal>
+                                    <goal>cpd</goal>
+                                    <goal>cpd-check</goal>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -375,6 +375,26 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- ################################ static code analysis ################################ -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.12.0</version>
+                <configuration>
+                    <printFailingErrors>true</printFailingErrors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>pmd</goal>
+                            <goal>cpd</goal>
+                            <goal>cpd-check</goal>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This PR adds pmd checks to SW360, and applies them to `lib-datahandler` (via travis).

Can be executed with `mvn install -DskipTests -Ppmd -pl libraries/lib-datahandler`.

Or for the full project:
```
$ mvn install -DskipTests -Ppmd
[...]
[INFO] --- maven-pmd-plugin:3.12.0:check (default) @ exporters ---
[INFO] PMD Failure: org.eclipse.sw360.exporter.LicsExporter:66 Rule:UnnecessaryFullyQualifiedName Priority:4 Unnecessary use of fully qualified name 'ConvertRecord.PropertyWithValueAndId' due to existing static import 'org.eclipse.sw360.exporter.utils.ConvertRecord.*'.
[INFO] PMD Failure: org.eclipse.sw360.exporter.LicsExporter:68 Rule:UnnecessaryFullyQualifiedName Priority:4 Unnecessary use of fully qualified name 'ConvertRecord.fillTodoCustomPropertyInfo' due to existing static import 'org.eclipse.sw360.exporter.utils.ConvertRecord.*'.
[INFO] PMD Failure: org.eclipse.sw360.exporter.ReleaseExporter:62 Rule:UnnecessaryFullyQualifiedName Priority:4 Unnecessary use of fully qualified name 'Vendor._Fields.PERMISSIONS' due to existing static import 'org.eclipse.sw360.datahandler.thrift.components.Release._Fields.*'.
[INFO] PMD Failure: org.eclipse.sw360.exporter.ReleaseExporter:63 Rule:UnnecessaryFullyQualifiedName Priority:4 Unnecessary use of fully qualified name 'Vendor._Fields.REVISION' due to existing static import 'org.eclipse.sw360.datahandler.thrift.components.Release._Fields.*'.
[INFO] PMD Failure: org.eclipse.sw360.exporter.ReleaseExporter:64 Rule:UnnecessaryFullyQualifiedName Priority:4 Unnecessary use of fully qualified name 'Vendor._Fields.ID' due to existing static import 'org.eclipse.sw360.datahandler.thrift.components.Release._Fields.*'.
[INFO] PMD Failure: org.eclipse.sw360.exporter.ReleaseExporter:65 Rule:UnnecessaryFullyQualifiedName Priority:4 Unnecessary use of fully qualified name 'Vendor._Fields.TYPE' due to existing static import 'org.eclipse.sw360.datahandler.thrift.components.Release._Fields.*'.
[INFO] PMD Failure: org.eclipse.sw360.exporter.helper.ComponentHelper:11 Rule:TooManyStaticImports Priority:3 Too many static imports may lead to messy code.
[INFO] PMD Failure: org.eclipse.sw360.exporter.helper.ProjectHelper:12 Rule:TooManyStaticImports Priority:3 Too many static imports may lead to messy code.
[INFO] PMD Failure: org.eclipse.sw360.exporter.helper.ReleaseHelper:11 Rule:TooManyStaticImports Priority:3 Too many static imports may lead to messy code.
[INFO] PMD Failure: org.eclipse.sw360.exporter.utils.ConvertRecord:452 Rule:UselessParentheses Priority:4 Useless parentheses..
[INFO] PMD Failure: org.eclipse.sw360.exporter.utils.ConvertRecord:453 Rule:UselessParentheses Priority:4 Useless parentheses..
[INFO] PMD Failure: org.eclipse.sw360.exporter.utils.TypeMappings:48 Rule:UselessParentheses Priority:4 Useless parentheses..
[INFO] ------------------------------------------------------------------------
```

Since this finds a lot of Warnings and Errors it also contains a lot of changes.