### PR TITLE
fix(Rest-Component): Corrected components by type rest end point

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -108,7 +108,7 @@ public class ComponentController implements ResourceProcessor<RepositoryLinksRes
 
         List<Resource<Component>> componentResources = new ArrayList<>();
         paginationResult.getResources().stream()
-                .filter(component -> componentType == null || componentType.equals(component.componentType.name()))
+                .filter(component -> componentType == null || (component.isSetComponentType() && componentType.equals(component.componentType.name())))
                 .forEach(c -> {
                     Component embeddedComponent = restControllerHelper.convertToEmbeddedComponent(c, fields);
                     componentResources.add(new Resource<>(embeddedComponent));


### PR DESCRIPTION
1. From rest end point when user was requesting `get all components`  based on component type, it was failing with 500 error.
2. Corrected the same by adding necessary checks. 