### PR TITLE
fix(REST-API): Corrected download link for attachments

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/AttachmentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/AttachmentController.java
@@ -97,17 +97,17 @@ public class AttachmentController implements ResourceProcessor<RepositoryLinksRe
             case PROJECT_ID:
                 Project sw360Project = projectService.getProjectForUserById(owner.getProjectId(), sw360User);
                 restControllerHelper.addEmbeddedProject(halAttachment, sw360Project);
-                downloadLink = linkTo(ProjectController.class).slash(sw360Project.getId() + "/attachment/" + sw360Project.getId() + "/" + attachmendId).withRel("downloadLink");
+                downloadLink = linkTo(ProjectController.class).slash("/api/projects/" + sw360Project.getId() + "/attachments/" + attachmendId).withRel("downloadLink");
                 break;
             case COMPONENT_ID:
                 Component sw360Component = componentService.getComponentForUserById(owner.getComponentId(), sw360User);
                 restControllerHelper.addEmbeddedComponent(halAttachment, sw360Component);
-                downloadLink = linkTo(ComponentController.class).slash(sw360Component.getId() + "/attachment/" + sw360Component.getId() + "/" + attachmendId).withRel("downloadLink");
+                downloadLink = linkTo(ComponentController.class).slash("/api/components/" + sw360Component.getId() + "/attachments/" + attachmendId).withRel("downloadLink");
                 break;
             case RELEASE_ID:
                 Release sw360Release = releaseService.getReleaseForUserById(owner.getReleaseId(), sw360User);
                 restControllerHelper.addEmbeddedRelease(halAttachment, sw360Release);
-                downloadLink = linkTo(ComponentController.class).slash("/release/" + sw360Release.getComponentId() + "/" + sw360Release.getId() + "/attachment/" + sw360Release.getId() + "/" + attachmendId).withRel("downloadLink");
+                downloadLink = linkTo(ComponentController.class).slash("/api/releases/" + sw360Release.getId() + "/attachments/" + attachmendId).withRel("downloadLink");
                 break;
         }
 


### PR DESCRIPTION
Corrected the the download attachment link for project,component  and release.

Steps to reproduce:
1. Try to access attachment info with the attachment id. The request URL should look similar to
http://localhost:8080/resource/api/attachments/5037abe393379e786693b7385400295e4
2. Look for the "sw360:downloadLink" on the response and try to download the attachment with the given link.
3. User should be able to download the attachment successfully.


closes : #465 
Signed-off-by: Nutan Das <nutan.das@siemens.com>