### PR TITLE
fix(LicenseDisclosureDocument): Ordering and formating license disclosure document.

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/OutputGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/OutputGenerator.java
@@ -41,7 +41,6 @@ import java.util.stream.Stream;
 public abstract class OutputGenerator<T> {
     protected static final String VELOCITY_TOOLS_FILE = "velocity-tools.xml";
     protected static final String LICENSE_REFERENCE_ID_MAP_CONTEXT_PROPERTY = "licenseNameWithTextToReferenceId";
-    protected static final String LICENSENAMES = "licenseNames";
     protected static final String ACKNOWLEDGEMENTS_CONTEXT_PROPERTY = "acknowledgements";
     protected static final String ALL_LICENSE_NAMES_WITH_TEXTS = "allLicenseNamesWithTexts";
     protected static final String LICENSE_INFO_RESULTS_CONTEXT_PROPERTY = "licenseInfoResults";
@@ -238,7 +237,6 @@ public abstract class OutputGenerator<T> {
         // sorted lists of all license to be displayed at the end of the file at once
         List<LicenseNameWithText> licenseNamesWithTexts = getSortedLicenseNameWithTexts(projectLicenseInfoResults);
         vc.put(ALL_LICENSE_NAMES_WITH_TEXTS, licenseNamesWithTexts);
-        Set<String> licenseNames = new TreeSet<String>();
         // assign a reference id to each license in order to only display references for
         // each release. The references will point to
         // the list with all details at the and of the file (see above)
@@ -246,10 +244,8 @@ public abstract class OutputGenerator<T> {
         Map<LicenseNameWithText, Integer> licenseToReferenceId = Maps.newHashMap();
         for (LicenseNameWithText licenseNamesWithText : licenseNamesWithTexts) {
             licenseToReferenceId.put(licenseNamesWithText, referenceId++);
-            licenseNames.add(licenseNamesWithText.getLicenseName());
         }
         vc.put(LICENSE_REFERENCE_ID_MAP_CONTEXT_PROPERTY, licenseToReferenceId);
-        vc.put(LICENSENAMES, licenseNames);
 
         Map<Boolean, List<LicenseInfoParsingResult>> partitionedResults =
                 projectLicenseInfoResults.stream().collect(Collectors.partitioningBy(r -> r.getStatus() == LicenseInfoRequestStatus.SUCCESS));

--- a/backend/src/src-licenseinfo/src/main/resources/textLicenseInfoFile.vm
+++ b/backend/src/src-licenseinfo/src/main/resources/textLicenseInfoFile.vm
@@ -30,7 +30,11 @@ Open Source Software Contained in this Product/Device:
 
 
 #if($licenseInfoResults.keySet().size() > 0)
+Details
+========
+
 #foreach($releaseName in $licenseInfoResults.keySet())
+
 ## Acknowledgments
 ##
 #set($acks = [])
@@ -51,7 +55,6 @@ $ack
 ## Licenses
 ##
 #set($licenses = [])
-#set($licenseId = 1)
 #if(${licenseInfoResults.get($releaseName).licenseInfo})
 #set($licenses = $licenseInfoResults.get($releaseName).licenseInfo.licenseNamesWithTexts)
 Licenses for $releaseName
@@ -59,17 +62,31 @@ Licenses for $releaseName
 #if($licenses.size() == 0)
 <No licenses found>
 #else## if($licenses.size() > 0)
-#foreach($license in ${licenseNames})
+#foreach($license in ${licenses})
 #set($licenseName = "<no license name available>")
-#if($license)
-#set($licenseName = $license)
-#end## if($license)
-($licenseId) $licenseName
-#set($licenseId = $licenseId + 1)
-#end## foreach($license in ${licenseNames})
+#if($license.licenseName)
+#set($licenseName = $license.licenseName)
+#end## if($license.licenseName)
+#set($licenseId = $licenseNameWithTextToReferenceId.get($license))
+* $licenseName ($licenseId)
+#end## foreach($license in ${licenses})
 #end## if($licenses.size() > 0)
+#set($copyrights = [])
+#if(${licenseInfoResults.get($releaseName).licenseInfo})
+#set($copyrights = $licenseInfoResults.get($releaseName).licenseInfo.copyrights)
+#if($copyrights.size() > 0)
+
+Copyright Notices for $releaseName
+-----------------
+#foreach($copyright in ${copyrights})
+$copyright
+#end## foreach($copyright in ${copyrights})
 
 
+#end## if($copyrights.size() > 0)
+#end## if(${licenseInfoResults.get($releaseName).licenseInfo})
+##
+##
 #end## if(${licenseInfoResults.get($releaseName).licenseInfo})
 ##
 #end## foreach($releaseName in $licenseInfoResults.keySet())
@@ -103,30 +120,3 @@ $licenseText.trim()
 Definition of Open Source Software
 ==================================
 As used herein, the term “Open Source Software” means any software that is licensed royalty-free (i.e., fees for exercising the licensed rights are prohibited, whereas fees for reimbursement of costs incurred by licensor are generally permitted) under any license terms which allow all users to modify such software. “Open Source Software” as used here may require, as a condition of modification and/or distribution that the source code of such software be made available to all users of the software for purposes of information and modification.
-
-#if($licenseInfoResults.keySet().size() > 0)
-Details
-========
-
-##
-##
-## Copyrights
-##
-#foreach($releaseName in $licenseInfoResults.keySet())
-#set($copyrights = [])
-#if(${licenseInfoResults.get($releaseName).licenseInfo})
-#set($copyrights = $licenseInfoResults.get($releaseName).licenseInfo.copyrights)
-#if($copyrights.size() > 0)
-Copyright Notices for $releaseName
------------------
-#foreach($copyright in ${copyrights})
-$copyright
-#end## foreach($copyright in ${copyrights})
-
-
-#end## if($copyrights.size() > 0)
-#end## if(${licenseInfoResults.get($releaseName).licenseInfo})
-#end## foreach($releaseName in $licenseInfoResults.keySet())
-#end## if($licenseInfoResults.keySet().size() > 0)
-##
-##

--- a/backend/src/src-licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
+++ b/backend/src/src-licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
@@ -123,6 +123,8 @@
                             <a class="top" href="#releaseHeader">&#8679;</a>
                         </h3>
                     </div>
+
+
                     #if(${acknowledgements.get($releaseName)})
                         Acknowledgements:<br/>
                             #set($acks = [])
@@ -136,24 +138,33 @@ $esc.xml($ack)
 
                     Licenses:<br/>
                     #set($licenses = [])
-                    #set($licenseId = 1)
                     #if(${licenseInfoResults.get($releaseName).licenseInfo})
                         #set($licenses = $licenseInfoResults.get($releaseName).licenseInfo.licenseNamesWithTexts)
                         #if($licenses.size() > 0)
                             <ul style="list-style-type:none" class="licenseEntries">
-                            #foreach($license in ${licenseNames})
+                            #foreach($license in ${licenses})
                                 #set($licenseName = "&lt;no license name available&gt;")
-                                #if($license)
-                                    #set($licenseName = $esc.xml($license))
+                                #if($license.licenseName)
+                                    #set($licenseName = $esc.xml($license.licenseName))
                                 #end
+                                #set($licenseId = $licenseNameWithTextToReferenceId.get($license))
                                 <li class="licenseEntry" id="licenseEntry$licenseId" title="$licenseName">
-                                    <a href="#$licenseName">($licenseId) $licenseName </a>
-                                    #set($licenseId = $licenseId + 1)
+                                    <a href="#licenseTextItem$licenseId">$licenseName ($licenseId)</a>
                                </li>
                             #end
                             </ul>
                         #end
                     #end
+                     #set($copyrights = [])
+                        #if(${licenseInfoResults.get($releaseName).licenseInfo})
+                            #set($copyrights = $licenseInfoResults.get($releaseName).licenseInfo.copyrights)
+    <pre class="copyrights">
+#foreach($copyright in ${copyrights})
+$esc.xml($copyright)
+#end
+<h3><a class="top" href="#releaseHeader">&#8679;</a></h3>
+    </pre>
+                        #end
                 </li>
             #end
         </ul>
@@ -178,7 +189,7 @@ $esc.xml($ack)
             #end
 
             #set($licenseId = $licenseNameWithTextToReferenceId.get($license))
-            <li id="$licenseName">
+            <li id="licenseTextItem$licenseId">
                 <h3>$licenseId: $licenseName<a class="top" href="#releaseHeader">&#8679;</a></h3>
     <pre class="licenseText" id="licenseText$licenseId">
 $licenseText
@@ -187,21 +198,6 @@ $licenseText
         #end
         </ul>
     #end
-<ul id="releases" style="list-style-type:none">
-    #foreach($releaseName in $licenseInfoResults.keySet())
-        <li id="$esc.xml($releaseName).replace(" ","_").replace(",","-")" class="release" title="$esc.xml($releaseName)">
-        #set($copyrights = [])
-       #if(${licenseInfoResults.get($releaseName).licenseInfo})
-           #set($copyrights = $licenseInfoResults.get($releaseName).licenseInfo.copyrights)
-           <pre class="copyrights">
-           #foreach($copyright in ${copyrights})
-$esc.xml($copyright)
-           #end
-           </pre>
-       #end
-            </li>
-    #end
-</ul>
-<h3><a class="top" href="#releaseHeader">&#8679;</a></h3>
+
 </body>
 </html>


### PR DESCRIPTION
This change will add ordering and formatting for all three types (docx,html,txt) of license disclosure document. 
- Copyrights to be displayed for each component.
- Running number for each license name of corresponding license text on the license listing.
- Provided license name and link to the corresponding license text.

