### PR TITLE
chores(build): Fix deploy profile

### DIFF
--- a/backend/svc/pom.xml
+++ b/backend/svc/pom.xml
@@ -73,21 +73,6 @@
     </build>
     <profiles>
       <profile>
-        <id>deploy</id>
-        <build>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-war-plugin</artifactId>
-              <version>2.2</version>
-              <configuration>
-                <outputDirectory>${webapps.dir}</outputDirectory>
-              </configuration>
-            </plugin>
-          </plugins>
-        </build>
-      </profile>
-      <profile>
           <id>codescoop</id>
           <modules>
               <module>svc-codescoop</module>

--- a/frontend/sw360-portlet/pom.xml
+++ b/frontend/sw360-portlet/pom.xml
@@ -354,16 +354,4 @@
             <artifactId>com.liferay.petra.lang</artifactId>
         </dependency>
     </dependencies>
-
-    <!-- For deployment right to your local liferay folder -->
-    <profiles>
-        <profile>
-            <id>deploy</id>
-            <build>
-                <plugins>
-                    <!--  FIXME: deploy profile has lost plugin since liferay-maven-plugin no longer available since liferay 7.0 CE -->
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -382,62 +382,66 @@
         <profile>
             <id>deploy</id>
             <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-dependency-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>copy-jar</id>
+                                    <phase>package</phase>
+                                    <goals>
+                                        <goal>copy</goal>
+                                    </goals>
+                                    <configuration>
+                                        <artifactItems>
+                                            <artifactItem>
+                                                <groupId>${project.groupId}</groupId>
+                                                <artifactId>${project.artifactId}</artifactId>
+                                                <version>${project.version}</version>
+                                                <type>${project.packaging}</type>
+                                                <destFileName>${project.build.finalName}.${project.packaging}</destFileName>
+                                            </artifactItem>
+                                        </artifactItems>
+                                        <!--
+                                            This property is set by the submodules themself, depending wether they are backend, frontend or library
+                                            modules.
+                                            All other submodule leave this property blank causing the dependency plugin to copy the artifact inside
+                                            the target folder.
+                                        -->
+                                        <outputDirectory>${artifact.deploy.dir}</outputDirectory>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>copy-jar</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>copy</goal>
-                                </goals>
-                                <configuration>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>${project.groupId}</groupId>
-                                            <artifactId>${project.artifactId}</artifactId>
-                                            <version>${project.version}</version>
-                                            <type>${project.packaging}</type>
-                                            <destFileName>${project.build.finalName}.${project.packaging}</destFileName>
-                                        </artifactItem>
-                                    </artifactItems>
-                                    <!--
-                                        This property is set by the submodules themself, depending wether they are backend, frontend or library
-                                        modules.
-                                        All other submodule leave this property blank causing the dependency plugin to copy the artifact inside
-                                        the target folder.
-                                    -->
-                                    <outputDirectory>${artifact.deploy.dir}</outputDirectory>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <version>3.0.0-M2</version>
-                        <executions>
-                            <execution>
-                                <id>enforce</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <configuration>
-                                    <rules>
-                                        <requireProperty>
-                                            <property>base.deploy.dir</property>
-                                            <message>You must set at least the property 'base.deploy.dir'!</message>
-                                            <regex>^.+$</regex>
-                                            <regexMessage>You must set at least the property 'base.deploy.dir'!</regexMessage>
-                                        </requireProperty>
-                                    </rules>
-                                    <fail>true</fail>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-enforcer-plugin</artifactId>
+                            <version>3.0.0-M2</version>
+                            <executions>
+                                <execution>
+                                    <id>enforce</id>
+                                    <goals>
+                                        <goal>enforce</goal>
+                                    </goals>
+                                    <configuration>
+                                        <rules>
+                                            <requireProperty>
+                                                <property>base.deploy.dir</property>
+                                                <message>You must set at least the property 'base.deploy.dir'!</message>
+                                                <regex>^.+$</regex>
+                                                <regexMessage>You must set at least the property 'base.deploy.dir'!</regexMessage>
+                                            </requireProperty>
+                                        </rules>
+                                        <fail>true</fail>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
                 </plugins>
             </build>
         </profile>

--- a/rest/authorization-server/pom.xml
+++ b/rest/authorization-server/pom.xml
@@ -171,21 +171,6 @@
 
     <profiles>
         <profile>
-            <id>deploy</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-war-plugin</artifactId>
-                        <version>2.2</version>
-                        <configuration>
-                            <outputDirectory>${webapps.dir}</outputDirectory>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>fatjar</id>
             <build>
                 <plugins>

--- a/rest/resource-server/pom.xml
+++ b/rest/resource-server/pom.xml
@@ -275,21 +275,6 @@
 
     <profiles>
         <profile>
-            <id>deploy</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-war-plugin</artifactId>
-                        <version>2.2</version>
-                        <configuration>
-                            <outputDirectory>${webapps.dir}</outputDirectory>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>fatjar</id>
             <build>
                 <plugins>


### PR DESCRIPTION
Before this commit, the maven dependency plugin was activated with
the 'deploy' profile for every module, even for the parent pom. Since
there is a configuration to copy some information from the
'build-configuration'-submodule, an initial build with active profile
failed.

This fix moves the configuration of the plugin for the 'deploy'-profile
into a 'pluginManagement'-section. This way it is only activated for
relevant modules.

This also removes the old profile sections.

Closes #621

Signed-off-by: Leo von Klenze <leo.vonklenze@scansation.de>