### PR TITLE
Fix(Project UI): Fixed Lic Info Header & Obligation when duplicating Project

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -886,11 +886,8 @@ public class ProjectPortlet extends FossologyAwarePortlet {
     private void prepareDetailView(RenderRequest request, RenderResponse response) throws IOException, PortletException {
         User user = UserCacheHolder.getUserFromRequest(request);
         String id = request.getParameter(PROJECT_ID);
-        request.setAttribute(DOCUMENT_TYPE, SW360Constants.TYPE_PROJECT);
+        setDefaultRequestAttributes(request);
         request.setAttribute(DOCUMENT_ID, id);
-        request.setAttribute(DEFAULT_LICENSE_INFO_HEADER_TEXT, getProjectDefaultLicenseInfoHeaderText());
-
-        request.setAttribute(DEFAULT_OBLIGATIONS_TEXT, getProjectDefaultObligationsText());
         if (id != null) {
             try {
                 ProjectService.Iface client = thriftClients.makeProjectClient();
@@ -1150,12 +1147,10 @@ public class ProjectPortlet extends FossologyAwarePortlet {
     private void prepareProjectEdit(RenderRequest request) {
         User user = UserCacheHolder.getUserFromRequest(request);
         String id = request.getParameter(PROJECT_ID);
-        request.setAttribute(DOCUMENT_TYPE, SW360Constants.TYPE_PROJECT);
+        setDefaultRequestAttributes(request);
         Project project;
         Set<Project> usingProjects;
         int allUsingProjectCount = 0;
-        request.setAttribute(DEFAULT_LICENSE_INFO_HEADER_TEXT, getProjectDefaultLicenseInfoHeaderText());
-        request.setAttribute(DEFAULT_OBLIGATIONS_TEXT, getProjectDefaultObligationsText());
 
         if (id != null) {
 
@@ -1214,7 +1209,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
     private void prepareProjectDuplicate(RenderRequest request) {
         User user = UserCacheHolder.getUserFromRequest(request);
         String id = request.getParameter(PROJECT_ID);
-        request.setAttribute(DOCUMENT_TYPE, SW360Constants.TYPE_PROJECT);
+        setDefaultRequestAttributes(request);
 
         try {
             if (id != null) {
@@ -1479,6 +1474,12 @@ public class ProjectPortlet extends FossologyAwarePortlet {
         } else {
             return min(projectParameters.getDisplayStart() + projectParameters.getDisplayLength(), maxSize);
         }
+    }
+
+    private void setDefaultRequestAttributes(RenderRequest request) {
+        request.setAttribute(DOCUMENT_TYPE, SW360Constants.TYPE_PROJECT);
+        request.setAttribute(DEFAULT_LICENSE_INFO_HEADER_TEXT, getProjectDefaultLicenseInfoHeaderText());
+        request.setAttribute(DEFAULT_OBLIGATIONS_TEXT, getProjectDefaultObligationsText());
     }
 
     private List<Project> sortProjectList(List<Project> projectList, PaginationParameters projectParameters) {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/edit.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/edit.jsp
@@ -57,6 +57,7 @@
     <jsp:useBean id="defaultObligationsText" class="java.lang.String" scope="request" />
 
     <core_rt:set  var="addMode"  value="${empty project.id}" />
+    <core_rt:set  var="pageName"  value="<%= request.getParameter("pagename") %>" />
 </c:catch>
 
 <%--These variables are used as a trick to allow referencing enum values in EL expressions below--%>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/administrationEdit.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/administrationEdit.jspf
@@ -244,7 +244,7 @@
 		}
         });
 
-        <core_rt:if test="${addMode}" >
+        <core_rt:if test="${addMode and pageName ne 'duplicate' }" >
             setDefaultTextAndResize($('#obligationsText'));
             setDefaultTextAndResize($('#licenseInfoHeaderText'))
         </core_rt:if>


### PR DESCRIPTION
**Issue Description:** `License Info Header` text and `obligation` text won't get copied when duplicating a `Project` from Project List table.

**Testing Description:** 
- Duplicate the existing project, and see that ( _**add mode**_) `Obligation` text and `License Info Header` text is getting copied from the source project as it is. Clicking on "Set To Default Text" button should set the Obligation / License Info Header text to default.
- Create a new project, and see that (_**add mode**_) `Obligation / License Info Header` text field are populated with default text.

closes: #631 

Signed-off-by: Abdul Kapti abdul.mannankapti@siemens.com