### PR TITLE
feat(License Disclosure): Change order of listed items in disclosure documents

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/OutputGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/OutputGenerator.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 public abstract class OutputGenerator<T> {
     protected static final String VELOCITY_TOOLS_FILE = "velocity-tools.xml";
     protected static final String LICENSE_REFERENCE_ID_MAP_CONTEXT_PROPERTY = "licenseNameWithTextToReferenceId";
+    protected static final String LICENSENAMES = "licenseNames";
     protected static final String ACKNOWLEDGEMENTS_CONTEXT_PROPERTY = "acknowledgements";
     protected static final String ALL_LICENSE_NAMES_WITH_TEXTS = "allLicenseNamesWithTexts";
     protected static final String LICENSE_INFO_RESULTS_CONTEXT_PROPERTY = "licenseInfoResults";
@@ -237,6 +238,7 @@ public abstract class OutputGenerator<T> {
         // sorted lists of all license to be displayed at the end of the file at once
         List<LicenseNameWithText> licenseNamesWithTexts = getSortedLicenseNameWithTexts(projectLicenseInfoResults);
         vc.put(ALL_LICENSE_NAMES_WITH_TEXTS, licenseNamesWithTexts);
+        Set<String> licenseNames = new TreeSet<String>();
         // assign a reference id to each license in order to only display references for
         // each release. The references will point to
         // the list with all details at the and of the file (see above)
@@ -244,8 +246,10 @@ public abstract class OutputGenerator<T> {
         Map<LicenseNameWithText, Integer> licenseToReferenceId = Maps.newHashMap();
         for (LicenseNameWithText licenseNamesWithText : licenseNamesWithTexts) {
             licenseToReferenceId.put(licenseNamesWithText, referenceId++);
+            licenseNames.add(licenseNamesWithText.getLicenseName());
         }
         vc.put(LICENSE_REFERENCE_ID_MAP_CONTEXT_PROPERTY, licenseToReferenceId);
+        vc.put(LICENSENAMES, licenseNames);
 
         Map<Boolean, List<LicenseInfoParsingResult>> partitionedResults =
                 projectLicenseInfoResults.stream().collect(Collectors.partitioningBy(r -> r.getStatus() == LicenseInfoRequestStatus.SUCCESS));

--- a/backend/src/src-licenseinfo/src/main/resources/textLicenseInfoFile.vm
+++ b/backend/src/src-licenseinfo/src/main/resources/textLicenseInfoFile.vm
@@ -30,29 +30,7 @@ Open Source Software Contained in this Product/Device:
 
 
 #if($licenseInfoResults.keySet().size() > 0)
-Details
-========
-
-##
-##
-## Copyrights
-##
 #foreach($releaseName in $licenseInfoResults.keySet())
-#set($copyrights = [])
-#if(${licenseInfoResults.get($releaseName).licenseInfo})
-#set($copyrights = $licenseInfoResults.get($releaseName).licenseInfo.copyrights)
-#if($copyrights.size() > 0)
-Copyright Notices for $releaseName
------------------
-#foreach($copyright in ${copyrights})
-$copyright
-#end## foreach($copyright in ${copyrights})
-
-
-#end## if($copyrights.size() > 0)
-#end## if(${licenseInfoResults.get($releaseName).licenseInfo})
-##
-##
 ## Acknowledgments
 ##
 #set($acks = [])
@@ -73,6 +51,7 @@ $ack
 ## Licenses
 ##
 #set($licenses = [])
+#set($licenseId = 1)
 #if(${licenseInfoResults.get($releaseName).licenseInfo})
 #set($licenses = $licenseInfoResults.get($releaseName).licenseInfo.licenseNamesWithTexts)
 Licenses for $releaseName
@@ -80,14 +59,14 @@ Licenses for $releaseName
 #if($licenses.size() == 0)
 <No licenses found>
 #else## if($licenses.size() > 0)
-#foreach($license in ${licenses})
+#foreach($license in ${licenseNames})
 #set($licenseName = "<no license name available>")
-#if($license.licenseName)
-#set($licenseName = $license.licenseName)
-#end## if($license.licenseName)
-#set($licenseId = $licenseNameWithTextToReferenceId.get($license))
-* $licenseName ($licenseId)
-#end## foreach($license in ${licenses})
+#if($license)
+#set($licenseName = $license)
+#end## if($license)
+($licenseId) $licenseName
+#set($licenseId = $licenseId + 1)
+#end## foreach($license in ${licenseNames})
 #end## if($licenses.size() > 0)
 
 
@@ -124,3 +103,30 @@ $licenseText.trim()
 Definition of Open Source Software
 ==================================
 As used herein, the term “Open Source Software” means any software that is licensed royalty-free (i.e., fees for exercising the licensed rights are prohibited, whereas fees for reimbursement of costs incurred by licensor are generally permitted) under any license terms which allow all users to modify such software. “Open Source Software” as used here may require, as a condition of modification and/or distribution that the source code of such software be made available to all users of the software for purposes of information and modification.
+
+#if($licenseInfoResults.keySet().size() > 0)
+Details
+========
+
+##
+##
+## Copyrights
+##
+#foreach($releaseName in $licenseInfoResults.keySet())
+#set($copyrights = [])
+#if(${licenseInfoResults.get($releaseName).licenseInfo})
+#set($copyrights = $licenseInfoResults.get($releaseName).licenseInfo.copyrights)
+#if($copyrights.size() > 0)
+Copyright Notices for $releaseName
+-----------------
+#foreach($copyright in ${copyrights})
+$copyright
+#end## foreach($copyright in ${copyrights})
+
+
+#end## if($copyrights.size() > 0)
+#end## if(${licenseInfoResults.get($releaseName).licenseInfo})
+#end## foreach($releaseName in $licenseInfoResults.keySet())
+#end## if($licenseInfoResults.keySet().size() > 0)
+##
+##

--- a/backend/src/src-licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
+++ b/backend/src/src-licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
@@ -123,17 +123,6 @@
                             <a class="top" href="#releaseHeader">&#8679;</a>
                         </h3>
                     </div>
-
-                        #set($copyrights = [])
-                        #if(${licenseInfoResults.get($releaseName).licenseInfo})
-                            #set($copyrights = $licenseInfoResults.get($releaseName).licenseInfo.copyrights)
-    <pre class="copyrights">
-#foreach($copyright in ${copyrights})
-$esc.xml($copyright)
-#end
-    </pre>
-                        #end
-
                     #if(${acknowledgements.get($releaseName)})
                         Acknowledgements:<br/>
                             #set($acks = [])
@@ -147,18 +136,19 @@ $esc.xml($ack)
 
                     Licenses:<br/>
                     #set($licenses = [])
+                    #set($licenseId = 1)
                     #if(${licenseInfoResults.get($releaseName).licenseInfo})
                         #set($licenses = $licenseInfoResults.get($releaseName).licenseInfo.licenseNamesWithTexts)
                         #if($licenses.size() > 0)
                             <ul style="list-style-type:none" class="licenseEntries">
-                            #foreach($license in ${licenses})
+                            #foreach($license in ${licenseNames})
                                 #set($licenseName = "&lt;no license name available&gt;")
-                                #if($license.licenseName)
-                                    #set($licenseName = $esc.xml($license.licenseName))
+                                #if($license)
+                                    #set($licenseName = $esc.xml($license))
                                 #end
-                                #set($licenseId = $licenseNameWithTextToReferenceId.get($license))
                                 <li class="licenseEntry" id="licenseEntry$licenseId" title="$licenseName">
-                                    <a href="#licenseTextItem$licenseId">$licenseName ($licenseId)</a>
+                                    <a href="#$licenseName">($licenseId) $licenseName </a>
+                                    #set($licenseId = $licenseId + 1)
                                </li>
                             #end
                             </ul>
@@ -188,7 +178,7 @@ $esc.xml($ack)
             #end
 
             #set($licenseId = $licenseNameWithTextToReferenceId.get($license))
-            <li id="licenseTextItem$licenseId">
+            <li id="$licenseName">
                 <h3>$licenseId: $licenseName<a class="top" href="#releaseHeader">&#8679;</a></h3>
     <pre class="licenseText" id="licenseText$licenseId">
 $licenseText
@@ -197,6 +187,21 @@ $licenseText
         #end
         </ul>
     #end
-
+<ul id="releases" style="list-style-type:none">
+    #foreach($releaseName in $licenseInfoResults.keySet())
+        <li id="$esc.xml($releaseName).replace(" ","_").replace(",","-")" class="release" title="$esc.xml($releaseName)">
+        #set($copyrights = [])
+       #if(${licenseInfoResults.get($releaseName).licenseInfo})
+           #set($copyrights = $licenseInfoResults.get($releaseName).licenseInfo.copyrights)
+           <pre class="copyrights">
+           #foreach($copyright in ${copyrights})
+$esc.xml($copyright)
+           #end
+           </pre>
+       #end
+            </li>
+    #end
+</ul>
+<h3><a class="top" href="#releaseHeader">&#8679;</a></h3>
 </body>
 </html>


### PR DESCRIPTION
Formatted the order of items in disclosure documents:

Ordering for each components:
* acknowledgements + license conditions
* Listing of licenses:
  * in alphabetical order
  * Added with a counting/running number of corresponding license text.
  * Each line represents a link to the corresponding license texts
  * multiple recurrent identical licenses shall be listed only once !
* Copyrights
* Added a hyperlink to the start of the start of the referring section