### PR TITLE
fix(EditRelease UI): Removed duplicate field 'Licenses' from edit release

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/editReleaseInformation.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/editReleaseInformation.jspf
@@ -177,12 +177,6 @@
                                    description="Moderators" multiUsers="true" readonly="false"/>
         </td>
     </tr>
-    <tr>
-        <td width="33%">
-            <sw360:DisplayMainLicensesEdit id="<%=Release._Fields.MAIN_LICENSE_IDS.toString()%>"
-                                           licenseIds="${release.mainLicenseIds}"/>
-        </td>
-    </tr>
 </table>
 
 <script>


### PR DESCRIPTION
There were two fields for "Licenses" in edit release page. I have removed one entry to fix the same.

Signed-off-by: Nutan Das <nutan.das@siemens.com>