### PR TITLE
fix(DownloadLicenseInfo): Corrected license selection based on attachment selection on attachmentusage

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -220,7 +220,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                         .filter(usage -> allUsagesByProject.stream()
                                 .noneMatch(isUsageEquivalent(usage)))
                         .collect(Collectors.toList());
-
+                setProjectPathToAttachmentUsages(usagesToCreate,project);
                 if (!usagesToDelete.isEmpty()) {
                     attachmentClient.deleteAttachmentUsages(usagesToDelete);
                 }
@@ -237,6 +237,14 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             response.setProperty(ResourceResponse.HTTP_STATUS_CODE, Integer.toString(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
         }
 
+    }
+
+    private void setProjectPathToAttachmentUsages(List<AttachmentUsage> usagesToCreate, Project project) {
+        usagesToCreate.forEach(usage -> {
+            LicenseInfoUsage licenseInfo= usage.getUsageData().getLicenseInfo();
+            if (licenseInfo != null && !licenseInfo.isSetProjectPath())
+                licenseInfo.setProjectPath(project.getId());
+        });
     }
 
     private void serveAttachmentUsagesRows(ResourceRequest request, ResourceResponse response) throws PortletException, IOException {


### PR DESCRIPTION
*   When user save the attachment usage  then project path was not getting saved in DB because of which license selection for the selected attachment was not appearing on download license info tab.
*  Now saving the project path, also during attachment usage save.

Closes: #643 
