### PR TITLE
chores(configuration): allow external files

### DIFF
--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/Sw360AuthorizationServer.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/Sw360AuthorizationServer.java
@@ -11,23 +11,17 @@
 
 package org.eclipse.sw360.rest.authserver;
 
-import org.eclipse.sw360.datahandler.common.CommonUtils;
-import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
-import org.eclipse.sw360.rest.common.Sw360CORSFilter;
+import java.util.Properties;
 
 import org.apache.log4j.Logger;
-import org.springframework.boot.SpringApplication;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
+import org.eclipse.sw360.rest.common.PropertyUtils;
+import org.eclipse.sw360.rest.common.Sw360CORSFilter;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Import;
-
-import javax.crypto.SealedObject;
-
-import java.io.IOException;
-import java.util.Properties;
-
-import static org.eclipse.sw360.rest.authserver.security.Sw360SecurityEncryptor.encrypt;
 
 @SpringBootApplication
 @Import(Sw360CORSFilter.class)
@@ -35,36 +29,33 @@ public class Sw360AuthorizationServer extends SpringBootServletInitializer {
 
     private static final Logger log = Logger.getLogger(Sw360AuthorizationServer.class);
 
-    private static final String PROPERTIES_FILE_PATH = "/sw360.properties";
+    private static final String SW360_PROPERTIES_FILE_PATH = "/sw360.properties";
     private static final String DEFAULT_WRITE_ACCESS_USERGROUP = UserGroup.SW360_ADMIN.name();
     private static final String DEFAULT_ADMIN_ACCESS_USERGROUP = UserGroup.SW360_ADMIN.name();
+    private static final String APPLICATION_ID = "authorization";
 
     public static final String CONFIG_ACCESS_TOKEN_VALIDITY_SECONDS;
     public static final UserGroup CONFIG_WRITE_ACCESS_USERGROUP;
     public static final UserGroup CONFIG_ADMIN_ACCESS_USERGROUP;
 
     static {
-        Properties props = CommonUtils.loadProperties(Sw360AuthorizationServer.class, PROPERTIES_FILE_PATH);
+        Properties props = CommonUtils.loadProperties(Sw360AuthorizationServer.class, SW360_PROPERTIES_FILE_PATH);
         CONFIG_WRITE_ACCESS_USERGROUP = UserGroup.valueOf(props.getProperty("rest.write.access.usergroup", DEFAULT_WRITE_ACCESS_USERGROUP));
         CONFIG_ADMIN_ACCESS_USERGROUP = UserGroup.valueOf(props.getProperty("rest.admin.access.usergroup", DEFAULT_ADMIN_ACCESS_USERGROUP));
         CONFIG_ACCESS_TOKEN_VALIDITY_SECONDS = props.getProperty("rest.access.token.validity.seconds", null);
     }
 
-    private static SealedObject getConfigClientSecret(Properties props) {
-        try {
-            return encrypt(props.getProperty("rest.security.client.secret", null));
-        } catch (IOException e) {
-            log.error("Error occured while encrypting client password", e);
-            return null;
-        }
-    }
-
     @Override
     protected SpringApplicationBuilder configure(SpringApplicationBuilder builder) {
-        return builder.sources(Sw360AuthorizationServer.class);
+        return builder
+            .sources(Sw360AuthorizationServer.class)
+            .properties(PropertyUtils.createDefaultProperties(APPLICATION_ID));
     }
 
     public static void main(String[] args) {
-        SpringApplication.run(Sw360AuthorizationServer.class, args);
+        new SpringApplicationBuilder(Sw360AuthorizationServer.class)
+            .properties(PropertyUtils.createDefaultProperties(APPLICATION_ID))
+            .build()
+            .run(args);
     }
 }

--- a/rest/authorization-server/src/main/resources/application.yml
+++ b/rest/authorization-server/src/main/resources/application.yml
@@ -7,9 +7,11 @@
 # http://www.eclipse.org/org/documents/edl-v10.php
 #
 
+# Port to open in standalone mode
 server:
   port: 8090
 
+# Connection to the couch databases. Will be used to store client credentials
 couchdb:
   url: http://localhost:5984
   database: sw360oauthclients
@@ -22,13 +24,19 @@ spring:
     serialization:
       indent_output: true
 
+# Common SW360 properties
 sw360:
+  # The url of the Liferay instance
   sw360-portal-server-url: ${SW360_PORTAL_SERVER_URL:http://127.0.0.1:8080}
+  # The id of the company in Liferay that sw360 is run for
   sw360-liferay-company-id: ${SW360_LIFERAY_COMPANY_ID:20155}
+  # Allowed origins that should be set in the header
   cors:
     allowed-origin: ${SW360_CORS_ALLOWED_ORIGIN:#{null}}
 
 security:
+  # Configuration for enabling authorization via headers, e.g. when using SSO
+  # in combination with a reverse proxy server
   customheader:
     headername:
       # You have to enable authorization by headers explicitly here

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
@@ -11,26 +11,26 @@
 
 package org.eclipse.sw360.rest.resourceserver;
 
-import org.eclipse.sw360.rest.common.Sw360CORSFilter;
+import java.util.Properties;
+import java.util.Set;
+
 import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.rest.common.PropertyUtils;
+import org.eclipse.sw360.rest.common.Sw360CORSFilter;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.security.apiToken.ApiTokenAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurerAdapter;
-import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.UriTemplate;
 import org.springframework.hateoas.hal.CurieProvider;
 import org.springframework.hateoas.hal.DefaultCurieProvider;
-
-import java.util.Properties;
-import java.util.Set;
 
 @SpringBootApplication
 @Import(Sw360CORSFilter.class)
@@ -39,8 +39,9 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
     @Value("${spring.data.rest.default-page-size:10}")
     private int defaultPageSize;
 
-    private static final String PROPERTIES_FILE_PATH = "/sw360.properties";
+    private static final String SW360_PROPERTIES_FILE_PATH = "/sw360.properties";
     private static final String CURIE_NAMESPACE = "sw360";
+    private static final String APPLICATION_ID = "rest";
 
     public static final String API_TOKEN_HASH_SALT;
     public static final String API_TOKEN_MAX_VALIDITY_READ_IN_DAYS;
@@ -48,7 +49,7 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
     public static final Set<String> DOMAIN;
 
     static {
-        Properties props = CommonUtils.loadProperties(Sw360ResourceServer.class, PROPERTIES_FILE_PATH);
+        Properties props = CommonUtils.loadProperties(Sw360ResourceServer.class, SW360_PROPERTIES_FILE_PATH);
         API_TOKEN_MAX_VALIDITY_READ_IN_DAYS = props.getProperty("rest.apitoken.read.validity.days", "90");
         API_TOKEN_MAX_VALIDITY_WRITE_IN_DAYS = props.getProperty("rest.apitoken.write.validity.days", "30");
         API_TOKEN_HASH_SALT = props.getProperty("rest.apitoken.hash.salt", "$2a$04$Software360RestApiSalt");
@@ -78,10 +79,15 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
 
     @Override
     protected SpringApplicationBuilder configure(SpringApplicationBuilder builder) {
-        return builder.sources(Sw360ResourceServer.class);
+        return builder
+            .sources(Sw360ResourceServer.class)
+            .properties(PropertyUtils.createDefaultProperties(APPLICATION_ID));
     }
 
     public static void main(String[] args) {
-        SpringApplication.run(Sw360ResourceServer.class, args);
+        new SpringApplicationBuilder(Sw360ResourceServer.class)
+            .properties(PropertyUtils.createDefaultProperties(APPLICATION_ID))
+            .build()
+            .run(args);
     }
 }

--- a/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/PropertyUtils.java
+++ b/rest/rest-common/src/main/java/org/eclipse/sw360/rest/common/PropertyUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.rest.common;
+
+import java.util.Properties;
+
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+
+public class PropertyUtils {
+    private static final String SPRING_CONFIG_LOCATIION_KEY = "spring.config.location";
+    
+    public static Properties createDefaultProperties(String applicationName) {
+        Properties properties = new Properties();
+
+        if(System.getProperty(SPRING_CONFIG_LOCATIION_KEY) == null) {
+            properties.setProperty(SPRING_CONFIG_LOCATIION_KEY,
+                "file:" + CommonUtils.SYSTEM_CONFIGURATION_PATH + "/" + applicationName + "/");
+        }
+
+        return properties;
+    }
+}


### PR DESCRIPTION
This commit allows the resource server and authorization server to be
configured via an external file in the following directories:
- /etc/sw360/authorization/
- /etc/sw360/rest/
The configuration files must be named according to the defaults of
Spring Boot ('application.yml', 'application-{profile}.yml').

Of course, standard property files (*.properties) can be used as well.

Closes #614

Signed-off-by: Leo von Klenze <leo.vonklenze@scansation.de>