### PR TITLE
feature(merge): add wizard for merging vendors

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -194,6 +194,10 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return releaseRepository.getReleasesFromVendorIds(ids);
     }
 
+    public Set<Release> getReleasesByVendorId(String vendorId) {
+        return releaseRepository.getReleasesByVendorId(vendorId);
+    }
+
     public List<Release> getReleasesFromComponentId(String id, User user) throws TException {
         return releaseRepository.getReleasesFromComponentId(id, user);
     }
@@ -852,6 +856,10 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return requestSummary;
     }
 
+    public RequestSummary updateReleasesDirectly(Set<Release> releases, User user) throws SW360Exception {
+        return RepositoryUtils.doBulk(prepareReleases(releases), user, releaseRepository);
+    }
+
     public RequestStatus updateReleaseFromAdditionsAndDeletions(Release releaseAdditions, Release releaseDeletions, User user){
 
         try {
@@ -865,7 +873,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
     }
 
-    protected Component updateReleaseDependentFieldsForComponentId(String componentId) {
+    public Component updateReleaseDependentFieldsForComponentId(String componentId) {
         Component component = componentRepository.get(componentId);
         recomputeReleaseDependentFields(component, null);
         componentRepository.update(component);
@@ -1238,6 +1246,10 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
     public Set<Component> getUsingComponents(Set<String> releaseIds) {
         return componentRepository.getUsingComponents(releaseIds);
+    }
+
+    public Set<Component> getComponentsByDefaultVendorId(String vendorId) {
+        return componentRepository.getComponentsByDefaultVendorId(vendorId);
     }
 
     public Component getComponentForReportFromFossologyUploadId(String uploadId) {

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
@@ -91,6 +91,12 @@ import java.util.*;
                         "       emit( [externalId, doc.externalIds[externalId]] , doc._id);" +
                         "    }" +
                         "  }" +
+                        "}"),
+        @View(name = "byDefaultVendorId",
+                map = "function(doc) {" +
+                        "  if (doc.type == 'component') {" +
+                        "       emit( doc.defaultVendorId , doc._id);" +
+                        "  }" +
                         "}")
 })
 public class ComponentRepository extends SummaryAwareRepository<Component> {
@@ -163,6 +169,11 @@ public class ComponentRepository extends SummaryAwareRepository<Component> {
     public Set<Component> getUsingComponents(Set<String> releaseIds) {
         final Set<String> componentIdsByLinkingRelease = queryForIdsAsValue("byLinkingRelease", releaseIds);
         return new HashSet<>(get(componentIdsByLinkingRelease));
+    }
+
+    public Set<Component> getComponentsByDefaultVendorId(String defaultVendorId) {
+        final Set<String> componentIds = queryForIdsAsValue("byDefaultVendorId", defaultVendorId);
+        return new HashSet<>(get(componentIds));
     }
 
     public Set<Component> searchByExternalIds(Map<String, Set<String>> externalIds) {

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
@@ -128,12 +128,14 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
     }
 
     public List<Release> getReleasesFromVendorIds(Set<String> ids) {
-
         return makeSummaryFromFullDocs(SummaryType.SHORT, queryByIds("releaseByVendorId", ids));
     }
 
-    public List<Release> searchReleasesByUsingLicenseId(String licenseId) {
+    public Set<Release> getReleasesByVendorId(String vendorId) {
+        return new HashSet<>(queryView("releaseByVendorId", vendorId));
+    }
 
+    public List<Release> searchReleasesByUsingLicenseId(String licenseId) {
         return queryView("releaseIdsByLicenseId", licenseId);
     }
 

--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -216,6 +216,11 @@ public class ComponentHandler implements ComponentService.Iface {
         return handler.getReleasesFromVendorIds(ids);
     }
 
+    @Override
+    public Set<Release> getReleasesByVendorId(String vendorId) throws TException {
+        return handler.getReleasesByVendorId(vendorId);
+    }
+    
     ////////////////////////////
     // ADD INDIVIDUAL OBJECTS //
     ////////////////////////////
@@ -298,6 +303,12 @@ public class ComponentHandler implements ComponentService.Iface {
         return handler.updateReleases(releases, user);
     }
 
+    @Override
+    public RequestSummary updateReleasesDirectly(Set<Release> releases, User user) throws TException {
+        assertUser(user);
+        return handler.updateReleasesDirectly(releases, user);
+    }
+
     public RequestStatus updateReleaseFromModerationRequest(Release releaseAdditions, Release releaseDeletions, User user) {
         return handler.updateReleaseFromAdditionsAndDeletions(releaseAdditions, releaseDeletions, user);
     }
@@ -342,6 +353,11 @@ public class ComponentHandler implements ComponentService.Iface {
     }
 
     @Override
+    public Set<Component> getComponentsByDefaultVendorId(String defaultVendorId) throws TException {
+        return handler.getComponentsByDefaultVendorId(defaultVendorId);
+    }
+
+    @Override
     public boolean releaseIsUsed(String releaseId) throws TException {
         return handler.checkIfInUse(releaseId);
     }
@@ -349,6 +365,11 @@ public class ComponentHandler implements ComponentService.Iface {
     @Override
     public boolean componentIsUsed(String componentId) throws TException {
         return handler.checkIfInUseComponent(componentId);
+    }
+
+    @Override
+    public Component recomputeReleaseDependentFields(String componentId) throws TException {
+        return handler.updateReleaseDependentFieldsForComponentId(componentId);
     }
 
     //////////////////////////////////

--- a/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorDatabaseHandler.java
+++ b/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorDatabaseHandler.java
@@ -11,23 +11,32 @@ package org.eclipse.sw360.vendors;
 
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.db.VendorRepository;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.datahandler.thrift.ThriftUtils;
+import org.eclipse.sw360.datahandler.thrift.components.Component;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
+import org.eclipse.sw360.datahandler.thrift.moderation.ModerationService;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.ektorp.http.HttpClient;
 
 import java.net.MalformedURLException;
+import java.util.HashSet;
 import java.util.List;
-import java.util.function.BiFunction;
-import java.util.function.Function;
+import java.util.Set;
 import java.util.function.Supplier;
 
-import static com.google.common.base.Strings.nullToEmpty;
+import com.google.common.collect.ImmutableSet;
+
 import static org.eclipse.sw360.datahandler.common.SW360Assert.assertNotNull;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.prepareVendor;
@@ -70,8 +79,6 @@ public class VendorDatabaseHandler {
             log.error("User is not allowed to delete!");
             return RequestStatus.FAILURE;
         }
-
-
     }
 
     public RequestStatus updateVendor(Vendor vendor, User user) {
@@ -84,8 +91,105 @@ public class VendorDatabaseHandler {
         }
     }
 
-
     public void fillVendor(Release release){
         repository.fillVendor(release);
     }
+
+    public RequestStatus mergeVendors(String mergeTargetId, String mergeSourceId, Vendor mergeSelection, User user) throws TException {
+        Vendor mergeTarget = getByID(mergeTargetId);
+        Vendor mergeSource = getByID(mergeSourceId);
+       
+        if (!makePermission(mergeTarget, user).isActionAllowed(RequestedAction.WRITE)
+                || !makePermission(mergeSource, user).isActionAllowed(RequestedAction.WRITE)
+                || !makePermission(mergeSource, user).isActionAllowed(RequestedAction.DELETE)) {
+            return RequestStatus.ACCESS_DENIED;
+        }
+
+        if (isVendorUnderModeration(mergeTargetId) ||
+                isVendorUnderModeration(mergeSourceId)){
+            return RequestStatus.IN_USE;
+        }
+
+        try {
+            RequestSummary summary;
+
+            // First merge everything into the new compontent which is mergable in one step (attachments, plain fields)
+            mergePlainFields(mergeSelection, mergeTarget);
+            RequestStatus status = updateVendor(mergeTarget, user);
+            if(status != RequestStatus.SUCCESS) {
+                return status;
+            }
+           
+            // now update the vendor in relating documents
+            summary = updateComponents(mergeTarget, mergeSource, user);
+            if(summary.getRequestStatus() != RequestStatus.SUCCESS) {
+                log.error("Cannot update [" + (summary.getTotalElements() - summary.getTotalAffectedElements()) 
+                    + "] of [" + summary.getTotalElements() + "] components: " + summary.getMessage());
+                return summary.getRequestStatus();
+            }
+
+            summary = updateReleases(mergeTarget, mergeSource, user);
+            if(summary.getRequestStatus() != RequestStatus.SUCCESS) {
+                log.error("Cannot update [" + (summary.getTotalElements() - summary.getTotalAffectedElements()) 
+                    + "] of [" + summary.getTotalElements() + "] releases: " + summary.getMessage());
+                return summary.getRequestStatus();
+            }
+
+            // Finally we can delete the source vendor
+            return deleteVendor(mergeSourceId, user);
+        } catch(Exception e) {
+            log.error("Cannot merge vendor [" + mergeSource.getId() + "] into [" + mergeTarget.getId() + "].", e);
+            return RequestStatus.FAILURE;
+        }
+    }
+
+    private void mergePlainFields(Vendor mergeSelection, Vendor mergeTarget) {
+        ThriftUtils.copyFields(mergeSelection, mergeTarget, ImmutableSet.<Vendor._Fields>builder()
+                .add(Vendor._Fields.FULLNAME)
+                .add(Vendor._Fields.SHORTNAME)
+                .add(Vendor._Fields.URL)
+                .build()
+        );
+    }
+
+    private RequestSummary updateComponents(Vendor mergeTarget, Vendor mergeSource, User user) throws TException {
+        ComponentService.Iface componentsClient = new ThriftClients().makeComponentClient();
+
+        Set<Component> components = componentsClient.getComponentsByDefaultVendorId(mergeSource.getId());
+        components.stream().forEach(component -> {
+            component.setDefaultVendorId(mergeTarget.getId());
+        });
+        
+        return componentsClient.updateComponents(components, user);
+    }
+
+    private RequestSummary updateReleases(Vendor mergeTarget, Vendor mergeSource, User user) throws TException {
+        ComponentService.Iface componentsClient = new ThriftClients().makeComponentClient();
+
+        Set<String> componentIds = new HashSet<>();
+        Set<Release> releases = componentsClient.getReleasesByVendorId(mergeSource.getId());
+        releases.stream().forEach(release -> {
+            componentIds.add(release.getComponentId());
+            release.setVendorId(mergeTarget.getId());
+        });
+
+        RequestSummary result = componentsClient.updateReleasesDirectly(releases, user);
+        if(result.getRequestStatus() != RequestStatus.SUCCESS) {
+            return result;
+        }
+
+        // update computed fields of affected components
+        for(String componentId : componentIds) {
+            componentsClient.recomputeReleaseDependentFields(componentId);
+        }
+
+        return result;
+    }
+
+    private boolean isVendorUnderModeration(String vendorId) throws TException {
+        ModerationService.Iface moderationClient = new ThriftClients().makeModerationClient();
+        List<ModerationRequest> sourceModerationRequests = moderationClient.getModerationRequestByDocumentId(vendorId);
+        return sourceModerationRequests.stream().anyMatch(CommonUtils::isInProgressOrPending);
+    }
+
 }

--- a/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorHandler.java
+++ b/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorHandler.java
@@ -25,13 +25,6 @@ import java.util.List;
 import java.util.Set;
 
 import static org.eclipse.sw360.datahandler.common.SW360Assert.*;
-
-/**
- * Implementation of the Thrift service
- *
- * @author Cedric.Bodet@tngtech.com
- * @author Johannes.Najjar@tngtech.com
- */
 public class VendorHandler implements VendorService.Iface {
 
     private final VendorDatabaseHandler vendorDatabaseHandler;
@@ -105,5 +98,14 @@ public class VendorHandler implements VendorService.Iface {
         assertNotNull(vendor);
 
         return vendorDatabaseHandler.updateVendor(vendor, user);
+    }
+
+    @Override
+    public RequestStatus mergeVendors(String mergeTargetId, String mergeSourceId, Vendor mergeSelection, User user) throws TException {
+        assertNotNull(mergeTargetId);
+        assertNotNull(mergeSourceId);
+        assertNotNull(mergeSelection);
+        
+        return vendorDatabaseHandler.mergeVendors(mergeTargetId, mergeSourceId, mergeSelection, user);
     }
 }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -138,6 +138,10 @@ public class PortalConstants {
     public static final String VENDOR = "vendor";
     public static final String VENDOR_ID = "vendorId";
     public static final String VENDOR_LIST = "vendorList";
+    public static final String VENDOR_SELECTION = "vendorSelection";
+    public static final String VENDOR_SOURCE_ID = "vendorSourceId";
+    public static final String VENDOR_TARGET_ID = "vendorTargetId";
+    public static final String PAGENAME_MERGE_VENDOR = "mergeVendor";
 
     //! Specialized keys for todos
     public static final String TODO_LIST = "todoList";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/VendorPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/VendorPortlet.java
@@ -10,17 +10,29 @@
  */
 package org.eclipse.sw360.portal.portlets.admin;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
+import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.PortletResponseUtil;
+import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vendors.VendorService;
 import org.eclipse.sw360.exporter.VendorExporter;
+import org.eclipse.sw360.portal.common.PortalConstants;
 import org.eclipse.sw360.portal.common.UsedAsLiferayAction;
 import org.eclipse.sw360.portal.portlets.Sw360Portlet;
 import org.eclipse.sw360.portal.portlets.components.ComponentPortletUtils;
@@ -28,11 +40,14 @@ import org.eclipse.sw360.portal.users.UserCacheHolder;
 
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
+import org.apache.thrift.TSerializer;
+import org.apache.thrift.protocol.TSimpleJSONProtocol;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import javax.portlet.*;
 import javax.servlet.http.HttpServletResponse;
@@ -62,6 +77,10 @@ import static org.eclipse.sw360.portal.common.PortalConstants.*;
 public class VendorPortlet extends Sw360Portlet {
 
     private static final Logger log = Logger.getLogger(VendorPortlet.class);
+
+    private static final JsonFactory JSON_FACTORY = new JsonFactory();
+    private static final TSerializer JSON_THRIFT_SERIALIZER = new TSerializer(new TSimpleJSONProtocol.Factory());
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     /**
      * Excel exporter
@@ -106,6 +125,9 @@ public class VendorPortlet extends Sw360Portlet {
         if (PAGENAME_EDIT.equals(pageName)) {
             prepareVendorEdit(request);
             include("/html/admin/vendors/edit.jsp", request, response);
+        }  else if (PAGENAME_MERGE_VENDOR.equals(pageName)) {
+            prepareVendorMerge(request, response);
+            include("/html/admin/vendors/mergeVendor.jsp", request, response);
         } else {
             prepareStandardView(request);
             super.doView(request, response);
@@ -132,6 +154,28 @@ public class VendorPortlet extends Sw360Portlet {
         }
         else{
             request.setAttribute(RELEASE_LIST, Collections.emptyList());
+        }
+    }
+
+    private void prepareVendorMerge(RenderRequest request, RenderResponse response) throws PortletException {
+        String vendorId = request.getParameter(VENDOR_ID);
+
+        if (isNullOrEmpty(vendorId)) {
+            throw new PortletException("Vendor ID not set!");
+        }
+
+        try {
+            VendorService.Iface client = thriftClients.makeVendorClient();
+            Vendor vendor = client.getByID(vendorId);
+            request.setAttribute(VENDOR, vendor);
+            addVendorBreadcrumb(request, response, vendor);
+
+            PortletURL mergeUrl = response.createRenderURL();
+            mergeUrl.setParameter(PortalConstants.PAGENAME, PortalConstants.PAGENAME_MERGE_VENDOR);
+            mergeUrl.setParameter(PortalConstants.VENDOR_ID, vendorId);
+            addBreadcrumbEntry(request, "Merge", mergeUrl);
+        } catch (TException e) {
+            log.error("Error fetching release from backend!", e);
         }
     }
 
@@ -189,5 +233,146 @@ public class VendorPortlet extends Sw360Portlet {
         } catch (TException e) {
             log.error("Error adding vendor", e);
         }
+    }
+
+    private void addVendorBreadcrumb(RenderRequest request, RenderResponse response, Vendor vendor) {
+        PortletURL vendorUrl = response.createRenderURL();
+        vendorUrl.setParameter(PAGENAME, PAGENAME_VIEW);
+
+        PortalUtil.addPortletBreadcrumbEntry(PortalUtil.getOriginalServletRequest(PortalUtil.getHttpServletRequest(request)),
+            vendor.getFullname(), vendorUrl.toString());
+    }
+
+    @UsedAsLiferayAction
+    public void vendorMergeWizardStep(ActionRequest request, ActionResponse response) throws IOException, PortletException {
+        int stepId = Integer.parseInt(request.getParameter("stepId"));
+        try {
+            HttpServletResponse httpServletResponse = PortalUtil.getHttpServletResponse(response);
+            httpServletResponse.setContentType(ContentTypes.APPLICATION_JSON);
+            JsonGenerator jsonGenerator = JSON_FACTORY.createGenerator(httpServletResponse.getWriter());
+
+            switch(stepId) {
+                case 0:
+                    generateSourceVendorsForMergeForWizardStep0(request, jsonGenerator);
+                    break;
+                case 1:
+                    generateCompareEditorForWizardStep1(request, jsonGenerator);
+                    break;
+                case 2:
+                    generateResultPreviewForWizardStep2(request, jsonGenerator);
+                    break;
+                case 3:
+                    mergeVendorsForWizardStep3(request, jsonGenerator);
+                    break;
+                default:
+                throw new SW360Exception("Step with id <" + stepId + "> not supported!");
+            }
+
+            jsonGenerator.close();
+        } catch (Exception e) {
+            log.error("An error occurred while generating a response to vendor merge wizard", e);
+            response.setProperty(ResourceResponse.HTTP_STATUS_CODE,
+                    Integer.toString(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    private void generateSourceVendorsForMergeForWizardStep0(ActionRequest request, JsonGenerator jsonGenerator) throws IOException, TException {
+        String targetId = request.getParameter(VENDOR_TARGET_ID);
+        VendorService.Iface client = thriftClients.makeVendorClient();
+        List<Vendor> vendors = client.getAllVendors();
+
+        jsonGenerator.writeStartObject();
+
+        jsonGenerator.writeArrayFieldStart("vendors");
+        vendors.stream().filter(vendor -> !vendor.getId().equals(targetId)).forEach(vendor -> {
+            try {
+                jsonGenerator.writeStartObject();
+                jsonGenerator.writeStringField("id", vendor.getId());
+                jsonGenerator.writeStringField("fullname", vendor.getFullname());
+                jsonGenerator.writeStringField("shortname", vendor.getShortname());
+                jsonGenerator.writeStringField("url", vendor.getUrl());
+                jsonGenerator.writeEndObject();
+            } catch (IOException e) {
+                log.error("An error occurred while generating wizard response", e);
+            }
+        });
+        jsonGenerator.writeEndArray();
+
+        jsonGenerator.writeEndObject();
+    }
+
+    private void generateCompareEditorForWizardStep1(ActionRequest request, JsonGenerator jsonGenerator) throws IOException, TException {
+        String vendorTargetId = request.getParameter(VENDOR_TARGET_ID);
+        String vendorSourceId = request.getParameter(VENDOR_SOURCE_ID);
+
+        VendorService.Iface client = thriftClients.makeVendorClient();
+        Vendor vendorTarget = client.getByID(vendorTargetId);
+        Vendor vendorSource = client.getByID(vendorSourceId);
+
+        User user = UserCacheHolder.getUserFromRequest(request);
+        ComponentService.Iface componentClient = thriftClients.makeComponentClient();
+        Set<Component> components = componentClient.getComponentsByDefaultVendorId(vendorSourceId);
+        Set<Release> releases = componentClient.getReleasesByVendorId(vendorSourceId);
+
+        jsonGenerator.writeStartObject();
+        jsonGenerator.writeRaw("\"vendorTarget\":" + JSON_THRIFT_SERIALIZER.toString(vendorTarget) + ",");
+        jsonGenerator.writeRaw("\"vendorSource\":" + JSON_THRIFT_SERIALIZER.toString(vendorSource) + ",");
+        jsonGenerator.writeNumberField("affectedComponents",  components.size());
+        jsonGenerator.writeNumberField("affectedReleases",  releases.size());
+        jsonGenerator.writeEndObject();
+    }
+
+    private void generateResultPreviewForWizardStep2(ActionRequest request, JsonGenerator jsonGenerator)
+            throws IOException, TException {
+        Vendor vendorSelection = OBJECT_MAPPER.readValue(request.getParameter(VENDOR_SELECTION), Vendor.class);
+        String vendorSourceId = request.getParameter(VENDOR_SOURCE_ID);
+        
+        jsonGenerator.writeStartObject();
+
+        // adding common title
+        jsonGenerator.writeRaw("\""+ VENDOR_SELECTION +"\":" + JSON_THRIFT_SERIALIZER.toString(vendorSelection) + ",");
+        jsonGenerator.writeStringField(VENDOR_SOURCE_ID, vendorSourceId);
+
+        jsonGenerator.writeEndObject();
+    }
+
+    private void mergeVendorsForWizardStep3(ActionRequest request, JsonGenerator jsonGenerator)
+            throws IOException, TException {
+        VendorService.Iface vendorClient = thriftClients.makeVendorClient();
+
+        // extract request data
+        Vendor vendorSelection = OBJECT_MAPPER.readValue(request.getParameter(VENDOR_SELECTION), Vendor.class);
+        String vendorSourceId = request.getParameter(VENDOR_SOURCE_ID);
+
+        // perform the real merge, update merge target and delete merge source
+        User sessionUser = UserCacheHolder.getUserFromRequest(request);
+        RequestStatus status = vendorClient.mergeVendors(vendorSelection.getId(), vendorSourceId, vendorSelection, sessionUser);
+        
+        // write response JSON
+        jsonGenerator.writeStartObject();
+
+        jsonGenerator.writeStringField("redirectUrl", createViewUrl(request).toString());
+        if (status == RequestStatus.IN_USE){
+            jsonGenerator.writeStringField("error", "Cannot merge when one of the vendors has an active moderation request.");
+        } else if (status == RequestStatus.ACCESS_DENIED) {
+            jsonGenerator.writeStringField("error", "You do not have sufficient permissions.");
+        } else if (status == RequestStatus.FAILURE) {
+            jsonGenerator.writeStringField("error", "An unknown error occurred during merge.");
+        }
+
+        jsonGenerator.writeEndObject();
+    }
+
+
+    private LiferayPortletURL createViewUrl(PortletRequest request) {
+        String portletId = (String) request.getAttribute(WebKeys.PORTLET_ID);
+        ThemeDisplay tD = (ThemeDisplay) request.getAttribute(WebKeys.THEME_DISPLAY);
+        long plid = tD.getPlid();
+
+        LiferayPortletURL vendorUrl = PortletURLFactoryUtil.create(request, portletId, plid,
+                PortletRequest.RENDER_PHASE);
+        vendorUrl.setParameter(PortalConstants.PAGENAME, PortalConstants.PAGENAME_VIEW);
+
+        return vendorUrl;
     }
 }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -833,13 +833,14 @@ public class ComponentPortlet extends FossologyAwarePortlet {
 
     private void generateComponentMergeWizardStep0Response(ActionRequest request, JsonGenerator jsonGenerator) throws IOException, TException {
         User sessionUser = UserCacheHolder.getUserFromRequest(request);
+        String targetId = request.getParameter(COMPONENT_TARGET_ID);
         ComponentService.Iface cClient = thriftClients.makeComponentClient();
         List<Component> componentSummary = cClient.getComponentSummary(sessionUser);
 
         jsonGenerator.writeStartObject();
 
         jsonGenerator.writeArrayFieldStart("components");
-        componentSummary.stream().forEach(component -> {
+        componentSummary.stream().filter( component -> !component.getId().equals(targetId)).forEach(component -> {
             try {
                 jsonGenerator.writeStartObject();
                 jsonGenerator.writeStringField("id", component.getId());

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/vendors/mergeVendor.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/vendors/mergeVendor.jsp
@@ -1,0 +1,277 @@
+<%--
+  ~ Copyright Siemens AG, 2017, 2019. Part of the SW360 Portal Project.
+  ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+--%>
+<%@include file="/html/init.jsp" %>
+<%-- the following is needed by liferay to display error messages--%>
+<%@include file="/html/utils/includes/errorKeyToMessage.jspf"%>
+
+<portlet:defineObjects/>
+<liferay-theme:defineObjects/>
+
+<portlet:actionURL var="vendorMergeWizardStepUrl" name="vendorMergeWizardStep"/>
+
+<div id="vendorMergeWizard" class="container" data-step-id="0" data-vendor-target-id="${vendor.id}">
+    <div class="row portlet-toolbar">
+        <div class="col portlet-title text-truncate" title="Merge into <sw360:out value='${vendor.fullname}'/>">
+            Merge into <sw360:out value='${vendor.fullname}'/>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col">
+            <div class="wizardHeader">
+                <ul>
+                    <li class="active">1. Choose source<br /><small>Choose a vendor that should be merged into the current one</small></li>
+                    <li>2. Merge data<br /><small>Merge data from source into target vendor</small></li>
+                    <li>3. Confirm<br /><small>Check the merged version and confirm</small></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col">
+            <div class="merge wizardBody">
+                <div class="step active" data-step-id="1">
+                    <div class="spinner spinner-with-text">
+                        <div class="spinner-border" role="status">
+                            <span class="sr-only">Loading data for step 1, please wait...</span>
+                        </div>
+                        Loading data for step 1, please wait...
+                    </div>
+                </div>
+                <div class="step" data-step-id="2">
+                    <div class="spinner spinner-with-text">
+                        <div class="spinner-border" role="status">
+                            <span class="sr-only">Loading data for step 2, please wait...</span>
+                        </div>
+                        Loading data for step 2, please wait...
+                    </div>
+                </div>
+                <div class="step" data-step-id="3">
+                    <div class="spinner spinner-with-text">
+                        <div class="spinner-border" role="status">
+                            <span class="sr-only">Loading data for step 3, please wait...</span>
+                        </div>
+                        Loading data for step 3, please wait...
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<%--for javascript library loading --%>
+<%@ include file="/html/utils/includes/requirejs.jspf" %>
+<script>
+    require(['jquery', 'bridges/datatables', 'modules/mergeWizard'], function($, datatables, wizard) {
+        var mergeWizardStepUrl = '<%=vendorMergeWizardStepUrl%>',
+            postParamsPrefix = '<portlet:namespace/>',
+            $wizardRoot = $('#vendorMergeWizard');
+
+        wizard({
+            wizardRoot: $wizardRoot,
+            postUrl: mergeWizardStepUrl,
+            postParamsPrefix: postParamsPrefix,
+            loadErrorHook: errorHook,
+
+            steps: [
+                {
+                    renderHook: renderChooseVendor,
+                    submitHook: submitChosenVendor,
+                    errorHook: errorHook
+                },
+                {
+                    renderHook: renderMergeVendor,
+                    submitHook: submitMergedVendor,
+                    errorHook: errorHook
+                },
+                {
+                    renderHook: renderConfirmMergedVendor,
+                    submitHook: submitConfirmedMergedVendor,
+                    errorHook: errorHook
+                }
+            ],
+            finishCb: function($stepElement, data) {
+                if (data && data.error) {
+                    let $error = $('<div/>', {
+                        'class': 'alert alert-danger mt-3'
+                    });
+                    let $idList = $('<ul>');
+
+                    $error.append($('<p/>').append($('<b/>').text('Could not merge vendors: ' + data.error)));
+                    $error.append($('<p/>').text('This error can lead to inconsistencies in the database. Please inform the administrator that the following vendors could not be merged:'));
+                    $error.append($('<p>').append($idList));
+                    
+                    let releaseSourceId = $stepElement.data('releaseSourceId');
+                    $idList.append($('<li>').text('Source vendor: ' + releaseSourceId));
+                    $idList.append($('<li>').text('Target vendor: ' + $wizardRoot.data('releaseTargetId')));
+                    
+                    $stepElement.html('').append($error);
+                    return false;
+                } else if(data && data.redirectUrl) {
+                    window.location.href = data.redirectUrl;
+                    return true;
+                } else {
+                    window.history.back();
+                    return true;
+                }
+            }
+        });
+
+        function renderChooseVendor($stepElement, data) {
+            $stepElement.html('' +
+                    '<div class="stepFeedback"></div>' +
+                    '<form>' +
+                    '    <table id="vendorSourcesTable" class="table table-bordered" title="Source vendor">' +
+                    '        <colgroup>' +
+                    '            <col style="width: 1.7rem;" />' +
+                    '            <col style="width: 50%;" />' +
+                    '            <col style="width: 20%;" />' +
+                    '            <col style="width: 30%;" />' +
+                    '        </colgroup>' +
+                    '        <thead>' +
+                    '            <tr>' +
+                    '                <th></th>' +
+                    '                <th>Vendor Full Name</th>' +
+                    '                <th>Vendor Short Name</th>' +
+                    '                <th>URL</th>' +
+                    '            </tr>' +
+                    '        </thead>' +
+                    '        <tbody>' +
+                    '        </tbody>' +
+                    '    </table>' +
+                    '</form>'
+                    );
+
+            var table = datatables.create($stepElement.find('#vendorSourcesTable'), {
+                data: data.vendors,
+                columns: [
+                    { data: "id", render: $.fn.dataTable.render.inputRadio('vendorChooser'), orderable: false },
+                    { data: "fullname" },
+                    { data: "shortname" },
+                    { data: "url" }
+                ],
+                order: [ [ 1, 'asc' ] ],
+                select: 'single'
+            });
+            datatables.enableCheckboxForSelection(table, 0);
+        }
+
+        function submitChosenVendor($stepElement) {
+            var checkedList = $stepElement.find('input:checked');
+            if (checkedList.length !== 1 || $(checkedList.get(0)).val() ===  $wizardRoot.data('vendorTargetId')) {
+                $stepElement.find('.stepFeedback').html('<div class="alert alert-danger">Please choose exactly one vendor, which is not the target vendor itself!</div>');
+                $('html, body').stop().animate({ scrollTop: 0 }, 300, 'swing');
+                setTimeout(function() {
+                    $stepElement.find('.stepFeedback').html('');
+                }, 5000);
+                return false;
+            }
+            $stepElement.data('vendorTargetId', $wizardRoot.data('vendorTargetId'));
+            $stepElement.data('vendorSourceId', $(checkedList.get(0)).val());
+        }
+
+        function renderMergeVendor($stepElement, data) {
+            $stepElement.html('<div class="stepFeedback"></div>');
+            $stepElement.data('vendorSourceId', data.vendorSource.id);
+            $wizardRoot.data('affectedComponents', data.affectedComponents);
+            $wizardRoot.data('affectedReleases', data.affectedReleases);
+
+            $stepElement.append(renderNotice(data.affectedComponents, data.affectedReleases));
+            
+            $stepElement.append(wizard.createCategoryLine('Vendor'));
+            $stepElement.append(wizard.createSingleMergeLine('Full Name', data.vendorTarget.fullname, data.vendorSource.fullname));
+            $stepElement.append(wizard.createSingleMergeLine('Short Name', data.vendorTarget.shortname, data.vendorSource.shortname));
+            $stepElement.append(wizard.createSingleMergeLine('URL', data.vendorTarget.url, data.vendorSource.url));
+            
+            wizard.registerClickHandlers();
+        }
+
+        function submitMergedVendor($stepElement) {
+            var vendorSelection = {};
+
+            vendorSelection.id = $wizardRoot.data('vendorTargetId');
+
+            vendorSelection.fullname = wizard.getFinalSingleValue('Full Name');
+            vendorSelection.shortname = wizard.getFinalSingleValue('Short Name');
+            vendorSelection.url = wizard.getFinalSingleValue('URL');
+
+            $stepElement.data('vendorSelection', vendorSelection);
+        }
+
+        function renderConfirmMergedVendor($stepElement, data) {
+            $stepElement.data('vendorSourceId', data.vendorSourceId);
+            $stepElement.data('vendorSelection', data.vendorSelection);
+
+            $stepElement.html('<div class="stepFeedback"></div>');
+
+            $stepElement.append(renderNotice($wizardRoot.data('affectedComponents'), $wizardRoot.data('affectedReleases')));
+
+            $stepElement.append(wizard.createCategoryLine('Vendor'));
+            $stepElement.append(wizard.createSingleDisplayLine('Full Name', data.vendorSelection.fullname));
+            $stepElement.append(wizard.createSingleDisplayLine('Short Name', data.vendorSelection.shortname));
+            $stepElement.append(wizard.createSingleDisplayLine('URL', data.vendorSelection.url));
+        }
+
+        function submitConfirmedMergedVendor($stepElement) {
+            /* vendorSourceId still as data at stepElement */
+            /* vendorSelection still as data at stepElement */
+        }
+
+        function errorHook($stepElement, textStatus, error) {
+            if($stepElement.find('.stepFeedback').length === 0) {
+                // initial loading
+                $stepElement.html('<div class="stepFeedback"></div>');
+            }
+
+            $wizardRoot.find('.active.step .stepFeedback').html('<div class="alert alert-danger">An error happened while communicating with the server: ' + textStatus + error + '</div>');
+            $('html, body').stop().animate({ scrollTop: 0 }, 300, 'swing');
+            setTimeout(function() {
+                $wizardRoot.find('.active.step .stepFeedback').html('');
+            }, 5000);
+        }
+
+        function renderNotice(affectedComponents, affectedReleases) {
+            var $note = $(
+                '<div class="alert mt-4">' +
+                    'The following documents will be affected by this merge and are changed accordingly:' +
+                    '<ul>' +
+                    '</ul>' +
+                '</div>'
+            );
+
+            if(affectedReleases == 0 && affectedComponents == 0) {
+                return $();
+            }
+
+            if(affectedComponents > 0) {
+                var $li = $('<li><b class="number"></b> component(s)</li>');
+                $li.find('.number').text(affectedComponents)
+                
+                $note.find('ul').append($li);
+            }
+            if(affectedReleases > 0) {
+                var $li = $('<li><b class="number"></b> release(s)</li>');
+                $li.find('.number').text(affectedReleases)
+                
+                $note.find('ul').append($li);
+            }
+            if(affectedComponents + affectedReleases > 1000) {
+                $note.append('<b>More than 1000 documents affected. The merge operation might time out. In consequence only some of ' +
+                    'the documents might be changed accordingly. In this case just restart the operation as long as the source vendor ' + 
+                    'continues to exist.');
+                $note.addClass('alert-warning');
+            } else {
+                $note.addClass('alert-info');
+            }
+
+            return $note;
+        }
+    });
+</script>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/vendors/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/vendors/view.jsp
@@ -80,6 +80,7 @@
                 vendorIdInURL = '<%=PortalConstants.VENDOR_ID%>',
                 pageName = '<%=PortalConstants.PAGENAME%>';
                 pageEdit = '<%=PortalConstants.PAGENAME_EDIT%>';
+                pageMerge = '<%=PortalConstants.PAGENAME_MERGE_VENDOR%>';
                 baseUrl = '<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>';
 
             // initializing
@@ -95,10 +96,19 @@
                 var data = $(event.currentTarget).data();
                 window.location.href = createDetailURLfromVendorId(data.vendorId);
             });
+            $('#vendorsTable').on('click', 'svg.merge', function (event) {
+                var data = $(event.currentTarget).data();
+                window.location.href = createMergeURLfromVendorId(data.vendorId);
+            });
 
             // helper functions
             function createDetailURLfromVendorId (paramVal) {
-                var portletURL = PortletURL.createURL( baseUrl ).setParameter(pageName,pageEdit).setParameter(vendorIdInURL, paramVal);
+                var portletURL = PortletURL.createURL( baseUrl ).setParameter(pageName, pageEdit).setParameter(vendorIdInURL, paramVal);
+                return portletURL.toString();
+            }
+
+            function createMergeURLfromVendorId (paramVal) {
+                var portletURL = PortletURL.createURL( baseUrl ).setParameter(pageName, pageMerge).setParameter(vendorIdInURL, paramVal);
                 return portletURL.toString();
             }
 
@@ -122,6 +132,7 @@
                         "2": "<sw360:out value="${vendor.url}"/>",
                         "3":  '<div class="actions">'
                             +   '<svg class="edit lexicon-icon" data-vendor-id="${vendor.id}"><title>Edit</title><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#pencil"/></svg>'
+                            +   '<svg class="merge lexicon-icon" data-vendor-id="${vendor.id}"><title>Merge</title><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#merge"/></svg>'
                             +   '<svg class="delete lexicon-icon" data-vendor-id="${vendor.id}" data-vendor-name="<sw360:out value="${vendor.fullname}"/>"><title>Delete</title><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#trash"/></svg>'
                             + '</div>'
 
@@ -134,7 +145,7 @@
                         {"title": "Full Name"},
                         {"title": "Short Name"},
                         {"title": "URL"},
-                        {"title": "Actions", className: "two actions" }
+                        {"title": "Actions", className: "three actions" }
                     ],
                     searching: true,
                     language: {

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -488,6 +488,11 @@ service ComponentService {
     list<Release> getReleasesFromVendorIds(1: set<string> ids);
 
     /**
+      * get full release documents with the specifed vendor id
+      */
+    set<Release> getReleasesByVendorId(1: string vendorId);
+
+    /**
      * update release in database if user has permissions
      * otherwise create moderation request
      **/
@@ -504,6 +509,11 @@ service ComponentService {
      * update the bulk of releases in database if user is admin
      **/
     RequestSummary updateReleases(1: set<Release> releases, 2: User user);
+
+    /**
+     * Update the set of releases. Do only use for updating simple fields.
+     */ 
+    RequestSummary updateReleasesDirectly(1: set<Release> releases, 2: User user);
 
     /**
      * delete release from database if user has permissions
@@ -531,6 +541,16 @@ service ComponentService {
      * get components belonging to linked releases of the releases specified by releaseId
      **/
     set <Component> getUsingComponentsForComponent(1: set <string> releaseId );
+
+    /**
+     * get components using the given vendor id
+     */
+    set <Component> getComponentsByDefaultVendorId(1: string vendorId);
+
+    /**
+     * Recomputes the fields of a component that are aggregated by its releases.
+     */
+    Component recomputeReleaseDependentFields(1: string componentId);
 
     /**
      * check if release is used by other releases, components or projects

--- a/libraries/lib-datahandler/src/main/thrift/vendors.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/vendors.thrift
@@ -71,4 +71,14 @@ service VendorService {
      * vendor specified by id is updated in database if user has sufficient permissions, otherwise FAILURE is returned
      **/
     RequestStatus updateVendor(1: Vendor vendor, 2: User user);
+
+    /**
+     * merge vendor identified by vendorSourceId into vendor identified by vendorTargetId.
+     * The vendorSelection shows which data has to be set on the target. The source will be deleted afterwards.
+     * If user does not have permissions, RequestStatus.ACCESS_DENIED is returned
+     * If any of the vendor has an active moderation request, it's a noop and RequestStatus.IN_USE is returned.
+     * On any other error, REQUEST_FAILURE is returned.
+     **/
+    RequestStatus mergeVendors(1: string vendorTargetId, 2: string vendorSourceId, 3: Vendor vendorSelection, 4: User user);
+
 }


### PR DESCRIPTION
This commits adds an merge wizard for vendors. In the vendor overview,
one can click on the merge action, select a source vendor and then
merge the fields.

All dependening components and releases are adapted automatically.

Closes #629

Signed-off-by: Leo von Klenze <leo.vonklenze@scansation.de>