### PR TITLE
 fix(rest): auth server is broken due to liferay api change

### DIFF
--- a/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/basicauth/Sw360LiferayAuthenticationProvider.java
+++ b/rest/authorization-server/src/main/java/org/eclipse/sw360/rest/authserver/security/basicauth/Sw360LiferayAuthenticationProvider.java
@@ -35,6 +35,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * This {@link AuthenticationProvider} is able to verify the given credentials
@@ -118,7 +119,9 @@ public class Sw360LiferayAuthenticationProvider implements AuthenticationProvide
         ResponseEntity<String> response = restTemplate.postForEntity(url, null, String.class);
 
         try {
-            Integer.parseInt(response.getBody());
+            Integer.parseInt(Optional.ofNullable(response.getBody())
+                    .map(s -> s.replace("\"",""))
+                    .orElse(""));
         } catch (NumberFormatException e) {
             return false;
         }

--- a/rest/authorization-server/src/main/resources/application.yml
+++ b/rest/authorization-server/src/main/resources/application.yml
@@ -29,7 +29,7 @@ sw360:
   # The url of the Liferay instance
   sw360-portal-server-url: ${SW360_PORTAL_SERVER_URL:http://127.0.0.1:8080}
   # The id of the company in Liferay that sw360 is run for
-  sw360-liferay-company-id: ${SW360_LIFERAY_COMPANY_ID:20155}
+  sw360-liferay-company-id: ${SW360_LIFERAY_COMPANY_ID:20101}
   # Allowed origins that should be set in the header
   cors:
     allowed-origin: ${SW360_CORS_ALLOWED_ORIGIN:#{null}}


### PR DESCRIPTION
The liferay rest request returns now a number in qoutes instead of a raw number. We have to strip the quotes first.

Also the default company Id has changed (is this id deterministic?)

based on: https://github.com/eclipse/sw360/pull/616