### PR TITLE
feature(table-filter): add filter box, fix print

### DIFF
--- a/frontend/liferay-theme/src/main/webapp/css/sw360/components/_table.scss
+++ b/frontend/liferay-theme/src/main/webapp/css/sw360/components/_table.scss
@@ -11,7 +11,8 @@
 
 table.table {
 	&.label-value-table {
-		border-color: $light-color;
+		// for some reason, the color is not applied when switching pages without the '!important' modifier.
+		border-color: $light-color !important;
 	}
 
 	th {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/databaseSanitation/duplicatesAjax.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/databaseSanitation/duplicatesAjax.jsp
@@ -26,7 +26,6 @@
 <jsp:useBean id="duplicateProjects" type="java.util.Map<java.lang.String,  java.util.List<java.lang.String>>"
              scope="request"/>
 
-<h4>Releases with the same identifier [name(version)]</h4>
 <core_rt:if test="${duplicateReleases.size()>0}">
     <h4>Releases with the same identifier [name(version)]</h4>
     <table id="duplicateReleasesTable" class="table table-bordered">

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/clearingStatus.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/clearingStatus.jspf
@@ -92,7 +92,7 @@ require(['jquery', 'bridges/datatables', 'components/includes/releases/linkProje
                 {title: "Clearing State"},
                 {title: "Clearing Report"},
                 {title: "Release Mainline State"},
-                {title: "Actions", render: {display: renderActions}, className: "five actions", orderable: false }
+                {title: "Actions", render: {display: renderActions}, className: "five actions" }
             ],
             columnDefs: [
                 {
@@ -105,7 +105,7 @@ require(['jquery', 'bridges/datatables', 'components/includes/releases/linkProje
                 }
             ],
             order: [1, 'desc']
-        });
+        }, [0, 1, 2, 3, 4], [5], true);
 
         function renderActions(id, type, row) {
             if(!row[5]) {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/vulnerabilities.jspf
@@ -166,7 +166,7 @@
                 tableDefinition.columns[0].title = '<div class="form-check"><input data-action="select-all" type="checkbox" class="form-check-input" /></div>';
             }
 
-            table = datatable.create('#vulnerabilityTable', tableDefinition, [1, 2, 3, 4, 5, 6, 7], [0]);
+            table = datatable.create('#vulnerabilityTable', tableDefinition, [1, 2, 3, 4, 5, 6], [0, 7], true);
             if($('#vulnerabilityTable').data().editable) {
                 datatable.enableCheckboxForSelection(table, 0);
             }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/mergeComponent.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/mergeComponent.jsp
@@ -136,14 +136,14 @@
             var table = datatables.create($stepElement.find('#componentSourcesTable'), {
                 data: data.components,
                 columns: [
-                    { data: "id", render: $.fn.dataTable.render.inputRadio('componentChooser'), orderable: false },
+                    { data: "id", render: $.fn.dataTable.render.inputRadio('componentChooser') },
                     { data: "name" },
                     { data: "createdBy" },
                     { data: "releases" }
                 ],
                 order: [ [ 1, 'asc' ] ],
                 select: 'single'
-            });
+            }, undefined, [0], true);
             datatables.enableCheckboxForSelection(table, 0);
         }
 

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/view.jsp
@@ -262,7 +262,7 @@
                             }},
                         {"title": "Vendor", data: "vndrs"},
                         {"title": "Component Name", data: "name", render: {display: renderComponentNameLink}},
-                        {"title": "Main Licenses", data: "lics"},
+                        {"title": "Main Licenses", data: "lics", render: {display: renderLicenseLink}},
                         {"title": "Rate", data: function(row, type, val, meta){
                                 return dataGetter(row.DT_RowId, 'rate');
                             }},
@@ -299,23 +299,24 @@
             }
 
             function renderComponentActions(id, type, row) {
-                 var $actions = $('<div>', {
-				'class': 'actions'
-			}),
-			$editAction = render.linkTo(
-			makeComponentUrl(id, '<%=PortalConstants.PAGENAME_EDIT%>'),
+                var $actions = $('<div>', {
+				    'class': 'actions'
+                    }),
+                    $editAction = render.linkTo(
+                        makeComponentUrl(id, '<%=PortalConstants.PAGENAME_EDIT%>'),
                         "",
                         '<svg class="lexicon-icon" title="Edit"><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#pencil"/></svg>'
                     ),
                     $deleteAction = $('<svg>', {
-			'class': 'delete lexicon-icon',
-			title: 'Delete',
-			'data-component-id': id,
-			'data-component-name': row.name,
-			'data-component-release-count': row.lRelsSize,
-			'data-component-attachment-count': row.attsSize,
+                        'class': 'delete lexicon-icon',
+                        title: 'Delete',
+                        'data-component-id': id,
+                        'data-component-name': row.name,
+                        'data-component-release-count': row.lRelsSize,
+                        'data-component-attachment-count': row.attsSize,
                     });
-			$deleteAction.append($('<use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#trash"/>'));
+            
+                $deleteAction.append($('<use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#trash"/>'));
 
                 $actions.append($editAction, $deleteAction);
                 return $actions[0].outerHTML;
@@ -326,14 +327,23 @@
             }
 
             function renderLicenseLink(lics, type, row) {
-                var licensePortletURL = '<%=friendlyLicenseURL%>'
+                var links = [],
+                    licensePortletURL = '<%=friendlyLicenseURL%>'
                     .replace(/components/g, "licenses");// DIRTY WORKAROUND
 
                 for (var i = 0; i < lics.length; i++) {
-                    lics[i] = render.linkTo(replaceFriendlyUrlParameter(licensePortletURL.toString(), lics[i], '<%=PortalConstants.PAGENAME_DETAIL%>'), lics[i]);
+                    links[i] = render.linkTo(replaceFriendlyUrlParameter(licensePortletURL.toString(), lics[i], '<%=PortalConstants.PAGENAME_DETAIL%>'), lics[i]);
                 }
 
-                return lics;
+                if(type == 'display') {
+                    return links.join(', ');
+                } else if(type == 'print') {
+                    return lics.join(', ');
+                } else if(type == 'type') {
+                    return 'string';
+                } else {
+                    return lics.join(', ');
+                }
             }
 
             // Export Spreadsheet action

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/ecc/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/ecc/view.jsp
@@ -109,7 +109,7 @@
             function configureEccInfoTable(){
                 return datatables.create('#eccInfoTable', {
                     searching: true
-                }, [0, 1, 2, 3, 4, 5, 6, 7]);
+                }, [0, 1, 2, 3, 4, 5, 6]);
             }
         });
     });

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/licenses/includes/detailRisks.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/licenses/includes/detailRisks.jspf
@@ -46,6 +46,6 @@
             language: {
                 emptyTable: 'No license risks analysis available.'
             }
-        }, [0, 1, 2]);
+        }, [0, 1, 2], undefined, true);
     });
 </script>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/clearingStatus.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/clearingStatus.jspf
@@ -60,12 +60,7 @@ require(['jquery', 'bridges/datatables', 'utils/includes/fossologyClearing', 'ut
         </core_rt:forEach>
 
         table = datatables.create('#releasesTable', {
-            searching: true,
             data: result,
-            dom:
-                "<'row'<'col-sm-12 col-md-9'l><'col-sm-12 col-md-2'f><'col-sm-12 col-md-1'B>>" +
-                "<'row'<'col-sm-12'tr>>" +
-                "<'row'<'col-sm-12 col-md-5'i><'col-sm-12 col-md-7'p>>",
             columns: [
                 {title: "Name"},
                 {title: "Project Origin"},
@@ -81,7 +76,7 @@ require(['jquery', 'bridges/datatables', 'utils/includes/fossologyClearing', 'ut
                     visible: $('#releasesTable').data() ? $('#releasesTable').data().detailsContext : false
                 }
             ]
-        }, [0, 1, 2, 3, 4, 5], 6);
+        }, [0, 1, 2, 3, 4, 5], 6, true);
 
         function renderActions(id, type, row) {
             var $actions = $('<div>', {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/eccStatus.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/eccStatus.jspf
@@ -53,7 +53,7 @@
                     {title: "ECC Assessor Group"},
                     {title: "ECC Assessment Date"}
                 ]
-            }, [0, 1, 2, 3, 4, 5, 6]);
+            }, [0, 1, 2, 3, 4, 5, 6], undefined, true);
         }
 
         function exportReleasesSpreadsheet() {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/vulnerabilities.jspf
@@ -201,7 +201,7 @@
                 tableDefinition.columns[0].title = '<div class="form-check"><input data-action="select-all" type="checkbox" class="form-check-input" /></div>';
             }
 
-            table = datatable.create('#vulnerabilityTable', tableDefinition, [1, 2, 3, 4, 5, 6, 7], [0]);
+            table = datatable.create('#vulnerabilityTable', tableDefinition, [1, 2, 3, 4, 5, 6, 7], [0], true);
             if($('#vulnerabilityTable').data() && $('#vulnerabilityTable').data().writeAccess) {
                 datatable.enableCheckboxForSelection(table, 0);
             }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/usingProjectsTable.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/usingProjectsTable.jspf
@@ -11,7 +11,7 @@
 --%>
 
 <core_rt:if test="${usingProjects != null && allUsingProjectsCount > 0}">
-    <div class="alert alert-info mt-default mb-0">
+    <div class="alert alert-info mt-default">
         <sw360:out value="${documentName}"/> is used by a total of ${allUsingProjectsCount}
                         (${usingProjects.size()} visible / ${allUsingProjectsCount - usingProjects.size()} restricted) projects.
     </div>
@@ -48,7 +48,7 @@
             datatables.create('#usingProjectsTable', {
                 data: result,
                 lengthChange: false
-            });
+            }, undefined, undefined, true);
         });
     </script>
 </core_rt:if>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/vulnerabilities/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/vulnerabilities/view.jsp
@@ -162,6 +162,8 @@
                             _target: '_self'
                         }).text(data);
                         return $link[0].outerHTML;
+                    } else if(type === 'print') {
+                        return data;
                     } else if(type === 'type') {
                         return 'string';
                     } else {
@@ -183,6 +185,14 @@
                         }
                         $cvss.append($.fn.dataTable.render.infoText('/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#info-circle-open'));
                         return $cvss[0].outerHTML;
+                    } else if(type === 'print') {
+                        if(data.weighting) {
+                            $cvss.text(data.weighting);
+                            if(data.time) {
+                                $cvss.append(" (as of: ").append($('<span/>').text(data.time)).append(")");
+                            }
+                        }
+                    }
                     } else if(type === 'type') {
                         return 'number';
                     } else {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/bridges/datatables.js
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/bridges/datatables.js
@@ -46,9 +46,9 @@ define('bridges/datatables', [
 
 			autoWidth: false,
 			dom:
-				"<'row'<'col-sm-12 col-md-6'l><'col-sm-12 col-md-6'B>>" +
-				"<'row'<'col-sm-12'tr>>" +
-				"<'row'<'col-sm-12 col-md-5'i><'col-sm-12 col-md-7'p>>",
+				"<'row'<'col-auto'l><'col'B>>" + 	// line above table
+				"<'row'<'col-12'tr>>" +				// table
+				"<'row'<'col-auto'i><'col'p>>",		// line below table
 			buttons: [],
 			info: true,
 			lengthMenu: [ [10, 25, 50, 100, -1], [10, 25, 50, 100, "All"] ],
@@ -63,7 +63,16 @@ define('bridges/datatables', [
 	}
 
 	return {
-		create: function(selector, config, printColumns, noSortColumns) {
+		/**
+		 * Creates a new datatable on the given selector.
+		 * 
+		 * @param {string} selector a jquery selector of the table to transform 
+		 * @param {object} config configuration object for the datatable. See its documentation for details. 
+		 * @param {array} printColumns array of column indexes of columns that should not be printed. Setting to undefined will not show the print button. 
+		 * @param {array} noSortColumns array of column indexes of columns that shoud not be sortable
+		 * @param {boolean} quickFilter flag if there should be an autosearch field on the top right corner of the table 
+		 */
+		create: function(selector, config, printColumns, noSortColumns, quickFilter) {
 			if(typeof printColumns !== 'undefined') {
 				if(!config.buttons) {
 					config.buttons = [];
@@ -75,7 +84,8 @@ define('bridges/datatables', [
 					autoPrint: true,
 					className: 'btn btn-sm btn-secondary btn-print',
 					exportOptions: {
-						columns: printColumns
+						columns: printColumns,
+						orthogonal: "print"
 					}
 				});
 			}
@@ -89,6 +99,20 @@ define('bridges/datatables', [
 					targets: noSortColumns,
 					orderable: false
 				});
+			}
+
+			if(quickFilter) {
+				config.searching = true;
+
+				if(typeof printColumns !== 'undefined' && printColumns.length > 0) {
+					config.dom = "<'row'<'col-auto'l><'col'f><'col-auto'B>>"; 	// line above table
+				} else {
+					config.dom = "<'row'<'col-auto'l><'col'f>>"; 	// line above table
+				}
+
+				config.dom += '' +
+					"<'row'<'col-12'tr>>" +			// table
+					"<'row'<'col-auto'i><'col'p>>"; // line below table
 			}
 
 			return $(selector).DataTable(config);

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/modules/datatables-renderer.js
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/modules/datatables-renderer.js
@@ -212,7 +212,7 @@ define('modules/datatables-renderer', ['jquery', 'modules/dialog', /* jquery-plu
         return function(key, type, row, meta) {
             var select;
 
-            if(type === 'filter' || type === 'sort') {
+            if(type === 'filter' || type === 'sort' || type === 'print') {
                 return meta.settings.json[selectDataKey][key];
             } else if(type === 'display') {
                 select = createSelectInput(selectDataKey, meta.settings.json[selectDataKey], name, clazz, optionClazz, key);


### PR DESCRIPTION
This commits adds an option to the generic create-method for datatables as
well as fixes the print button on some pages.

* Filter Box
There is no one more parameter to the create-method of the bridges/datatables
module. Giving true as last parameter will add a filter box at the top right
for the datatable.
This option has been set on many pages now, except where explicit quick filters
already exist.

* Fix print button
When adding a print button, the additional option 'orthogonal' has been set.
With this option in place, all render methods are called with type set to
'print' when printing. This way renderer can omit html tags or links when
rendering for print view. Renderes has been adapted as necessary.

Closes #657

Signed-off-by: Leo von Klenze <leo.vonklenze@scansation.de>