### PR TITLE
fix(merge): Some fields were not merged

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -549,6 +549,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 .add(Component._Fields.MODERATORS)
                 .add(Component._Fields.SUBSCRIBERS)
                 .add(Component._Fields.ROLES)
+                .add(Component._Fields.OWNER_COUNTRY)
                 .build());
     }
 


### PR DESCRIPTION
The field 'owner country' was not merged during component merge.

Closes: #627

Signed-off-by: Leo von Klenze <leo.vonklenze@scansation.de>