### PR TITLE
fix(Component UI): Fixed SPDX License import functionality for XML CLI files

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -91,6 +91,7 @@ public class PortalConstants {
     public static final String DB_TODOS_FROM_MODERATION_REQUEST = "db_todos_from_moderation_request";
     public static final String MODERATION_LICENSE_DETAIL = "moderationLicenseDetail";
     public static final String LICENSE_TYPE_CHOICE = "licenseTypeChoice";
+    public static final String LICENSE_TYPE_GLOBAL = "global";
 
     //! Specialized keys for moderation
     public static final String MODERATION_PORTLET_NAME = PORTLET_NAME_PREFIX + "moderations";
@@ -144,6 +145,7 @@ public class PortalConstants {
 
     //! Specialized keys for attachments
     public static final String ATTACHMENTS = "attachments";
+    public static final String ATTACHMENT_NAME = "attachmentName";
     public static final String SPDX_ATTACHMENTS = "spdxAttachments";
     public static final String ADDED_ATTACHMENTS = "added_attachments";
     public static final String REMOVED_ATTACHMENTS = "removed_attachments";
@@ -155,6 +157,8 @@ public class PortalConstants {
     public static final String ATTACHMENT_USAGES = "attachmentUsages";
     public static final String ATTACHMENT_USAGES_RESTRICTED_COUNTS = "attachmentUsagesRestrictedCounts";
     public static final String SPDX_LICENSE_INFO = "spdxLicenseInfo";
+    public static final String SPDX_IDENTIFIER_UNKNOWN = "SPDX identifier unknown";
+    public static final String SPDX_IDENTIFIER_NA = "n/a";
 
     //! Specialized keys for projects
     public static final String PROJECT_PORTLET_NAME = PORTLET_NAME_PREFIX + "projects";

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/clearingDetails.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/clearingDetails.jspf
@@ -27,6 +27,7 @@
         data-write-spdx-license-info-into-release-url="<%=writeSpdxLicenseInfoIntoReleaseUrl%>"
         data-release-id-parameter-name="<%=PortalConstants.RELEASE_ID%>"
         data-attachment-id-parameter-name="<%=PortalConstants.ATTACHMENT_ID%>"
+        data-attachment-name-parameter-name="<%=PortalConstants.ATTACHMENT_NAME%>"
         data-spdx-license-info-parameter-name="<%=PortalConstants.SPDX_LICENSE_INFO%>">
     <colgroup>
         <col style="width: 60%;"/>
@@ -48,7 +49,8 @@
                     <sw360:out value="${spdxAttachment.filename}"/>
                 </td>
                 <td data-attachment-id="${spdxAttachment.attachmentContentId}">
-                    <button class="btn btn-secondary showSpdxContentBtn" data-release-id="${release.id}" data-attachment-id="${spdxAttachment.attachmentContentId}">Show License Info</button>
+                    <button class="btn btn-secondary showSpdxContentBtn" data-attachment-name="${spdxAttachment.filename}"
+                    data-release-id="${release.id}" data-attachment-id="${spdxAttachment.attachmentContentId}">Show License Info</button>
                 </td>
                 <td class="result">
                 </td>
@@ -243,6 +245,7 @@
 
             url.setParameter(tableData.releaseIdParameterName, releaseId);
             url.setParameter(tableData.attachmentIdParameterName, attachmentId);
+            url.setParameter(tableData.attachmentNameParameterName, btnData.attachmentName);
 
             button.wait($btnCell.find('button'));
 
@@ -269,10 +272,10 @@
                 $cell = $row.find('.result');
 
             $cell.html('');
-            $cell.append($('<span>', { text: 'Concluded License Ids:'}));
+            $cell.append($('<span>', { text: data.license}));
             $cell.append($list);
 
-            data.concludedLicenseIds.forEach(function(id) {
+            data.licenseIds.forEach(function(id) {
                 $list.append($('<li>', { text: id }));
             });
         }


### PR DESCRIPTION
The below issue is fixed:
For **`XML CLI`** files, Clicking on **`Show License Info`** button in _**Reelase -> Clearing Details**_ tab always gives error message: `Cannot load license information: parsererror (200).`

Attached screenshot for reference:
**BEFORE:**
![Before_01_LI](https://user-images.githubusercontent.com/50870174/64427265-710c9080-d0ce-11e9-9ac6-6484793a09bb.jpg)

**STEP 1:**
![After_01_LI](https://user-images.githubusercontent.com/50870174/64427441-de202600-d0ce-11e9-9d69-0e66a7a71921.jpg)

**STEP 2:**
![After_02_LI](https://user-images.githubusercontent.com/50870174/64427445-e0828000-d0ce-11e9-8f96-f2c327bbf93b.jpg)


**AFTER:**
![After_03_LI](https://user-images.githubusercontent.com/50870174/64427459-e9735180-d0ce-11e9-8144-ea8bff8300cd.jpg)

closes #636 

Signed-off-by: Abdul Kapti <abdul.mannankapti@siemens.com>