### PR TITLE
fix(vendor): fix view name used when editing vendors

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
@@ -129,7 +129,7 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
 
     public List<Release> getReleasesFromVendorIds(Set<String> ids) {
 
-        return makeSummaryFromFullDocs(SummaryType.SHORT, queryByIds("releaseIdByVendorId", ids));
+        return makeSummaryFromFullDocs(SummaryType.SHORT, queryByIds("releaseByVendorId", ids));
     }
 
     public List<Release> searchReleasesByUsingLicenseId(String licenseId) {


### PR DESCRIPTION
This commit fixes a view name that is used during editing vendors.

Closes #672

Signed-off-by: Leo von Klenze <leo.vonklenze@scansation.de>