### PR TITLE
fix(rest): License information generation based on attachment usages from rest

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
@@ -25,6 +25,7 @@ import org.eclipse.sw360.commonIO.AttachmentFrontendUtils;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.common.Duration;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
+import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.attachments.*;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
@@ -33,12 +34,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
-import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.google.common.collect.Sets;
+
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -63,6 +66,12 @@ public class Sw360AttachmentService {
     private static final Logger log = Logger.getLogger(Sw360AttachmentService.class);
     private final Duration downloadTimeout = Duration.durationOf(30, TimeUnit.SECONDS);
     private AttachmentConnector attachmentConnector;
+
+    public List<AttachmentUsage> getAttachemntUsages(String projectId) throws TException {
+        AttachmentService.Iface attachmentClient = getThriftAttachmentClient();
+        return attachmentClient.getUsedAttachments(Source.projectId(projectId),
+                UsageData.licenseInfo(new LicenseInfoUsage(Sets.newHashSet())));
+    }
 
     public AttachmentInfo getAttachmentById(String id) throws TException {
         AttachmentService.Iface attachmentClient = getThriftAttachmentClient();

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -28,6 +28,7 @@ import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.AwareOfRestServices;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
@@ -56,6 +57,15 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
     public List<Component> getComponentsForUser(User sw360User) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
         return sw360ComponentClient.getComponentSummary(sw360User);
+    }
+
+    public Release getReleaseById(String id, User sw360User) {
+        try {
+            ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+            return sw360ComponentClient.getReleaseById(id, sw360User);
+        } catch (TException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public Component getComponentForUserById(String componentId, User sw360User) throws TException {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licenseinfo/Sw360LicenseInfoService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licenseinfo/Sw360LicenseInfoService.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.sw360.rest.resourceserver.licenseinfo;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -19,7 +20,9 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.THttpClient;
 import org.apache.thrift.transport.TTransportException;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoFile;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoService;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatInfo;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseNameWithText;
@@ -51,6 +54,15 @@ public class Sw360LicenseInfoService {
         try {
             LicenseInfoService.Iface sw360LicenseInfoClient = getThriftLicenseInfoClient();
             return sw360LicenseInfoClient.getLicenseInfoFile(project, sw360User, generatorClassNameWithVariant, selectedReleaseAndAttachmentIds, excludedLicenses, externalIds);
+        } catch (TException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public List<LicenseInfoParsingResult> getLicenseInfoForAttachment(Release release, User sw360User, String attachmentContentId) {
+        try {
+            LicenseInfoService.Iface sw360LicenseInfoClient = getThriftLicenseInfoClient();
+            return sw360LicenseInfoClient.getLicenseInfoForAttachment(release, attachmentContentId, sw360User);
         } catch (TException e) {
             throw new RuntimeException(e);
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -16,16 +16,24 @@ package org.eclipse.sw360.rest.resourceserver.project;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.THttpClient;
 import org.apache.thrift.transport.TTransportException;
+import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStatusData;
+import org.eclipse.sw360.datahandler.thrift.components.ReleaseLink;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectLink;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.AwareOfRestServices;
@@ -35,15 +43,27 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
+import static com.google.common.base.Strings.nullToEmpty;
+import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptyList;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class Sw360ProjectService implements AwareOfRestServices<Project> {
+
+    private static final Logger log = Logger.getLogger(Sw360ProjectService.class);
+
     @Value("${sw360.thrift-server-url:http://localhost:8080}")
     private String thriftServerUrl;
 
@@ -150,4 +170,35 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         TProtocol protocol = new TCompactProtocol(thriftClient);
         return new ProjectService.Client(protocol);
     }
+
+    public Function<ProjectLink, ProjectLink> filterAndSortAttachments(Collection<AttachmentType> attachmentTypes) {
+        Predicate<Attachment> filter = att -> attachmentTypes.contains(att.getAttachmentType());
+        return createProjectLinkMapper(rl -> rl.setAttachments(nullToEmptyList(rl.getAttachments())
+                .stream()
+                .filter(filter)
+                .sorted(Comparator
+                        .comparing((Attachment a) -> nullToEmpty(a.getCreatedTeam()))
+                        .thenComparing(Comparator.comparing((Attachment a) -> nullToEmpty(a.getCreatedOn())).reversed()))
+                .collect(Collectors.toList())));
+    }
+
+    public Function<ProjectLink, ProjectLink> createProjectLinkMapper(Function<ReleaseLink, ReleaseLink> releaseLinkMapper){
+        return (projectLink) -> {
+            List<ReleaseLink> mappedReleaseLinks = nullToEmptyList(projectLink
+                    .getLinkedReleases())
+                    .stream()
+                    .map(releaseLinkMapper)
+                    .collect(Collectors.toList());
+            projectLink.setLinkedReleases(mappedReleaseLinks);
+            return projectLink;
+        };
+    }
+
+    protected List<ProjectLink> createLinkedProjects(Project project,
+            Function<ProjectLink, ProjectLink> projectLinkMapper, boolean deep, User user) {
+        final Collection<ProjectLink> linkedProjects = SW360Utils
+                .flattenProjectLinkTree(SW360Utils.getLinkedProjects(project, deep, new ThriftClients(), log, user));
+        return linkedProjects.stream().map(projectLinkMapper).collect(Collectors.toList());
+    }
+
 }


### PR DESCRIPTION
* License information generation from rest endpoint based on the persisted attachment usages.

Closes: #686

Signed-off-by: Smruti Sahoo <smruti.sahoo@siemens.com>