### PR TITLE
fix(Componnet): ComponentType field should be mandatory

### DIFF
--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -225,6 +225,7 @@ public class ComponentHandler implements ComponentService.Iface {
         assertNotNull(component);
         assertIdUnset(component.getId());
         assertUser(user);
+        assertNotNull(component.getComponentType(), "ComponentType is not present on the request");
 
         return handler.addComponent(component, user.getEmail());
     }

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/ComponentHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/ComponentHandlerTest.java
@@ -54,7 +54,7 @@ public class ComponentHandlerTest {
     @Test
     public void testGetByUploadId() throws Exception {
 
-        Component originalComponent = new Component("name").setDescription("a desc");
+        Component originalComponent = new Component("name").setDescription("a desc").setComponentType(ComponentType.OSS);
         String componentId = componentHandler.addComponent(originalComponent, adminUser).getId();
 
         Release release = new Release("name", "version", componentId);

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/editBasicInfo.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/editBasicInfo.jspf
@@ -50,8 +50,8 @@
     <tr>
         <td>
             <div class="form-group">
-                <label for="comp_componenttype">Component Type</label>
-                <select class="form-control" id="comp_componenttype" name="<portlet:namespace/><%=Component._Fields.COMPONENT_TYPE%>">
+                <label class="mandatory" for="comp_componenttype">Component Type</label>
+                <select class="form-control" id="comp_componenttype" required name="<portlet:namespace/><%=Component._Fields.COMPONENT_TYPE%>">
                     <option value=""></option>
                     <sw360:DisplayEnumOptions type="<%=ComponentType.class%>" selected="${component.componentType}"/>
                 </select>
@@ -59,6 +59,9 @@
                     <sw360:DisplayEnumInfo type="<%=ComponentType.class%>"/>
                     Learn more about component types.
                 </small>
+                <div class="invalid-feedback">
+                    Please enter component type
+                </div>
             </div>
         </td>
         <td>

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -43,6 +43,7 @@ import org.springframework.hateoas.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
@@ -174,6 +175,9 @@ public class ComponentController implements ResourceProcessor<RepositoryLinksRes
     public ResponseEntity<Resource<Component>> createComponent(@RequestBody Component component) throws URISyntaxException, TException {
 
         User user = restControllerHelper.getSw360UserFromAuthentication();
+        if(component.getComponentType() == null) {
+            throw new HttpMessageNotReadableException("Required field componentType is not present");
+        }
 
         if (component.getVendorNames() != null) {
             Set<String> vendors = new HashSet<>();


### PR DESCRIPTION
1. Added a fix to make the component type field as mandatory. 
2. This fix is  both for SW360 UI and Rest end point. 
3. From rest end point user might not get the exact error response with field name,  if component type input is left  blank.  Rest end point field validation  will be taken care as part of issue fix for  
#584 .

closes: #676 