### PR TITLE
Add additionalData maps to releases, components, projects and licenses 

### DIFF
--- a/backend/src-common/src/test/java/org/eclipse/sw360/components/summary/ProjectSummaryTest.java
+++ b/backend/src-common/src/test/java/org/eclipse/sw360/components/summary/ProjectSummaryTest.java
@@ -42,6 +42,9 @@ public class ProjectSummaryTest {
                 case EXTERNAL_IDS:
                     project.externalIds = Collections.emptyMap();
                     break;
+                case ADDITIONAL_DATA:
+                    project.additionalData = Collections.emptyMap();
+                    break;
                 case ATTACHMENTS:
                     project.attachments = Collections.emptySet();
                     break;

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ComponentModerationRequestGenerator.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ComponentModerationRequestGenerator.java
@@ -65,6 +65,9 @@ public class ComponentModerationRequestGenerator extends ModerationRequestGenera
                     case EXTERNAL_IDS:
                         dealWithStringtoStringMap(Component._Fields.EXTERNAL_IDS);
                         break;
+                    case ADDITIONAL_DATA:
+                        dealWithStringKeyedMap(Component._Fields.ADDITIONAL_DATA);
+                        break;
                     default:
                         dealWithBaseTypes(field, Component.metaDataMap.get(field));
                 }

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ProjectModerationRequestGenerator.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ProjectModerationRequestGenerator.java
@@ -70,6 +70,9 @@ public class ProjectModerationRequestGenerator extends ModerationRequestGenerato
                     case EXTERNAL_IDS:
                         dealWithStringtoStringMap(Project._Fields.EXTERNAL_IDS);
                         break;
+                    case ADDITIONAL_DATA:
+                        dealWithStringKeyedMap(Project._Fields.ADDITIONAL_DATA);
+                        break;
                     case ROLES:
                         dealWithCustomMap(Project._Fields.ROLES);
                         break;

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ReleaseModerationRequestGenerator.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ReleaseModerationRequestGenerator.java
@@ -76,6 +76,9 @@ public class ReleaseModerationRequestGenerator extends ModerationRequestGenerato
                     case EXTERNAL_IDS:
                         dealWithStringtoStringMap(Release._Fields.EXTERNAL_IDS);
                         break;
+                    case ADDITIONAL_DATA:
+                        dealWithStringKeyedMap(Release._Fields.ADDITIONAL_DATA);
+                        break;
                     default:
                         dealWithBaseTypes(field, Release.metaDataMap.get(field));
                 }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -385,6 +385,8 @@ public class PortalConstants {
     public static final String CUSTOM_MAP_VALUE = "customMapValue";
     public static final String EXTERNAL_ID_KEY = "externalIdKey";
     public static final String EXTERNAL_ID_VALUE = "externalIdValue";
+    public static final String ADDITIONAL_DATA_KEY = "additionalDataKey";
+    public static final String ADDITIONAL_DATA_VALUE = "additionalDataValue";
 
     //! request status
     public static final String REQUEST_STATUS = "request_status";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
@@ -355,12 +355,20 @@ public class PortletUtils {
         return customMap;
     }
 
-    public static Map<String,String> getExternalIdMapFromRequest(PortletRequest request) {
-        Map<String, Set<String>> customMap = getCustomMapFromRequest(request, PortalConstants.EXTERNAL_ID_KEY, PortalConstants.EXTERNAL_ID_VALUE);
+    public static Map<String,String> getMapFromRequest(PortletRequest request, String key, String value) {
+        Map<String, Set<String>> customMap = getCustomMapFromRequest(request, key, value);
         return customMap.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey,
                         e -> e.getValue().stream()
                                 .findFirst()
                                 .orElse("")));
+    }
+
+    public static Map<String,String> getExternalIdMapFromRequest(PortletRequest request) {
+        return getMapFromRequest(request, PortalConstants.EXTERNAL_ID_KEY, PortalConstants.EXTERNAL_ID_VALUE);
+    }
+
+    public static Map<String,String> getAdditionalDataMapFromRequest(PortletRequest request) {
+        return getMapFromRequest(request, PortalConstants.ADDITIONAL_DATA_KEY, PortalConstants.ADDITIONAL_DATA_VALUE);
     }
 }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -1067,14 +1067,14 @@ public class ComponentPortlet extends FossologyAwarePortlet {
 
         long numberOfCorrectVuls = vuls.stream()
                 .filter(vul -> ! VerificationState.INCORRECT.equals(getVerificationState(vul)))
-                .map(vul -> vul.getExternalId())
+                .map(VulnerabilityDTO::getExternalId)
                 .collect(Collectors.toSet())
                 .size();
         request.setAttribute(NUMBER_OF_CHECKED_OR_UNCHECKED_VULNERABILITIES, numberOfCorrectVuls);
         if (PermissionUtils.isAdmin(UserCacheHolder.getUserFromRequest(request))) {
             long numberOfIncorrectVuls = vuls.stream()
                     .filter(v -> VerificationState.INCORRECT.equals(getVerificationState(v)))
-                    .map(vul -> vul.getExternalId())
+                    .map(VulnerabilityDTO::getExternalId)
                     .collect(Collectors.toSet())
                     .size();
             request.setAttribute(NUMBER_OF_INCORRECT_VULNERABILITIES, numberOfIncorrectVuls);

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortletUtils.java
@@ -78,8 +78,13 @@ public abstract class ComponentPortletUtils {
                     break;
                 case ROLES:
                     release.setRoles(PortletUtils.getCustomMapFromRequest(request));
+                    break;
                 case EXTERNAL_IDS:
                     release.setExternalIds(PortletUtils.getExternalIdMapFromRequest(request));
+                    break;
+                case ADDITIONAL_DATA:
+                    release.setAdditionalData(PortletUtils.getAdditionalDataMapFromRequest(request));
+                    break;
                 default:
                     setFieldValue(request, release, field);
             }
@@ -125,14 +130,24 @@ public abstract class ComponentPortletUtils {
     }
 
     static void updateComponentFromRequest(PortletRequest request, Component component) {
-        List<String> requestParams = Collections.list(request.getParameterNames());
-        for (Component._Fields field : extractFieldsForComponentUpdate(requestParams, component)) {
-            setFieldValue(request, component, field);
+        for (Component._Fields field : Component._Fields.values()) {
+            switch (field) {
+                case ATTACHMENTS:
+                    component.setAttachments(PortletUtils.updateAttachmentsFromRequest(request, component.getAttachments()));
+                    break;
+                case ROLES:
+                    component.setRoles(PortletUtils.getCustomMapFromRequest(request));
+                case EXTERNAL_IDS:
+                    component.setExternalIds(PortletUtils.getExternalIdMapFromRequest(request));
+                    break;
+                case ADDITIONAL_DATA:
+                    component.setAdditionalData(PortletUtils.getAdditionalDataMapFromRequest(request));
+                    break;
+                default:
+                    setFieldValue(request, component, field);
+                    break;
+            }
         }
-
-        component.setAttachments(PortletUtils.updateAttachmentsFromRequest(request, component.getAttachments()));
-        component.setRoles(PortletUtils.getCustomMapFromRequest(request));
-        component.setExternalIds(PortletUtils.getExternalIdMapFromRequest(request));
     }
 
     private static List<Component._Fields> extractFieldsForComponentUpdate(List<String> requestParams, Component component) {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtils.java
@@ -108,6 +108,8 @@ public class ProjectPortletUtils {
                 case EXTERNAL_IDS:
                     project.setExternalIds(PortletUtils.getExternalIdMapFromRequest(request));
                     break;
+                case ADDITIONAL_DATA:
+                    project.setAdditionalData(PortletUtils.getAdditionalDataMapFromRequest(request));
                 case TODOS:
                     String userId = UserCacheHolder.getUserFromRequest(request).getId();
                     updateProjectTodosFromRequest(request.getParameterValues(field.toString()), userId, project);

--- a/frontend/sw360-portlet/src/main/webapp/html/components/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/edit.jsp
@@ -125,6 +125,8 @@
             <core_rt:set var="externalIdsSet" value="${component.externalIds.entrySet()}"/>
             <core_rt:set var="externalIdKeys" value="<%=PortalConstants.COMPONENT_EXTERNAL_ID_KEYS%>"/>
             <%@include file="/html/utils/includes/editExternalIds.jsp" %>
+            <core_rt:set var="additionalDataSet" value="${component.additionalData.entrySet()}"/>
+            <%@include file="/html/utils/includes/editAdditionalData.jsp" %>
             <core_rt:if test="${not componentDivAddMode}">
                 <%@include file="/html/utils/includes/editAttachments.jspf" %>
             <core_rt:set var="documentName"><sw360:out value='${component.name}'/></core_rt:set>

--- a/frontend/sw360-portlet/src/main/webapp/html/components/editRelease.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/editRelease.jsp
@@ -116,6 +116,8 @@
                             <core_rt:set var="externalIdsSet" value="${release.externalIds.entrySet()}"/>
                             <core_rt:set var="externalIdKeys" value="<%=PortalConstants.RELEASE_EXTERNAL_ID_KEYS%>"/>
                             <%@include file="/html/utils/includes/editExternalIds.jsp" %>
+                            <core_rt:set var="additionalDataSet" value="${release.additionalData.entrySet()}"/>
+                            <%@include file="/html/utils/includes/editAdditionalData.jsp" %>
                             <%@include file="/html/components/includes/releases/editReleaseRepository.jspf" %>
                         </div>
                         <div id="tab-ReleaseLinks">

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/summary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/components/summary.jspf
@@ -61,6 +61,10 @@
         <td>External ids:</td>
         <td><sw360:DisplayMap value="${component.externalIds}"/></td>
     </tr>
+    <tr>
+        <td>Additional Data:</td>
+        <td><sw360:DisplayMap value="${component.additionalData}"/></td>
+    </tr>
 </table>
 <table class="table info_table" id="releaseAggregateTable">
     <thead>

--- a/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/summaryRelease.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/includes/releases/summaryRelease.jspf
@@ -82,6 +82,10 @@
             <td>External ids:</td>
             <td><sw360:DisplayMap value="${release.externalIds}"/></td>
         </tr>
+        <tr>
+            <td>Additional Data:</td>
+            <td><sw360:DisplayMap value="${release.additionalData}"/></td>
+        </tr>
     </table>
     <table class="table info_table" id="ReleaseRepository">
         <core_rt:if test="${release.setRepository}">

--- a/frontend/sw360-portlet/src/main/webapp/html/components/mergeComponent.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/components/mergeComponent.jsp
@@ -160,7 +160,8 @@
             $stepElement.append(wizard.createSingleMergeLine('Wiki', data.componentTarget.wiki, data.componentSource.wiki));
             $stepElement.append(wizard.createSingleMergeLine('Mailing list', data.componentTarget.mailinglist, data.componentSource.mailinglist));
             $stepElement.append(wizard.createSingleMergeLine('Description', data.componentTarget.description, data.componentSource.description));
-            $stepElement.append(wizard.createSingleMergeLine('External ids', data.componentTarget.externalids, data.componentSource.externalids));
+            $stepElement.append(wizard.createMapMergeLine('External ids', data.componentTarget.externalIds, data.componentSource.externalIds));
+            $stepElement.append(wizard.createMapMergeLine('Additional Data', data.componentTarget.additionalData, data.componentSource.additionalData));
 
             $stepElement.append(wizard.createCategoryLine('Roles'));
             $stepElement.append(wizard.createSingleMergeLine('Component owner', data.componentTarget.componentOwner, data.componentSource.componentOwner));
@@ -209,7 +210,8 @@
             componentSelection.wiki = wizard.getFinalSingleValue('Wiki');
             componentSelection.mailinglist = wizard.getFinalSingleValue('Mailing list');
             componentSelection.description = wizard.getFinalSingleValue('Description');
-            componentSelection.externalids = wizard.getFinalSingleValue('External ids');
+            componentSelection.externalIds = wizard.getFinalMapValue('External ids');
+            componentSelection.additionalData = wizard.getFinalMapValue('Additional Data');
 
             componentSelection.componentOwner = wizard.getFinalSingleValue('Component owner');
             componentSelection.ownerAccountingUnit = wizard.getFinalSingleValue('Owner accounting unit');
@@ -264,6 +266,8 @@
             $stepElement.append(wizard.createSingleDisplayLine('Wiki', data.componentSelection.wiki));
             $stepElement.append(wizard.createSingleDisplayLine('Mailing list', data.componentSelection.mailinglist));
             $stepElement.append(wizard.createSingleDisplayLine('Description', data.componentSelection.description));
+            $stepElement.append(wizard.createMapDisplayLine('External ids', data.componentSelection.externalIds));
+            $stepElement.append(wizard.createMapDisplayLine('Additional Data', data.componentSelection.additionalData));
 
             $stepElement.append(wizard.createCategoryLine('Roles'));
             $stepElement.append(wizard.createSingleDisplayLine('Component owner', data.componentSelection.componentOwner));

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/edit.jsp
@@ -103,6 +103,8 @@
                         <core_rt:set var="externalIdsSet" value="${project.externalIds.entrySet()}"/>
                         <core_rt:set var="externalIdKeys" value="<%=PortalConstants.PROJECT_EXTERNAL_ID_KEYS%>"/>
                         <%@include file="/html/utils/includes/editExternalIds.jsp" %>
+                        <core_rt:set var="additionalDataSet" value="${project.additionalData.entrySet()}"/>
+                        <%@include file="/html/utils/includes/editAdditionalData.jsp" %>
                     </div>
                     <div id="tab-Administration" >
                         <%@include file="/html/projects/includes/projects/administrationEdit.jspf" %>

--- a/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/summary.jspf
+++ b/frontend/sw360-portlet/src/main/webapp/html/projects/includes/projects/summary.jspf
@@ -60,6 +60,10 @@
         <td>External ids:</td>
         <td><sw360:DisplayMap value="${project.externalIds}"/></td>
     </tr>
+    <tr>
+        <td>Additional Data:</td>
+        <td><sw360:DisplayMap value="${project.additionalData}"/></td>
+    </tr>
 </table>
 
 <table class="table info_table" id="roles">

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/editAdditionalData.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/editAdditionalData.jsp
@@ -1,0 +1,75 @@
+<%@ taglib prefix="portlet" uri="http://java.sun.com/portlet_2_0" %>
+<%--
+  ~ Copyright Siemens AG, 2017-2018. Part of the SW360 Portal Project.
+  ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+--%>
+<%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
+
+<table class="table info_table" id="additionalDataTable">
+    <thead>
+    <tr>
+        <th colspan="3" class="headlabel">Additional Data</th>
+    </tr>
+    </thead>
+</table>
+
+<input type="button" class="addButton" id="add-additional-data" value="Click to add row of Additional Data"/>
+<br/>
+<br/>
+
+<script>
+    require(['jquery', 'modules/confirm'], function($, confirm) {
+
+        Liferay.on('allPortletsReady', function() {
+            createAdditionalDataTable();
+
+            $('#add-additional-data').on('click', function() {
+                addRowToAdditionalDataTable();
+            });
+        });
+
+        function deleteIDItem(rowIdOne) {
+            function deleteMapItemInternal() {
+                $('#' + rowIdOne).remove();
+            }
+            deleteConfirmed("Do you really want to remove this item?", deleteMapItemInternal);
+        }
+
+        function addRowToAdditionalDataTable(key, value, rowId) {
+            if (!rowId) {
+                rowId = "additionalDataTableRow" + Date.now();
+            }
+            if ((!key) && (!value)) {
+                key = "";
+                value = "";
+            }
+
+            var newRowAsString =
+                '<tr id="' + rowId + '" class="bodyRow">' +
+                '<td width="46%">' +
+                '<input list="additionalDataKeyList" class="keyClass" id="<%=PortalConstants.ADDITIONAL_DATA_KEY%>' + rowId + '" name="<portlet:namespace/><%=PortalConstants.ADDITIONAL_DATA_KEY%>' + rowId + '" required="" minlength="1" class="toplabelledInput" placeholder="Enter additional data key" title="additional data name" value="' + key + '"/>' +
+                '</td>' +
+                '<td width="46%">' +
+                '<input class="valueClass" id="<%=PortalConstants.ADDITIONAL_DATA_VALUE%>' + rowId + '" name="<portlet:namespace/><%=PortalConstants.ADDITIONAL_DATA_VALUE%>' + rowId + '" required="" minlength="1" class="toplabelledInput" placeholder="Enter additional data value" title="additional data value" value="' + value + '"/>' +
+                '</td>' +
+                '<td class="deletor" width="8%">' +
+                '<img src="<%=request.getContextPath()%>/images/Trash.png" onclick="deleteMapItem(\'' + rowId + '\')" alt="Delete">' +
+                '</td>' +
+                '</tr>';
+            $('#additionalDataTable tr:last').after(newRowAsString);
+        }
+
+        function createAdditionalDataTable() {
+            <core_rt:forEach items="${additionalDataSet}" var="tableEntry" varStatus="loop">
+            addRowToAdditionalDataTable('<sw360:out value="${tableEntry.key}"/>', '<sw360:out value="${tableEntry.value}"/>', 'additionalDataTableRow${loop.count}');
+            </core_rt:forEach>
+        }
+    });
+
+</script>

--- a/frontend/sw360-portlet/src/main/webapp/html/utils/includes/editExternalIds.jsp
+++ b/frontend/sw360-portlet/src/main/webapp/html/utils/includes/editExternalIds.jsp
@@ -42,10 +42,11 @@
 
         function addRowToExternalIdsTable(key, value, rowId) {
             if (!rowId) {
-                var rowId = "externalIdsTableRow" + Date.now();
+                rowId = "externalIdsTableRow" + Date.now();
             }
             if ((!key) && (!value)) {
-                var key = "", value = "";
+                key = "";
+                value = "";
             }
 
             var newRowAsString =

--- a/frontend/sw360-portlet/src/main/webapp/js/modules/mergeWizard.js
+++ b/frontend/sw360-portlet/src/main/webapp/js/modules/mergeWizard.js
@@ -83,6 +83,40 @@ define('modules/mergeWizard', [ 'jquery', 'modules/sw360Wizard' ], function($, s
         return result;
     };
 
+    mergeWizard.createMapMergeLine = function createMapMergeLine(propName, target, source, detailFormatter) {
+        var result,
+            keys = [],
+            existInBoth = [];
+
+        target = target == null ? {} : target;
+        source = source == null ? {} : source;
+        detailFormatter = detailFormatter || function(element) { return element; };
+
+        result = $($.parseHTML('<fieldset id="' + propName.replace(/ /g, '') + '" class="merge line">' +
+            '    <div class="merge multi header">' + propName + '</div>' +
+            '</fieldset>'));
+
+        $.each(target, function(key, value) {
+            if (!source[key]) {
+                result.append(mergeWizard.createSingleMergeLine(key, value, [], detailFormatter));
+            } else {
+                result.append(mergeWizard.createSingleMergeLine(key, value, source[key], detailFormatter));
+                existInBoth.push(key);
+            }
+            keys.push(key);
+        });
+        $.each(source, function(key, value) {
+            if ($.inArray(key, existInBoth) === -1) {
+                result.append(mergeWizard.createSingleMergeLine(key, [], value, detailFormatter));
+                keys.push(key);
+            }
+        });
+
+        result.data('mapKeys', keys);
+
+        return result;
+    };
+
     mergeWizard.createMultiMapMergeLine = function createMultiMapMergeLine(propName, target, source, detailFormatter) {
         var result,
             keys = [],
@@ -174,6 +208,23 @@ define('modules/mergeWizard', [ 'jquery', 'modules/sw360Wizard' ], function($, s
 
         $.each(values, function(index, value) {
             result.append(createSingleDisplayContent(value, detailFormatter));
+        });
+
+        return result;
+    };
+
+    mergeWizard.createMapDisplayLine = function createMapDisplayLine(propName, values, detailFormatter) {
+        var result;
+
+        values = values == null ? {} : values;
+        detailFormatter = detailFormatter || function(element) { return element; };
+
+        result = $($.parseHTML('<fieldset id="' + propName.replace(/ /g, '') + '" class="display line">' +
+            '    <div class="display multi header">' + propName + '</div>' +
+            '</fieldset>'));
+
+        $.each(values, function(key, value) {
+            result.append(mergeWizard.createSingleDisplayLine(key, value, detailFormatter));
         });
 
         return result;
@@ -303,6 +354,22 @@ define('modules/mergeWizard', [ 'jquery', 'modules/sw360Wizard' ], function($, s
             finalVal = getFinalValue($(value));
             if (finalVal !== undefined) {
                 result.push(finalVal);
+            }
+        });
+
+        return result;
+    };
+
+    mergeWizard.getFinalMapValue = function getFinalMapValue(propName) {
+        var $fieldset = $('#' + propName.replace(/ /g, '')),
+            keys = $fieldset.data('mapKeys'),
+            result = {},
+            finalVal;
+
+        $.each(keys, function(index, value) {
+            finalVal = mergeWizard.getFinalSingleValue(value);
+            if (finalVal !== undefined) {
+                result[value] = finalVal;
             }
         });
 

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -177,6 +177,7 @@ struct Release {
 
     // information from external data sources
     9: optional  map<string, string> externalIds,
+    300: optional map<string, string> additionalData,
 
     // Additional informations
     10: optional set<Attachment> attachments,
@@ -257,6 +258,7 @@ struct Component {
 
     // information from external data sources
     31: optional  map<string, string> externalIds,
+    300: optional map<string, string> additionalData,
 
     // Linked objects
     32: optional list<Release> releases,

--- a/libraries/lib-datahandler/src/main/thrift/licenses.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/licenses.thrift
@@ -50,6 +50,7 @@ struct Todo {
 
     // information from external data sources
     19: optional map<string, string> externalIds,
+    300: optional map<string, string> additionalData,
 
     // is valid for Projects
     20: optional bool validForProject,
@@ -93,6 +94,7 @@ struct License {
 
     // information from external data sources
      9: optional map<string, string> externalIds,
+    300: optional map<string, string> additionalData,
 
     // Additional informations
 	// 10: optional bool GPLv2Compat,

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -78,6 +78,7 @@ struct Project {
 
     // information from external data sources
     9: optional map<string, string> externalIds,
+    300: optional map<string, string> additionalData,
 
     // Additional informations
     10: optional set<Attachment> attachments,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -157,7 +157,9 @@ class JacksonCustomizations {
                 "setLicenseInfoHeaderText",
                 "setProjectOwner",
                 "setEnableSvm",
-                "setEnableVulnerabilitiesDisplay"
+                "setEnableVulnerabilitiesDisplay",
+                "additionalDataSize",
+                "setAdditionalData",
         })
         static abstract class ProjectMixin extends Project {
 
@@ -313,6 +315,8 @@ class JacksonCustomizations {
                 "setOwnerCountry",
                 "rolesSize",
                 "setRoles",
+                "additionalDataSize",
+                "setAdditionalData",
         })
         static abstract class ComponentMixin extends Component {
             @Override
@@ -386,6 +390,8 @@ class JacksonCustomizations {
                 "setSoftwarePlatforms",
                 "softwarePlatformsSize",
                 "softwarePlatformsIterator",
+                "additionalDataSize",
+                "setAdditionalData",
         })
         static abstract class ReleaseMixin extends Release {
             @Override
@@ -492,7 +498,9 @@ class JacksonCustomizations {
                 "setRisks",
                 "setText",
                 "mainLicenseIdsIterator",
-                "setChecked"
+                "setChecked",
+                "additionalDataSize",
+                "setAdditionalData",
         })
         static abstract class LicenseMixin extends License {
             @Override

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ComponentSpecTest.java
@@ -108,6 +108,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
         angularComponent.setAttachments(attachmentList);
         angularComponent.setExternalIds(Collections.singletonMap("component-id-key", "1831A3"));
         angularComponent.setMailinglist("test@liferay.com");
+        angularComponent.setAdditionalData(Collections.singletonMap("Key", "Value"));
         angularComponent.setHomepage("https://angular.io");
         componentList.add(angularComponent);
         componentListByName.add(angularComponent);
@@ -306,6 +307,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("categories").description("The component categories"),
                                 fieldWithPath("languages").description("The language of the component"),
                                 fieldWithPath("externalIds").description("When projects are imported from other tools, the external ids can be stored here"),
+                                fieldWithPath("additionalData").description("A place to store additional data used by external tools"),
                                 fieldWithPath("operatingSystems").description("The OS on which the component operates"),
                                 fieldWithPath("mailinglist").description("Component mailing lists"),
                                 fieldWithPath("homepage").description("The homepage url of the component"),
@@ -446,6 +448,7 @@ public class ComponentSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("ownerGroup").description("The owner group of the component"),
                                 fieldWithPath("ownerCountry").description("The owner country of the component"),
                                 fieldWithPath("externalIds").description("When projects are imported from other tools, the external ids can be stored here"),
+                                fieldWithPath("additionalData").description("A place to store additional data used by external tools"),
                                 fieldWithPath("categories").description("The component categories"),
                                 fieldWithPath("languages").description("The language of the component"),
                                 fieldWithPath("mailinglist").description("Component mailing lists"),

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/LicenseSpecTest.java
@@ -23,8 +23,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultHandler;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.eq;
@@ -56,6 +55,11 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
         license.setFullname("Apache License 2.0");
         license.setShortname("Apache 2.0");
         license.setText("placeholder for the Apache 2.0 license text");
+        Map<String,String> externalIds = new HashMap<>();
+        externalIds.put("SPDX", "Apache-2.0");
+        externalIds.put("Trove", "License :: OSI Approved :: Apache Software License");
+        license.setExternalIds(externalIds);
+        license.setAdditionalData(Collections.singletonMap("Key", "Value"));
 
         License license2 = new License();
         license2.setId("MIT");
@@ -102,6 +106,8 @@ public class LicenseSpecTest extends TestRestDocsSpecBase {
                         responseFields(
                                 fieldWithPath("fullName").description("The full name of the license"),
                                 fieldWithPath("shortName").description("The short name of the license, optional"),
+                                fieldWithPath("externalIds").description("When releases are imported from other tools, the external ids can be stored here"),
+                                fieldWithPath("additionalData").description("A place to store additional data used by external tools"),
                                 fieldWithPath("text").description("The license's original text"),
                                 fieldWithPath("checked").description("The information, whether the license is already checked, optional and defaults to true"),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources")

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -121,6 +121,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         release.setClearingState(ClearingState.APPROVED);
         release.setMainlineState(MainlineState.OPEN);
         release.setExternalIds(Collections.singletonMap("mainline-id-component", "1432"));
+        release.setAdditionalData(Collections.singletonMap("Key", "Value"));
         release.setAttachments(attachmentList);
         release.setLanguages(new HashSet<>(Arrays.asList("C++", "Java")));
         release.setMainLicenseIds(new HashSet<>(Arrays.asList("GPL-2.0-or-later", "Apache-2.0")));
@@ -244,6 +245,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("mainlineState").description("the mainline state of the release, possible values are: " + Arrays.asList(MainlineState.values())),
                                 fieldWithPath("downloadurl").description("the download url of the release"),
                                 fieldWithPath("externalIds").description("When releases are imported from other tools, the external ids can be stored here"),
+                                fieldWithPath("additionalData").description("A place to store additional data used by external tools"),
                                 fieldWithPath("languages").description("The language of the component"),
                                 fieldWithPath("_embedded.sw360:licenses").description("An array of all main licenses with their fullName and link to their <<resources-license-get,License resource>>"),
                                 fieldWithPath("operatingSystems").description("The OS on which the release operates"),
@@ -300,6 +302,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("mainlineState").description("the mainline state of the release, possible values are: " + Arrays.asList(MainlineState.values())),
                                 fieldWithPath("downloadurl").description("the download url of the release"),
                                 fieldWithPath("externalIds").description("When releases are imported from other tools, the external ids can be stored here"),
+                                fieldWithPath("additionalData").description("A place to store additional data used by external tools"),
                                 fieldWithPath("languages").description("The language of the component"),
                                 fieldWithPath("_embedded.sw360:licenses").description("An array of all main licenses with their fullName and link to their <<resources-license-get,License resource>>"),
                                 fieldWithPath("operatingSystems").description("The OS on which the release operates"),


### PR DESCRIPTION
maps for licenses are currently supported by the backend and rest, but not by the frontend or moderation requests (already true for external IDs).

This is a **partial** fix to https://github.com/eclipse/sw360/issues/554. it allows to store generic data but without typing or configuration possibilities.

TODOs:

- [x] Editing of additional Data with components does not work