### PR TITLE
feature(release): add release merge wizard

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentDatabaseHandler.java
@@ -258,4 +258,8 @@ public class AttachmentDatabaseHandler {
     public List<Source> getAttachmentOwnersByIds(Set<String> ids) {
         return attachmentOwnerRepository.getOwnersByIds(ids);
     }
+    
+    public List<AttachmentUsage> getAttachmentUsagesByReleaseId(String releaseId) {
+        return attachmentUsageRepository.getUsagesByReleaseId(releaseId);
+    }
 }

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentUsageRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentUsageRepository.java
@@ -64,6 +64,20 @@ public class AttachmentUsageRepository extends DatabaseRepository<AttachmentUsag
         return queryView(viewQuery);
     }
 
+    @View(name = "referencesReleaseId", map = "" + 
+        "function(doc) { " +
+        "   if (doc.type == 'attachmentUsage') {" +
+        "       if(doc.owner && doc.owner.setField_ == 'RELEASE_ID') {" +
+        "           emit(doc.owner.value_, doc);" +
+        "       } else if(doc.usedBy && doc.usedBy.setField_ == 'RELEASE_ID') {" +
+        "           emit(doc.usedBy.value_, doc);" +
+        "       }" +
+        "   }" +
+        "}")
+    public List<AttachmentUsage> getUsagesByReleaseId(String releaseId) {
+        return queryView("referencesReleaseId", releaseId);
+    }
+
     public Map<Map<String, String>, Integer> getAttachmentUsageCount(Map<String, Set<String>> attachments, String filter) {
         ViewQuery viewQuery = createUsagesByAttachmentQuery(filter);
         List<ComplexKey> complexKeys = prepareKeys(attachments, filter);

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -26,14 +26,21 @@ import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
 import org.eclipse.sw360.datahandler.thrift.*;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentService;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage;
 import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
 import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationService;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
+import org.eclipse.sw360.datahandler.thrift.vulnerabilities.ProjectVulnerabilityRating;
+import org.eclipse.sw360.datahandler.thrift.vulnerabilities.ReleaseVulnerabilityRelation;
+import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityCheckStatus;
+import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityService;
 import org.eclipse.sw360.mail.MailConstants;
 import org.eclipse.sw360.mail.MailUtil;
 
@@ -628,7 +635,6 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
             }
         });
         mergeTarget.getAttachments().removeAll(attachmentsToDelete);
-
     }
 
     private void transferReleases(Set<String> releaseIds, Component mergeTarget, Component mergeSource) throws SW360Exception {
@@ -878,6 +884,304 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
             if (containedRelease.getId().equals(skipThisReleaseId)) continue;
             updateReleaseDependentFieldsForComponent(component, containedRelease);
         }
+    }
+
+    public RequestStatus mergeReleases(String mergeTargetId, String mergeSourceId, Release mergeSelection,
+        User sessionUser) throws TException {
+
+        Release mergeTarget = getRelease(mergeTargetId, sessionUser);
+        Release mergeSource = getRelease(mergeSourceId, sessionUser);
+        
+        if (!makePermission(mergeTarget, sessionUser).isActionAllowed(RequestedAction.WRITE)
+                || !makePermission(mergeSource, sessionUser).isActionAllowed(RequestedAction.WRITE)
+                || !makePermission(mergeSource, sessionUser).isActionAllowed(RequestedAction.DELETE)) {
+            return RequestStatus.ACCESS_DENIED;
+        }
+        if (isReleaseUnderModeration(mergeTargetId) ||
+                isReleaseUnderModeration(mergeSourceId)){
+            return RequestStatus.IN_USE;
+        }
+        try {
+            // First merge everything into the new compontent which is mergable in one step (attachments, plain fields)
+            mergeReleasePlainFields(mergeSelection, mergeTarget, mergeSource);
+            mergeReleaseAttachments(mergeSelection, mergeTarget, mergeSource);
+            
+            // update target first. If updating source fails, no data is lost (but inconsistency might occur)
+            updateReleaseCompletely(mergeTarget, sessionUser, true, true, true);
+            // now, update source (before deletion so that attachments and releases and
+            // stuff that has been migrated will not be deleted by component deletion!)
+            updateReleaseCompletely(mergeSource, sessionUser, false, true, false);
+
+            // updating references to source release
+            // it is important to migrate the attachment usages first otherwise they will be delete during project update
+            updateReleaseReferencesInAttachmentUsages(mergeTargetId, mergeSourceId);
+            updateReleaseReferencesInProjects(mergeTargetId, mergeSourceId, sessionUser);
+            updateReleaseReferencesInReleases(mergeTargetId, mergeSourceId, sessionUser);
+            updateReleaseReferencesInVulnerabilities(mergeTargetId, mergeSourceId, sessionUser);
+            updateReleaseReferencesInProjectRatings(mergeTargetId, mergeSourceId, sessionUser);
+
+            // Finally we can delete the source component
+            updateParentComponent(mergeSource, sessionUser);
+            deleteRelease(mergeSourceId, sessionUser);
+        } catch(Exception e) {
+            log.error("Cannot merge release [" + mergeSource.getId() + "] into [" + mergeTarget.getId() + "].", e);
+            return RequestStatus.FAILURE;
+        }
+
+        return RequestStatus.SUCCESS;
+    }
+
+    private boolean isReleaseUnderModeration(String releaseId) throws TException {
+        ModerationService.Iface moderationClient = new ThriftClients().makeModerationClient();
+        List<ModerationRequest> moderationRequests = moderationClient.getModerationRequestByDocumentId(releaseId);
+        return moderationRequests.stream().anyMatch(CommonUtils::isInProgressOrPending);
+    }
+
+    private void mergeReleasePlainFields(Release mergeSelection, Release mergeTarget, Release mergeSource) {
+        // First handle the creator of the release in a way, that the discarded creator will be on the 
+        // moderator list afterwards. There is nothing to do, if source and target author are the same
+        if(!nullToEmpty(mergeTarget.getCreatedBy()).equals(mergeSource.getCreatedBy())) {
+            if(nullToEmpty(mergeSelection.getCreatedBy()).equals(nullToEmpty(mergeTarget.getCreatedBy()))) {
+                // creator of the target component should be retained. Add creator of source component to list of moderators.
+                mergeTarget.setModerators(mergeSelection.getModerators());
+                if(!isNullOrEmpty(mergeSource.getCreatedBy())) {
+                    mergeTarget.addToModerators(mergeSource.getCreatedBy());
+                }
+            } else {
+                // creator of the source component has been selected. Add creator of target component to list of moderators.
+                mergeTarget.setModerators(mergeSelection.getModerators());
+                if(!isNullOrEmpty(mergeTarget.getCreatedBy())) {
+                    mergeTarget.addToModerators(mergeTarget.getCreatedBy());
+                }
+            }
+        }
+
+        // Handle default fields
+        copyFields(mergeSelection, mergeTarget, ImmutableSet.<Release._Fields>builder()
+            .add(Release._Fields.VENDOR_ID)
+            .add(Release._Fields.NAME)
+            .add(Release._Fields.VERSION)
+            .add(Release._Fields.LANGUAGES)
+            .add(Release._Fields.OPERATING_SYSTEMS)
+            .add(Release._Fields.CPEID)
+            .add(Release._Fields.SOFTWARE_PLATFORMS)
+            .add(Release._Fields.RELEASE_DATE)
+            .add(Release._Fields.MAIN_LICENSE_IDS)
+            .add(Release._Fields.DOWNLOADURL)
+            .add(Release._Fields.MAINLINE_STATE)
+            .add(Release._Fields.CREATED_ON)
+            .add(Release._Fields.CREATED_BY)
+            .add(Release._Fields.CONTRIBUTORS)
+            .add(Release._Fields.MODERATORS)
+            .add(Release._Fields.SUBSCRIBERS)
+            .add(Release._Fields.REPOSITORY)
+            .add(Release._Fields.ROLES)
+            .add(Release._Fields.EXTERNAL_IDS)
+            .add(Release._Fields.ADDITIONAL_DATA)
+            .add(Release._Fields.RELEASE_ID_TO_RELATIONSHIP)
+            .build());
+
+        // Remove self links
+        if(mergeTarget.isSetReleaseIdToRelationship()) {
+            mergeTarget.getReleaseIdToRelationship().remove(mergeTarget.getId());
+        }
+
+        // Handle clearing information
+        copyFields(mergeSelection.getClearingInformation(), mergeTarget.getClearingInformation(), ImmutableSet.<ClearingInformation._Fields>builder()
+            .add(ClearingInformation._Fields.BINARIES_ORIGINAL_FROM_COMMUNITY)
+            .add(ClearingInformation._Fields.BINARIES_SELF_MADE)
+            .add(ClearingInformation._Fields.COMPONENT_LICENSE_INFORMATION)
+            .add(ClearingInformation._Fields.SOURCE_CODE_DELIVERY)
+            .add(ClearingInformation._Fields.SOURCE_CODE_ORIGINAL_FROM_COMMUNITY)
+            .add(ClearingInformation._Fields.SOURCE_CODE_TOOL_MADE)
+            .add(ClearingInformation._Fields.SOURCE_CODE_SELF_MADE)
+            .add(ClearingInformation._Fields.SCREENSHOT_OF_WEB_SITE)
+            .add(ClearingInformation._Fields.FINALIZED_LICENSE_SCAN_REPORT)
+            .add(ClearingInformation._Fields.LICENSE_SCAN_REPORT_RESULT)
+            .add(ClearingInformation._Fields.LEGAL_EVALUATION)
+            .add(ClearingInformation._Fields.LICENSE_AGREEMENT)
+            .add(ClearingInformation._Fields.SCANNED)
+            .add(ClearingInformation._Fields.COMPONENT_CLEARING_REPORT)
+            .add(ClearingInformation._Fields.CLEARING_STANDARD)
+            .add(ClearingInformation._Fields.EXTERNAL_URL)
+            .add(ClearingInformation._Fields.COMMENT)
+            .add(ClearingInformation._Fields.REQUEST_ID)
+            .add(ClearingInformation._Fields.ADDITIONAL_REQUEST_INFO)
+            .add(ClearingInformation._Fields.PROC_START)
+            .add(ClearingInformation._Fields.EVALUATED)
+            .add(ClearingInformation._Fields.EXTERNAL_SUPPLIER_ID)
+            .add(ClearingInformation._Fields.COUNT_OF_SECURITY_VN)
+            .build());
+
+        // Handle ECC information
+        copyFields(mergeSelection.getEccInformation(), mergeTarget.getEccInformation(), ImmutableSet.<EccInformation._Fields>builder()
+            .add(EccInformation._Fields.ECC_STATUS)
+            .add(EccInformation._Fields.ECC_COMMENT)
+            .add(EccInformation._Fields.AL)
+            .add(EccInformation._Fields.ECCN)
+            .add(EccInformation._Fields.MATERIAL_INDEX_NUMBER)
+            .add(EccInformation._Fields.ASSESSOR_CONTACT_PERSON)
+            .add(EccInformation._Fields.ASSESSOR_DEPARTMENT)
+            .add(EccInformation._Fields.ASSESSMENT_DATE)
+            .build());
+
+        // Handle COTS information
+        copyFields(mergeSelection.getCotsDetails(), mergeTarget.getCotsDetails(), ImmutableSet.<COTSDetails._Fields>builder()
+            .add(COTSDetails._Fields.USAGE_RIGHT_AVAILABLE)
+            .add(COTSDetails._Fields.COTS_RESPONSIBLE)
+            .add(COTSDetails._Fields.CLEARING_DEADLINE)
+            .add(COTSDetails._Fields.LICENSE_CLEARING_REPORT_URL)
+            .add(COTSDetails._Fields.USED_LICENSE)
+            .add(COTSDetails._Fields.CONTAINS_OSS)
+            .add(COTSDetails._Fields.OSS_CONTRACT_SIGNED)
+            .add(COTSDetails._Fields.OSS_INFORMATION_URL)
+            .add(COTSDetails._Fields.SOURCE_CODE_AVAILABLE)
+            .build());   
+    }
+
+    private void mergeReleaseAttachments(Release mergeSelection, Release mergeTarget, Release mergeSource) {
+        // --- handle attachments (a bit more complicated)
+        // prepare for no NPE
+        if (mergeSource.getAttachments() == null) {
+            mergeSource.setAttachments(new HashSet<>());
+        }
+        if (mergeTarget.getAttachments() == null) {
+            mergeTarget.setAttachments(new HashSet<>());
+        }
+
+        Set<String> attachmentIdsSelected = mergeSelection.getAttachments().stream()
+                .map(Attachment::getAttachmentContentId).collect(Collectors.toSet());
+        // add new attachments from source
+        Set<Attachment> attachmentsToAdd = new HashSet<>();
+        mergeSource.getAttachments().forEach(a -> {
+            if (attachmentIdsSelected.contains(a.getAttachmentContentId())) {
+                attachmentsToAdd.add(a);
+            }
+        });
+        // remove moved attachments in source
+        attachmentsToAdd.forEach(a -> {
+            mergeTarget.addToAttachments(a);
+            mergeSource.getAttachments().remove(a);
+        });
+        // delete unchosen attachments from target
+        Set<Attachment> attachmentsToDelete = new HashSet<>();
+        mergeTarget.getAttachments().forEach(a -> {
+            if (!attachmentIdsSelected.contains(a.getAttachmentContentId())) {
+                attachmentsToDelete.add(a);
+            }
+        });
+        mergeTarget.getAttachments().removeAll(attachmentsToDelete);
+    }
+
+
+    /**
+     * The {{@link #updateRelease(Component, User, Iterable)} does not change the given
+     * release completely according to the user request. As we want to have
+     * exactly the given release as a result, this method is really submitting the
+     * given data to the persistence.
+     */
+    private void updateReleaseCompletely(Release release, User user, boolean updateClearingState, boolean cleanup, boolean sendmail) throws SW360Exception {
+        // Prepare component for database
+        prepareRelease(release);
+
+        Release actual = releaseRepository.get(release.getId());
+        assertNotNull(actual, "Could not find release to update!");
+
+        // Update the database with the release
+        if(updateClearingState) {
+            autosetReleaseClearingState(release, actual);
+        }
+        releaseRepository.update(release);
+
+        //clean up attachments in database
+        if(cleanup) {
+            attachmentConnector.deleteAttachmentDifference(actual.getAttachments(), release.getAttachments());
+        }
+        if(sendmail) {
+            sendMailNotificationsForReleaseUpdate(release, user.getEmail());
+        }
+    }
+
+    private void updateReleaseReferencesInProjects(String mergeTargetId, String mergeSourceId, User sessionUser) throws TException {
+        ProjectService.Iface projectClient = new ThriftClients().makeProjectClient();
+
+        Set<Project> projects = projectClient.searchByReleaseId(mergeSourceId, sessionUser);
+        for(Project project : projects) {
+            // retrieve full document, other method only retrieves summary
+            project = projectClient.getProjectById(project.getId(), sessionUser);
+            ProjectReleaseRelationship relationship = project.getReleaseIdToUsage().remove(mergeSourceId);
+            // if the target release is also linked, keep this one, do not overwrite
+            if(!project.getReleaseIdToUsage().containsKey(mergeTargetId)) {
+                project.putToReleaseIdToUsage(mergeTargetId, relationship);
+            }
+            projectClient.updateProject(project, sessionUser);
+        }
+    }
+    
+    private void updateReleaseReferencesInAttachmentUsages(String mergeTargetId, String mergeSourceId) throws TException {
+        AttachmentService.Iface attachmentClient = new ThriftClients().makeAttachmentClient();
+
+        List<AttachmentUsage> usages = attachmentClient.getAttachmentUsagesByReleaseId(mergeSourceId);
+        for(AttachmentUsage usage : usages) {
+            if(usage.getOwner().isSetReleaseId() && usage.getOwner().getReleaseId().equals(mergeSourceId)) {
+                usage.getOwner().setReleaseId(mergeTargetId);
+            }
+            if(usage.getUsedBy().isSetReleaseId() && usage.getUsedBy().getReleaseId().equals(mergeSourceId)) {
+                usage.getUsedBy().setReleaseId(mergeTargetId);
+            }
+            attachmentClient.updateAttachmentUsage(usage);
+        }
+    }
+    
+    private void updateReleaseReferencesInReleases(String mergeTargetId, String mergeSourceId, User sessionUser) throws SW360Exception {
+        List<Release> releases = getReferencingReleases(mergeSourceId);
+        for(Release release : releases) {
+            ReleaseRelationship relationship = release.getReleaseIdToRelationship().remove(mergeSourceId);
+            // if the target release is also linked, keep this one, do not overwrite
+            if(!release.getReleaseIdToRelationship().containsKey(mergeTargetId)) {
+                release.putToReleaseIdToRelationship(mergeTargetId, relationship);
+            }
+            updateReleaseCompletely(release, sessionUser, false, false, false);
+        }
+    }
+    
+    private void updateReleaseReferencesInVulnerabilities(String mergeTargetId, String mergeSourceId, User sessionUser) throws TException {
+        VulnerabilityService.Iface vulnerabilityService = new ThriftClients().makeVulnerabilityClient();
+
+        List<ReleaseVulnerabilityRelation> relations = vulnerabilityService.getReleaseVulnerabilityRelationsByReleaseId(mergeSourceId, sessionUser);
+        for(ReleaseVulnerabilityRelation relation : relations) {
+            if(relation.isSetReleaseId() && relation.getReleaseId().equals(mergeSourceId)) {
+                relation.setReleaseId(mergeTargetId);
+                vulnerabilityService.updateReleaseVulnerabilityRelation(relation, sessionUser);
+            }
+        }
+    }
+    
+    private void updateReleaseReferencesInProjectRatings(String mergeTargetId, String mergeSourceId, User sessionUser) throws TException {
+        VulnerabilityService.Iface vulnerabilityService = new ThriftClients().makeVulnerabilityClient();
+
+        List<ProjectVulnerabilityRating> ratings = vulnerabilityService.getProjectVulnerabilityRatingsByReleaseId(mergeSourceId, sessionUser);
+        for(ProjectVulnerabilityRating rating : ratings) {
+            for(Map<String, List<VulnerabilityCheckStatus>> map : rating.getVulnerabilityIdToReleaseIdToStatus().values()) {
+                List<VulnerabilityCheckStatus> list = map.remove(mergeSourceId);
+                // if the target release is also linked, keep this one, do not overwrite
+                if(list != null && !map.containsKey(mergeTargetId)) {
+                    map.put(mergeTargetId, list);
+                }
+            }
+            vulnerabilityService.updateProjectVulnerabilityRating(rating, sessionUser);
+        }
+    }
+
+    private void updateParentComponent(Release release, User sessionUser) throws SW360Exception {
+        Component component = getComponent(release.getComponentId(), sessionUser);
+
+        Set<String> releaseIds = nullToEmptyList(component.getReleases()).stream().map(Release::getId).collect(Collectors.toSet());
+        releaseIds.remove(release.getId());
+        component.setReleaseIds(releaseIds);
+
+        recomputeReleaseDependentFields(component, null);
+        updateComponentCompletely(component, sessionUser);
     }
 
     ///////////////////////////////
@@ -1313,6 +1617,10 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
     public int getTotalComponentsCount() {
         return componentRepository.getDocumentCount();
+    }
+
+    public List<Release> getReferencingReleases(String releaseId) {
+        return releaseRepository.getReferencingReleases(releaseId);
     }
 
     private void sendMailNotificationsForNewComponent(Component component, String user) {

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -530,6 +530,10 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return RequestStatus.SUCCESS;
     }
 
+    public List<ProjectVulnerabilityRating> getProjectVulnerabilityRatingsByReleaseId(String releaseId) {
+        return pvrRepository.getProjectVulnerabilityRatingsByReleaseId(releaseId);
+    }
+
     public List<Project> fillClearingStateSummary(List<Project> projects, User user) {
         Function<Project, Set<String>> extractReleaseIds = project -> CommonUtils.nullToEmptyMap(project.getReleaseIdToUsage()).keySet();
 

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectVulnerabilityRatingRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectVulnerabilityRatingRepository.java
@@ -49,4 +49,23 @@ public class ProjectVulnerabilityRatingRepository extends DatabaseRepository <Pr
         }
         return queryResults;
     }
+
+    @View(name = "byReleaseId", map = "" + 
+        "function(doc) {" +
+            "var ids = {};" +
+            "if(doc.type == 'projectvulnerabilityrating') {" +
+                "for(var cve in doc.vulnerabilityIdToReleaseIdToStatus) {" +
+                    "for(var id in doc.vulnerabilityIdToReleaseIdToStatus[cve]) {" +
+                        "if(!ids[doc._id]) {" +
+                            "emit(id, doc);" +
+                            "ids[doc._id] = true;" +
+                        "}" +
+                    "}" +
+                "}" +
+            "}" +
+        "}"
+    )
+    List<ProjectVulnerabilityRating> getProjectVulnerabilityRatingsByReleaseId(String releaseId) {
+        return queryView("byReleaseId", releaseId);
+    }
 }

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
@@ -49,6 +49,14 @@ import static com.google.common.base.Strings.isNullOrEmpty;
                     "    }" +
                     "  }" +
                     "}"),
+        @View(name = "usedInReleaseRelation",
+                map = "function(doc) {" +
+                    " if(doc.type == 'release') {" +
+                    "   for(var id in doc.releaseIdToRelationship) {" +
+                    "     emit(id, doc);" + 
+                    "   }" + 
+                    " }" +
+                    "}"),
         @View(name = "releaseByVendorId",
                 map = "function(doc) {" +
                     " if (doc.type == 'release'){" +
@@ -141,5 +149,9 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
         RepositoryUtils repositoryUtils = new RepositoryUtils();
         Set<String> searchIds = repositoryUtils.searchByExternalIds(this, "byExternalIds", externalIds);
         return new HashSet<>(get(searchIds));
+    }
+
+    public List<Release> getReferencingReleases(String releaseId) {
+        return queryView("usedInReleaseRelation", releaseId);
     }
 }

--- a/backend/src/src-attachments/src/main/java/org/eclipse/sw360/attachments/AttachmentHandler.java
+++ b/backend/src/src-attachments/src/main/java/org/eclipse/sw360/attachments/AttachmentHandler.java
@@ -227,4 +227,10 @@ public class AttachmentHandler implements AttachmentService.Iface {
         return handler.getAttachmentOwnersByIds(ids);
     }
 
+    @Override
+    public List<AttachmentUsage> getAttachmentUsagesByReleaseId(String releaseId) throws TException {
+        assertNotNull(releaseId);
+        return handler.getAttachmentUsagesByReleaseId(releaseId);
+    }
+
 }

--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -302,6 +302,17 @@ public class ComponentHandler implements ComponentService.Iface {
         return handler.updateReleaseFromAdditionsAndDeletions(releaseAdditions, releaseDeletions, user);
     }
 
+    @Override
+    public RequestStatus mergeReleases(String releaseTargetId, String releaseSourceId, Release releaseSelection,
+            User user) throws TException {
+        return handler.mergeReleases(releaseTargetId, releaseSourceId, releaseSelection, user);
+    }
+
+    @Override
+    public List<Release> getReferencingReleases(String releaseId) throws TException {
+        return handler.getReferencingReleases(releaseId);
+    }
+
     ///////////////////////////////
     // DELETE INDIVIDUAL OBJECTS //
     ///////////////////////////////

--- a/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/VulnerabilityHandler.java
+++ b/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/VulnerabilityHandler.java
@@ -320,4 +320,20 @@ public class VulnerabilityHandler implements VulnerabilityService.Iface {
 
         return dbHandler.getTotalVulnerabilityCount();
     }
+
+    @Override
+    public List<ReleaseVulnerabilityRelation> getReleaseVulnerabilityRelationsByReleaseId(String releaseId, User user) throws TException {
+        if (!PermissionUtils.isUserAtLeast(UserGroup.USER, user)) {
+            return new ArrayList<>();
+        }
+        return dbHandler.getReleaseVulnerabilityRelationsByReleaseId(releaseId);
+    }
+
+    @Override
+    public List<ProjectVulnerabilityRating> getProjectVulnerabilityRatingsByReleaseId(String releaseId, User user) throws TException {
+        if (!PermissionUtils.isUserAtLeast(UserGroup.USER, user)) {
+            return new ArrayList<>();
+        }
+        return projectDatabaseHandler.getProjectVulnerabilityRatingsByReleaseId(releaseId);
+    }
 }

--- a/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityDatabaseHandler.java
+++ b/backend/src/src-vulnerabilities/src/main/java/org/eclipse/sw360/vulnerabilities/db/VulnerabilityDatabaseHandler.java
@@ -11,6 +11,7 @@
 package org.eclipse.sw360.vulnerabilities.db;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
@@ -282,5 +283,9 @@ public class VulnerabilityDatabaseHandler {
 
     public int getTotalVulnerabilityCount() {
         return vulRepo.getDocumentCount();
+    }
+
+    public List<ReleaseVulnerabilityRelation> getReleaseVulnerabilityRelationsByReleaseId(String releaseId) {
+        return relationRepo.getRelationsByReleaseIds(Sets.newHashSet(releaseId));
     }
 }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -132,6 +132,11 @@ public class PortalConstants {
     public static final String RELEASE_EXTERNAL_IDS;
     public static final Set<String> RELEASE_EXTERNAL_ID_KEYS;
     public static final String RELEASE_LINK_TO_PROJECT = "releaseLinkToProject";
+    public static final String PAGENAME_MERGE_RELEASE = "mergeRelease";
+    public static final String RELEASE_SELECTION = "releaseSelection";
+    public static final String RELEASE_SOURCE_ID = "releaseSourceId";
+    public static final String RELEASE_TARGET_ID = "releaseTargetId";
+    
 
     //! Specialized keys for vendors
     public static final String VENDOR_PORTLET_NAME = PORTLET_NAME_PREFIX + "vendors";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayBoolean.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayBoolean.java
@@ -39,12 +39,12 @@ public class DisplayBoolean extends SimpleTagSupport {
 
         if (defined && value) {
             out.print("<span class=\"text-success\">");
-            out.print("<svg class=\"lexicon-icon\"><use href=\"/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#check-circle\"/></svg>");
+            out.print("<svg class=\"lexicon-icon\"><title>Yes</title><use href=\"/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#check-circle\"/></svg>");
             out.print("&nbsp;Yes");
             out.print("</span>");
         } else {
             out.print("<span class=\"text-danger\">");
-            out.print("<svg class=\"lexicon-icon\"><use href=\"/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#times-circle\"/></svg>");
+            out.print("<svg class=\"lexicon-icon\"><title>No</title><use href=\"/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#times-circle\"/></svg>");
             out.print("&nbsp;No");
             out.print("</span>");
         }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/components/_merge.scss
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/components/_merge.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright Siemens AG, 2017. Part of the SW360 Portal Project.
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
  *
  * SPDX-License-Identifier: EPL-1.0
  *

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/main.scss
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/main.scss
@@ -173,6 +173,11 @@
 			width: 8.5rem !important;
 		}
 
+		th.six.actions, td.six.actions {
+			max-width: 10.2rem;
+			width: 10.2rem !important;
+		}
+
 		div.dataTables_info {
 			padding-top: 0.5rem;
 			font-size: 0.875rem;

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/portlets/admin/_buttons.scss
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/portlets/admin/_buttons.scss
@@ -16,4 +16,4 @@
             margin: 0 0.5rem 0.75rem 0.5rem;
         }
     }
- }
+}

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/detailRelease.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/detailRelease.jsp
@@ -34,6 +34,7 @@
                  scope="request"/>
     <jsp:useBean id="usingComponents" type="java.util.Set<org.eclipse.sw360.datahandler.thrift.components.Component>" scope="request"/>
     <jsp:useBean id="allUsingProjectsCount" type="java.lang.Integer" scope="request"/>
+    <jsp:useBean id="isUserAllowedToMerge" type="java.lang.Boolean" scope="request"/>
     <core_rt:set var="cotsMode" value="<%=component.componentType == ComponentType.COTS%>"/>
     <jsp:useBean id="vulnerabilityVerificationEditable" type="java.lang.Boolean" scope="request"/>
     <core_rt:if test="${vulnerabilityVerificationEditable}">

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/clearingStatus.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/clearingStatus.jspf
@@ -92,7 +92,7 @@ require(['jquery', 'bridges/datatables', 'components/includes/releases/linkProje
                 {title: "Clearing State"},
                 {title: "Clearing Report"},
                 {title: "Release Mainline State"},
-                {title: "Actions", render: {display: renderActions}, className: "five actions" }
+                {title: "Actions", render: {display: renderActions}, className: "six actions" }
             ],
             columnDefs: [
                 {
@@ -144,6 +144,11 @@ require(['jquery', 'bridges/datatables', 'components/includes/releases/linkProje
                     'data-release-id': row.DT_RowId,
                     'data-release-name': row[5].name
                 }),
+                $mergeAction = render.linkTo(
+                    makeReleaseUrl(row.DT_RowId, 'merge'),
+                    "",
+                    '<svg class="lexicon-icon"><title>Merge</title><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#merge"/></svg>'
+                ),
                 $deleteAction = $('<svg>', {
                     'class': 'delete lexicon-icon',
                     'data-release-id': row.DT_RowId,
@@ -156,7 +161,7 @@ require(['jquery', 'bridges/datatables', 'components/includes/releases/linkProje
             $linkAction.append($('<title>Link Project</title><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#link"/>'));
             $deleteAction.append($('<title>Delete</title><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#trash"/>'));
 
-            $actions.append($clearingAction, $editAction, $copyAction, $linkAction, $deleteAction);
+            $actions.append($clearingAction, $editAction, $copyAction, $linkAction, $mergeAction, $deleteAction);
             return $actions[0].outerHTML;
         }
 

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/detailOverview.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/detailOverview.jspf
@@ -47,7 +47,7 @@
                             </div>
                             <core_rt:if test="${isUserAllowedToMerge}">
                                 <div class="btn-group" role="group">
-                                    <button type="button" data-component-id="${component.id}" id="mergeButton" class="btn btn-secondary" data-component-id="${component.id}">Merge</button>
+                                    <button type="button" data-component-id="${component.id}" id="mergeButton" class="btn btn-secondary">Merge</button>
                                 </div>
                             </core_rt:if>
                             <div class="btn-group" role="group">

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/vulnerabilities.jspf
@@ -166,7 +166,11 @@
                 tableDefinition.columns[0].title = '<div class="form-check"><input data-action="select-all" type="checkbox" class="form-check-input" /></div>';
             }
 
-            table = datatable.create('#vulnerabilityTable', tableDefinition, [1, 2, 3, 4, 5, 6], [0, 7], true);
+            if($('#vulnerabilityTable').data().insideComponent) {
+                table = datatable.create('#vulnerabilityTable', tableDefinition, [1, 2, 3, 4, 5, 6], [0, 7], true);
+            } else {
+                table = datatable.create('#vulnerabilityTable', tableDefinition, [1, 2, 3, 4, 5], [0, 6], true);
+            }
             if($('#vulnerabilityTable').data().editable) {
                 datatable.enableCheckboxForSelection(table, 0);
             }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/clearingDetails.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/clearingDetails.jspf
@@ -210,7 +210,7 @@
         <td><sw360:out value="${clearingInfo.externalSupplierID}"/></td>
     </tr>
     <tr>
-        <td>Number of Security VN:</td>
+        <td>Number of Security Vulnerabilities:</td>
         <td><sw360:out value="${clearingInfo.countOfSecurityVn}"/></td>
     </tr>
 </table>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/detailOverview.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/detailOverview.jspf
@@ -87,6 +87,11 @@
                             <div class="btn-group" role="group">
                                 <button type="button" id="linkToProject" class="btn btn-secondary" data-release-id="${releaseId}" data-release-name="<sw360:ReleaseName release="${release}"/>">Link to Project</button>
                             </div>
+                            <core_rt:if test="${isUserAllowedToMerge}">
+                                <div class="btn-group" role="group">
+                                    <button type="button" data-release-id="${release.id}" id="mergeButton" class="btn btn-secondary">Merge</button>
+                                </div>
+                            </core_rt:if>
                             <div class="btn-group" role="group">
                                 <sw360:DisplaySubscribeButton email="<%=themeDisplay.getUser().getEmailAddress()%>" object="${release}"
                                         id="SubscribeButton" />
@@ -177,6 +182,16 @@
         $('#linkToProject').on('click', function() {
             linkProject.openLinkDialog($(event.currentTarget).data().releaseId, $(event.currentTarget).data().releaseName);
         });
+
+        $('#mergeButton').on('click', function(event) {
+            var releaseId = $(event.currentTarget).data().releaseId;
+            var baseUrl = '<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RENDER_PHASE) %>',
+                portletURL = Liferay.PortletURL.createURL(baseUrl)
+                                                .setParameter('<%=PortalConstants.PAGENAME%>', '<%=PortalConstants.PAGENAME_MERGE_RELEASE%>')
+                                                .setParameter('<%=PortalConstants.RELEASE_ID%>', releaseId);
+            window.location = portletURL.toString();
+        });
+
 
         $('#SubscribeButton').on('click', function(event) {
             var $button = $(event.currentTarget),

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/editReleaseClearingInformation.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/editReleaseClearingInformation.jspf
@@ -38,7 +38,7 @@
                     value="<sw360:out value="${release.clearingInformation.binariesSelfMade}"/>"
                         <core_rt:if test="${release.clearingInformation.binariesSelfMade == 'true'}"> checked="checked" </core_rt:if>
                 />
-                <label class="form-check-label" for="binaries_self_made">Binaries Self Made</label>
+                <label class="form-check-label" for="binaries_self_made">Binaries Self-Made</label>
         </td>
         <td>
             <div class="form-check">
@@ -80,7 +80,7 @@
                     value="<sw360:out value="${release.clearingInformation.sourceCodeToolMade}"/>"
                         <core_rt:if test="${release.clearingInformation.sourceCodeToolMade == 'true'}"> checked="checked" </core_rt:if>
                 />
-                <label class="checkboxlabel" for="source_code_toolmade">Source Code Tool Made</label>
+                <label class="checkboxlabel" for="source_code_toolmade">Source Code Tool-Made</label>
             </div>
         </td>
     </tr>
@@ -93,7 +93,7 @@
                     value="<sw360:out value="${release.clearingInformation.sourceCodeSelfMade}"/>"
                         <core_rt:if test="${release.clearingInformation.sourceCodeSelfMade == 'true'}"> checked="checked" </core_rt:if>
                         />
-                <label class="form-check-label" for="source_code_selfmade">Source Code Selfmade</label>
+                <label class="form-check-label" for="source_code_selfmade">Source Code Self-Made</label>
             </div>
         </td>
         <td>
@@ -284,7 +284,7 @@
     <tr>
         <td>
             <div class="form-group">
-                <label for="externalSupplierId">ExternalSupplierId</label>
+                <label for="externalSupplierId">External Supplier ID</label>
                 <input id="externalSupplierId"
                     name="<portlet:namespace/><%=Release._Fields.CLEARING_INFORMATION%><%=ClearingInformation._Fields.EXTERNAL_SUPPLIER_ID%>"
                     type="text"

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/mergeComponent.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/mergeComponent.jsp
@@ -374,7 +374,7 @@
                 if (!attachment) {
                     return '';
                 }
-                return (attachment.filename || '-no-filename-') + ' (' + (attachment.attachementType || '-no-type-') + ')';
+                return (attachment.filename || '-no-filename-') + ' (' + (attachment.attachmentType || '-no-type-') + ')';
             }));
         }
 

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/mergeRelease.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/mergeRelease.jsp
@@ -1,0 +1,749 @@
+<%--
+  ~ Copyright Siemens AG, 2017, 2019. Part of the SW360 Portal Project.
+  ~
+  ~ SPDX-License-Identifier: EPL-1.0
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+--%>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.users.User" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.components.ComponentType" %>
+<%@ page import="org.eclipse.sw360.datahandler.common.ThriftEnumUtils" %>
+
+<%@include file="/html/init.jsp" %>
+<%-- the following is needed by liferay to display error messages--%>
+<%@include file="/html/utils/includes/errorKeyToMessage.jspf"%>
+
+<portlet:defineObjects/>
+<liferay-theme:defineObjects/>
+
+<portlet:actionURL var="releaseMergeWizardStepUrl" name="releaseMergeWizardStep"/>
+
+<div id="releaseMergeWizard" class="container" data-step-id="0" data-release-target-id="${release.id}" data-componentid="${release.componentId}">
+    <div class="row portlet-toolbar">
+        <div class="col portlet-title text-truncate" title="Merge into ${sw360:printReleaseName(release)}">
+            Merge into ${sw360:printReleaseName(release)}
+        </div>
+    </div>
+    <div class="row">
+        <div class="col">
+            <div class="wizardHeader">
+                <ul>
+                    <li class="active">1. Choose source<br /><small>Choose a release that should be merged into the current one</small></li>
+                    <li>2. Merge data<br /><small>Merge data from source into target release</small></li>
+                    <li>3. Confirm<br /><small>Check the merged version and confirm</small></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col">
+            <div class="merge wizardBody">
+                <div class="step active" data-step-id="1">
+                    <div class="spinner spinner-with-text">
+                        <div class="spinner-border" role="status">
+                            <span class="sr-only">Loading data for step 1, please wait...</span>
+                        </div>
+                        Loading data for step 1, please wait...
+                    </div>
+                </div>
+                <div class="step" data-step-id="2">
+                    <div class="spinner spinner-with-text">
+                        <div class="spinner-border" role="status">
+                            <span class="sr-only">Loading data for step 2, please wait...</span>
+                        </div>
+                        Loading data for step 2, please wait...
+                    </div>
+                </div>
+                <div class="step" data-step-id="3">
+                    <div class="spinner spinner-with-text">
+                        <div class="spinner-border" role="status">
+                            <span class="sr-only">Loading data for step 3, please wait...</span>
+                        </div>
+                        Loading data for step 3, please wait...
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<%--for javascript library loading --%>
+<%@ include file="/html/utils/includes/requirejs.jspf" %>
+<script>
+    require(['jquery', 'bridges/datatables', 'modules/mergeWizard'], function($, datatables, wizard) {
+        var mergeWizardStepUrl = '<%=releaseMergeWizardStepUrl%>',
+            postParamsPrefix = '<portlet:namespace/>',
+            $wizardRoot = $('#releaseMergeWizard');
+
+        wizard({
+            wizardRoot: $wizardRoot,
+            postUrl: mergeWizardStepUrl,
+            postParamsPrefix: postParamsPrefix,
+            loadErrorHook: errorHook,
+
+            steps: [
+                {
+                    renderHook: renderChooseRelease,
+                    submitHook: submitChosenRelease,
+                    errorHook: errorHook
+                },
+                {
+                    renderHook: renderMergeRelease,
+                    submitHook: submitMergedRelease,
+                    errorHook: errorHook
+                },
+                {
+                    renderHook: renderConfirmMergedRelease,
+                    submitHook: submitConfirmedMergedRelease,
+                    errorHook: errorHook
+                }
+            ],
+            finishCb: function($stepElement, data) {
+                if (data && data.error) {
+                    let $error = $('<div/>', {
+                        'class': 'alert alert-danger mt-3'
+                    });
+                    let $idList = $('<ul>');
+
+                    $error.append($('<p/>').append($('<b/>').text('Could not merge releases: ' + data.error)));
+                    $error.append($('<p/>').text('This error can lead to inconsistencies in the database. Please inform the administrator with the following information:'));
+                    $error.append($('<p>').append($idList));
+                    
+                    let releaseSourceId = $stepElement.data('releaseSourceId');
+                    $idList.append($('<li>').text('Source release: ' + releaseSourceId));
+                    $idList.append($('<li>').text('Target release: ' + $wizardRoot.data('releaseTargetId')));
+
+                    $stepElement.html('').append($error);
+                    return false;
+                } else if(data && data.redirectUrl) {
+                    window.location.href = data.redirectUrl;
+                    return true;
+                } else {
+                    window.history.back();
+                    return true;
+                }
+            }
+        });
+
+        function renderChooseRelease($stepElement, data) {
+            $stepElement.html('' +
+                    '<div class="stepFeedback"></div>' +
+                    '<form>' +
+                    '    <table id="releaseSourcesTable" class="table table-bordered" title="Source release">' +
+                    '        <colgroup>' +
+                    '            <col style="width: 1.7rem;" />' +
+                    '            <col style="width: 70%;" />' +
+                    '            <col style="width: 10%;" />' +
+                    '            <col style="width: 20%;" />' +
+                    '        </colgroup>' +
+                    '        <thead>' +
+                    '            <tr>' +
+                    '                <th></th>' +
+                    '                <th>Release name</th>' +
+                    '                <th>Version</th>' + 
+                    '                <th>Created by</th>' +
+                    '            </tr>' +
+                    '        </thead>' +
+                    '        <tbody>' +
+                    '        </tbody>' +
+                    '    </table>' +
+                    '</form>'
+                    );
+
+            var table = datatables.create($stepElement.find('#releaseSourcesTable'), {
+                data: data.releases,
+                columns: [
+                    { data: "id", render: $.fn.dataTable.render.inputRadio('releaseChooser') },
+                    { data: "name" },
+                    { data: "version" },
+                    { data: "createdBy" }
+                ],
+                order: [ [ 1, 'asc' ] ],
+                select: 'single'
+            }, undefined, [0], true);
+            datatables.enableCheckboxForSelection(table, 0);
+        }
+
+        function submitChosenRelease($stepElement) {
+            var checkedList = $stepElement.find('input:checked');
+            if (checkedList.length !== 1 || $(checkedList.get(0)).val() ===  $wizardRoot.data('releaseTargetId')) {
+                $stepElement.find('.stepFeedback').html('<div class="alert alert-danger">Please choose exactly one release, which is not the release itself!</div>');
+                $('html, body').stop().animate({ scrollTop: 0 }, 300, 'swing');
+                setTimeout(function() {
+                    $stepElement.find('.stepFeedback').html('');
+                }, 5000);
+                return false;
+            }
+            $stepElement.data('releaseTargetId', $wizardRoot.data('releaseTargetId'));
+            $stepElement.data('releaseSourceId', $(checkedList.get(0)).val());
+        }
+
+        function renderMergeRelease($stepElement, data) {
+            $stepElement.html('<div class="stepFeedback"></div>');
+            $stepElement.data('releaseSourceId', data.releaseSource.id);
+
+            $stepElement.append(renderNotice(data.usageInformation));
+
+            $stepElement.append(wizard.createCategoryLine('General'));
+            $stepElement.append(wizard.createSingleMergeLine('Vendor', 
+                data.releaseTarget.vendor ? data.releaseTarget.vendor.id : null, 
+                data.releaseSource.vendor ? data.releaseSource.vendor.id : null, 
+                vendorFormatter(data.releaseTarget.vendor, data.releaseSource.vendor)
+            ));
+            $stepElement.append(wizard.createSingleMergeLine('Name', data.releaseTarget.name, data.releaseSource.name));
+            $stepElement.append(wizard.createSingleMergeLine('Version', data.releaseTarget.version, data.releaseSource.version));
+            $stepElement.append(wizard.createMultiMergeLine('Programming Languages', data.releaseTarget.languages, data.releaseSource.languages));
+            $stepElement.append(wizard.createMultiMergeLine('Operating Systems', data.releaseTarget.operatingSystems, data.releaseSource.operatingSystems));
+            $stepElement.append(wizard.createSingleMergeLine('CPE ID', data.releaseTarget.cpeid, data.releaseSource.cpeid));
+            $stepElement.append(wizard.createMultiMergeLine('Software Platforms', data.releaseTarget.softwarePlatforms, data.releaseSource.softwarePlatforms));
+            $stepElement.append(wizard.createSingleMergeLine('Release Date', data.releaseTarget.releaseDate, data.releaseSource.releaseDate));
+            $stepElement.append(wizard.createMultiMergeLine('Licenses', data.releaseTarget.mainLicenseIds, data.releaseSource.mainLicenseIds));
+            $stepElement.append(wizard.createSingleMergeLine('Download URL', data.releaseTarget.downloadurl, data.releaseSource.downloadurl));
+            $stepElement.append(wizard.createSingleMergeLine('Release Mainline State', data.releaseTarget.mainlineState, data.releaseSource.mainlineState, mapFormatter(data.displayInformation, 'mainlineState')));
+            $stepElement.append(wizard.createSingleMergeLine('Created on', data.releaseTarget.createdOn, data.releaseSource.createdOn));
+            $stepElement.append(
+                renderCreatedBy(
+                    wizard.createSingleMergeLine('Created by', data.releaseTarget.createdBy, data.releaseSource.createdBy),
+                    data.releaseSource.createdBy != data.releaseTarget.createdBy,
+                    data.releaseSource.createdBy,
+                    'text-center'
+                )
+            );
+            $stepElement.append(wizard.createMultiMergeLine('Contributors', data.releaseTarget.contributors, data.releaseSource.contributors));
+            $stepElement.append(wizard.createMultiMergeLine('Moderators', data.releaseTarget.moderators, data.releaseSource.moderators));
+            $stepElement.append(wizard.createMultiMergeLine('Subscribers', data.releaseTarget.subscribers, data.releaseSource.subscribers));
+            $stepElement.append(wizard.createSingleMergeLine('Repository', data.releaseTarget.repository, data.releaseSource.repository, repositoryFormatter(data.displayInformation)));
+            $stepElement.append(wizard.createMultiMapMergeLine('Additional Roles', data.releaseTarget.roles, data.releaseSource.roles));
+            $stepElement.append(wizard.createMapMergeLine('External ids', data.releaseTarget.externalIds, data.releaseSource.externalIds));
+            $stepElement.append(wizard.createMapMergeLine('Additional Data', data.releaseTarget.additionalData, data.releaseSource.additionalData));
+            
+            $stepElement.append(wizard.createCategoryLine('Linked Releases'));
+            $stepElement.append(wizard.createMultiMergeLine('Linked Releases', Object.keys(data.releaseTarget.releaseIdToRelationship || {}), Object.keys(data.releaseSource.releaseIdToRelationship || {}), mapFormatter(data.displayInformation, 'release')));
+
+            $stepElement.append(wizard.createCategoryLine('Clearing Details'));
+            data.releaseTarget.clearingInformation = data.releaseTarget.clearingInformation || {};
+            data.releaseSource.clearingInformation = data.releaseSource.clearingInformation || {};
+            $stepElement.append(wizard.createSingleMergeLine('Binaries Original from Community', data.releaseTarget.clearingInformation.binariesOriginalFromCommunity, data.releaseSource.clearingInformation.binariesOriginalFromCommunity, flagFormatter));
+            $stepElement.append(wizard.createSingleMergeLine('Binaries Self-Made', data.releaseTarget.clearingInformation.binariesSelfMade, data.releaseSource.clearingInformation.binariesSelfMade, flagFormatter));
+            $stepElement.append(wizard.createSingleMergeLine('Component License Information', data.releaseTarget.clearingInformation.componentLicenseInformation, data.releaseSource.clearingInformation.componentLicenseInformation, flagFormatter));
+            $stepElement.append(wizard.createSingleMergeLine('Source Code Delivery', data.releaseTarget.clearingInformation.sourceCodeDelivery, data.releaseSource.clearingInformation.sourceCodeDelivery, flagFormatter));
+            $stepElement.append(wizard.createSingleMergeLine('Source Code Original from Community', data.releaseTarget.clearingInformation.sourceCodeOriginalFromCommunity, data.releaseSource.clearingInformation.sourceCodeOriginalFromCommunity, flagFormatter));
+            $stepElement.append(wizard.createSingleMergeLine('Source Code Tool-Made', data.releaseTarget.clearingInformation.sourceCodeToolMade, data.releaseSource.clearingInformation.sourceCodeToolMade, flagFormatter));
+            $stepElement.append(wizard.createSingleMergeLine('Source Code Self-Made', data.releaseTarget.clearingInformation.sourceCodeSelfMade, data.releaseSource.clearingInformation.sourceCodeSelfMade, flagFormatter));
+            $stepElement.append(wizard.createSingleMergeLine('Screenshot of Website', data.releaseTarget.clearingInformation.screenshotOfWebSite, data.releaseSource.clearingInformation.screenshotOfWebSite, flagFormatter));
+            $stepElement.append(wizard.createSingleMergeLine('Finalized License Scan Report', data.releaseTarget.clearingInformation.finalizedLicenseScanReport, data.releaseSource.clearingInformation.finalizedLicenseScanReport, flagFormatter));
+            $stepElement.append(wizard.createSingleMergeLine('License Scan Report Result', data.releaseTarget.clearingInformation.licenseScanReportResult, data.releaseSource.clearingInformation.licenseScanReportResult, flagFormatter));
+            $stepElement.append(wizard.createSingleMergeLine('Legal Evaluation', data.releaseTarget.clearingInformation.legalEvaluation, data.releaseSource.clearingInformation.legalEvaluation, flagFormatter));
+            $stepElement.append(wizard.createSingleMergeLine('License Agreement', data.releaseTarget.clearingInformation.licenseAgreement, data.releaseSource.clearingInformation.licenseAgreement, flagFormatter));
+            $stepElement.append(wizard.createSingleMergeLine('Scanned', data.releaseTarget.clearingInformation.scanned, data.releaseSource.clearingInformation.scanned));
+            $stepElement.append(wizard.createSingleMergeLine('Component Clearing Report', data.releaseTarget.clearingInformation.componentClearingReport, data.releaseSource.clearingInformation.componentClearingReport, flagFormatter));
+            $stepElement.append(wizard.createSingleMergeLine('Clearing Standard', data.releaseTarget.clearingInformation.clearingStandard, data.releaseSource.clearingInformation.clearingStandard));
+            $stepElement.append(wizard.createSingleMergeLine('External URL', data.releaseTarget.clearingInformation.externalUrl, data.releaseSource.clearingInformation.externalUrl));
+            $stepElement.append(wizard.createSingleMergeLine('Comment', data.releaseTarget.clearingInformation.comment, data.releaseSource.clearingInformation.comment));
+
+            $stepElement.append(wizard.createCategoryLine('Request Information'));
+            $stepElement.append(wizard.createSingleMergeLine('Request ID', data.releaseTarget.clearingInformation.requestID, data.releaseSource.clearingInformation.requestID));
+            $stepElement.append(wizard.createSingleMergeLine('Additional Request Info', data.releaseTarget.clearingInformation.additionalRequestInfo, data.releaseSource.clearingInformation.additionalRequestInfo));
+            $stepElement.append(wizard.createSingleMergeLine('Evaluation Start', data.releaseTarget.clearingInformation.procStart, data.releaseSource.clearingInformation.procStart));
+            $stepElement.append(wizard.createSingleMergeLine('Evalutation End', data.releaseTarget.clearingInformation.evaluated, data.releaseSource.clearingInformation.evaluated));
+
+            $stepElement.append(wizard.createCategoryLine('Supplemental Information'));
+            $stepElement.append(wizard.createSingleMergeLine('External Supplier ID', data.releaseTarget.clearingInformation.externalSupplierID, data.releaseSource.clearingInformation.externalSupplierID));
+            $stepElement.append(wizard.createSingleMergeLine('Count of Security Vulnerabilities', data.releaseTarget.clearingInformation.countOfSecurityVn, data.releaseSource.clearingInformation.countOfSecurityVn));
+
+            $stepElement.append(wizard.createCategoryLine('ECC Information'));
+            data.releaseTarget.eccInformation = data.releaseTarget.eccInformation || {};
+            data.releaseSource.eccInformation = data.releaseSource.eccInformation || {};
+            $stepElement.append(wizard.createSingleMergeLine('ECC Status', data.releaseTarget.eccInformation.eccStatus, data.releaseSource.eccInformation.eccStatus, mapFormatter(data.displayInformation, 'eccStatus')));
+            $stepElement.append(wizard.createSingleMergeLine('ECC Comment', data.releaseTarget.eccInformation.eccComment, data.releaseSource.eccInformation.eccComment));
+            $stepElement.append(wizard.createSingleMergeLine('Ausfuhrliste', data.releaseTarget.eccInformation.AL, data.releaseSource.eccInformation.AL));
+            $stepElement.append(wizard.createSingleMergeLine('ECCN', data.releaseTarget.eccInformation.ECCN, data.releaseSource.eccInformation.ECCN));
+            $stepElement.append(wizard.createSingleMergeLine('Material Index Number', data.releaseTarget.eccInformation.materialIndexNumber, data.releaseSource.eccInformation.materialIndexNumber));
+            $stepElement.append(
+                renderAssessorContactPerson(
+                    wizard.createSingleMergeLine('Assessor Contact Person', data.releaseTarget.eccInformation.assessorContactPerson, data.releaseSource.eccInformation.assessorContactPerson),
+                    true,
+                    data.releaseSource.eccInformation.assessorContactPerson && data.releaseSource.eccInformation.assessorContactPerson != data.releaseTarget.eccInformation.assessorContactPerson,
+                    data.releaseSource.eccInformation.assessorContactPerson,
+                    'text-center'
+                )
+            );
+
+            $stepElement.append(wizard.createCategoryLine('Commercial Details Administration'));
+            data.releaseTarget.cotsDetails = data.releaseTarget.cotsDetails || {};
+            data.releaseSource.cotsDetails = data.releaseSource.cotsDetails || {};
+            $stepElement.append(wizard.createSingleMergeLine('Usage Right Available', data.releaseTarget.cotsDetails.usageRightAvailable, data.releaseSource.cotsDetails.usageRightAvailable, flagFormatter));
+            $stepElement.append(wizard.createSingleMergeLine('COTS Responsible', data.releaseTarget.cotsDetails.cotsResponsible, data.releaseSource.cotsDetails.cotsResponsible));
+            $stepElement.append(wizard.createSingleMergeLine('COTS Clearing Deadline', data.releaseTarget.cotsDetails.clearingDeadline, data.releaseSource.cotsDetails.clearingDeadline));
+            $stepElement.append(wizard.createSingleMergeLine('COTS Clearing Report URL', data.releaseTarget.cotsDetails.licenseClearingReportURL, data.releaseSource.cotsDetails.licenseClearingReportURL));
+
+            $stepElement.append(wizard.createCategoryLine('COTS OSS Information'));
+            $stepElement.append(wizard.createSingleMergeLine('Used License', data.releaseTarget.cotsDetails.usedLicense, data.releaseSource.cotsDetails.usedLicense));
+            $stepElement.append(wizard.createSingleMergeLine('Contains OSS', data.releaseTarget.cotsDetails.containsOSS, data.releaseSource.cotsDetails.containsOSS, flagFormatter));
+            $stepElement.append(wizard.createSingleMergeLine('OSS contract signed', data.releaseTarget.cotsDetails.ossContractSigned, data.releaseSource.cotsDetails.ossContractSigned, flagFormatter));
+            $stepElement.append(wizard.createSingleMergeLine('OSS Information URL', data.releaseTarget.cotsDetails.ossInformationURL, data.releaseSource.cotsDetails.ossInformationURL));
+            $stepElement.append(wizard.createSingleMergeLine('Source Code Available', data.releaseTarget.cotsDetails.sourceCodeAvailable, data.releaseSource.cotsDetails.sourceCodeAvailable, flagFormatter));
+
+            $stepElement.append(wizard.createCategoryLine('Attachments'));
+            var sourceAttachmentMerge = createSourceCodeAttachmentsMultiMergeLine(data.displayInformation, data.releaseTarget.attachments, data.releaseSource.attachments);
+            $stepElement.append(sourceAttachmentMerge.$element);
+            $stepElement.append(wizard.createMultiMergeLine('Other Attachments', 
+                filterAttachments(data.releaseTarget.attachments, sourceAttachmentMerge.sourceCodeAttachmentIds), 
+                filterAttachments(data.releaseSource.attachments, sourceAttachmentMerge.sourceCodeAttachmentIds),
+                attachmentFormatter(data.displayInformation)
+            ));
+
+
+            wizard.registerClickHandlers({
+                'Created_by': true,
+                'Assessor_Contact_Person': true
+            }, function(propName, copied, targetValue, sourceValue) {
+                if(propName == 'Created_by') {
+                    $stepElement.find('.merge-info-createdby .user').text(copied ? targetValue : sourceValue);
+                } else if(propName == 'Assessor_Contact_Person') {
+                    $stepElement.find('.merge-info-assessor').replaceWith(renderAssessorContactPersonInfo(!copied, copied ? sourceValue : targetValue, copied || sourceValue, 'text-center'));
+                }
+            });
+
+            $wizardRoot.data('releaseSource', data.releaseSource);
+            $wizardRoot.data('releaseTarget', data.releaseTarget);
+            $wizardRoot.data('displayInformation', data.displayInformation);
+            $wizardRoot.data('usageInformation', data.usageInformation);
+        }
+
+        function submitMergedRelease($stepElement) {
+            var assessorResult,
+                releaseSelection = {},
+                attachments = [],
+                sourceCodeAttachments = [],
+                releaseSource = $wizardRoot.data('releaseSource'),
+                releaseTarget = $wizardRoot.data('releaseTarget');
+
+            releaseSelection.id = releaseTarget.id;
+            releaseSelection.componentId = releaseTarget.componentId;
+
+            releaseSelection.vendor = wizard.getEnhancedFinalSingleValue('Vendor').target ? releaseTarget.vendor : releaseSource.vendor;
+            releaseSelection.vendorId = releaseSelection.vendor ? releaseSelection.vendorId : undefined;
+            releaseSelection.name = wizard.getFinalSingleValue('Name');
+            releaseSelection.version = wizard.getFinalSingleValue('Version');
+            releaseSelection.languages = wizard.getFinalMultiValue('Programming Languages');
+            releaseSelection.operatingSystems = wizard.getFinalMultiValue('Operating Systems');
+            releaseSelection.cpeid = wizard.getFinalSingleValue('CPE ID');
+            releaseSelection.softwarePlatforms = wizard.getFinalMultiValue('Software Platforms');
+            releaseSelection.releaseDate = wizard.getFinalSingleValue('Release Date');
+            releaseSelection.mainLicenseIds = wizard.getFinalMultiValue('Licenses');
+            releaseSelection.downloadurl = wizard.getFinalSingleValue('Download URL');
+            releaseSelection.mainlineState = wizard.getFinalSingleValue('Release Mainline State');
+            releaseSelection.createdOn = wizard.getFinalSingleValue('Created on');
+            releaseSelection.createdBy = wizard.getFinalSingleValue('Created by');
+
+            releaseSelection.contributors = wizard.getFinalMultiValue('Contributors');
+            releaseSelection.moderators = wizard.getFinalMultiValue('Moderators');
+            releaseSelection.subscribers = wizard.getFinalMultiValue('Subscribers');
+            releaseSelection.repository = wizard.getFinalSingleValue('Repository');
+            releaseSelection.roles = wizard.getFinalMultiMapValue('Additional Roles');
+            releaseSelection.externalIds = wizard.getFinalMapValue('External ids');
+            releaseSelection.additionalData = wizard.getFinalMapValue('Additional Data');
+            
+            releaseSelection.releaseIdToRelationship = {};
+            wizard.getEnhancedFinalMultiValue('Linked Releases').forEach(function(result) {
+                releaseSelection.releaseIdToRelationship[result.value] = result.target ? releaseTarget.releaseIdToRelationship[result.value] : releaseSource.releaseIdToRelationship[result.value];
+            });
+
+            releaseSelection.clearingInformation = {};
+            releaseSelection.clearingInformation.binariesOriginalFromCommunity = wizard.getFinalSingleValue('Binaries Original from Community');
+            releaseSelection.clearingInformation.binariesSelfMade = wizard.getFinalSingleValue('Binaries Self-Made');
+            releaseSelection.clearingInformation.componentLicenseInformation = wizard.getFinalSingleValue('Component License Information');
+            releaseSelection.clearingInformation.sourceCodeDelivery = wizard.getFinalSingleValue('Source Code Delivery');
+            releaseSelection.clearingInformation.sourceCodeOriginalFromCommunity = wizard.getFinalSingleValue('Source Code Original from Community');
+            releaseSelection.clearingInformation.sourceCodeToolMade = wizard.getFinalSingleValue('Source Code Tool-Made');
+            releaseSelection.clearingInformation.sourceCodeSelfMade = wizard.getFinalSingleValue('Source Code Self-Made');
+            releaseSelection.clearingInformation.screenshotOfWebSite = wizard.getFinalSingleValue('Screenshot of Website');
+            releaseSelection.clearingInformation.finalizedLicenseScanReport = wizard.getFinalSingleValue('Finalized License Scan Report');
+            releaseSelection.clearingInformation.licenseScanReportResult = wizard.getFinalSingleValue('License Scan Report Result');
+            releaseSelection.clearingInformation.legalEvaluation = wizard.getFinalSingleValue('Legal Evaluation');
+            releaseSelection.clearingInformation.licenseAgreement = wizard.getFinalSingleValue('License Agreement');
+            releaseSelection.clearingInformation.scanned = wizard.getFinalSingleValue('Scanned');
+            releaseSelection.clearingInformation.componentClearingReport = wizard.getFinalSingleValue('Component Clearing Report');
+            releaseSelection.clearingInformation.clearingStandard = wizard.getFinalSingleValue('Clearing Standard');
+            releaseSelection.clearingInformation.externalUrl = wizard.getFinalSingleValue('External URL');
+            releaseSelection.clearingInformation.comment = wizard.getFinalSingleValue('Comment');
+
+            releaseSelection.clearingInformation.requestID = wizard.getFinalSingleValue('Request ID');
+            releaseSelection.clearingInformation.additionalRequestInfo = wizard.getFinalSingleValue('Additional Request Info');
+            releaseSelection.clearingInformation.procStart = wizard.getFinalSingleValue('Evaluation Start');
+            releaseSelection.clearingInformation.evaluated = wizard.getFinalSingleValue('Evalutation End');
+            
+            releaseSelection.clearingInformation.externalSupplierID = wizard.getFinalSingleValue('External Supplier ID');
+            releaseSelection.clearingInformation.countOfSecurityVn = wizard.getFinalSingleValue('Count of Security Vulnerabilities');
+
+            releaseSelection.eccInformation = {};
+            releaseSelection.eccInformation.eccStatus = wizard.getFinalSingleValue('ECC Status');
+            releaseSelection.eccInformation.eccComment = wizard.getFinalSingleValue('ECC Comment');
+            releaseSelection.eccInformation.AL = wizard.getFinalSingleValue('Ausfuhrliste');
+            releaseSelection.eccInformation.ECCN = wizard.getFinalSingleValue('ECCN');
+            releaseSelection.eccInformation.materialIndexNumber = wizard.getFinalSingleValue('Material Index Number');
+            assessorResult = wizard.getEnhancedFinalSingleValue('Assessor Contact Person');
+            if(assessorResult.target) {
+                releaseSelection.eccInformation.assessorContactPerson = releaseTarget.eccInformation.assessorContactPerson;
+                releaseSelection.eccInformation.assessorDepartment = releaseTarget.eccInformation.assessorDepartment;
+                releaseSelection.eccInformation.assessmentDate = releaseTarget.eccInformation.assessmentDate;
+            } else {
+                releaseSelection.eccInformation.assessorContactPerson = releaseSource.eccInformation.assessorContactPerson;
+                releaseSelection.eccInformation.assessorDepartment = releaseSource.eccInformation.assessorDepartment;
+                releaseSelection.eccInformation.assessmentDate = releaseSource.eccInformation.assessmentDate;
+            }
+
+            releaseSelection.cotsDetails = {};
+            releaseSelection.cotsDetails.usageRightAvailable = wizard.getFinalSingleValue('Usage Right Available');
+            releaseSelection.cotsDetails.cotsResponsible = wizard.getFinalSingleValue('COTS Responsible');
+            releaseSelection.cotsDetails.clearingDeadline = wizard.getFinalSingleValue('COTS Clearing Deadline');
+            releaseSelection.cotsDetails.licenseClearingReportURL = wizard.getFinalSingleValue('COTS Clearing Report URL');
+
+            releaseSelection.cotsDetails.usedLicense = wizard.getFinalSingleValue('Used License');
+            releaseSelection.cotsDetails.containsOSS = wizard.getFinalSingleValue('Contains OSS');
+            releaseSelection.cotsDetails.ossContractSigned = wizard.getFinalSingleValue('OSS contract signed');
+            releaseSelection.cotsDetails.ossInformationURL = wizard.getFinalSingleValue('OSS Information URL');
+            releaseSelection.cotsDetails.sourceCodeAvailable = wizard.getFinalSingleValue('Source Code Available');
+
+
+            releaseSelection.attachments = [];
+            sourceCodeAttachments = wizard.getFinalMultiValue('Matching Source Attachments');
+            $.each(sourceCodeAttachments, function(index, value) {
+                /* add just required fields for easy identification */
+                releaseSelection.attachments.push(JSON.parse('{ "attachmentContentId": "' + value.attachmentContentId + '", "filename": "' + value.filename + '"}'));
+            });
+            attachments = wizard.getFinalMultiValue('Other Attachments');
+            $.each(attachments, function(index, value) {
+                /* add just required fields for easy identification */
+                releaseSelection.attachments.push(JSON.parse('{ "attachmentContentId": "' + value.attachmentContentId + '", "filename": "' + value.filename + '"}'));
+            });
+
+            $stepElement.data('releaseSelection', releaseSelection);
+            /* releaseSourceId still as data at stepElement */
+        }
+
+        function renderConfirmMergedRelease($stepElement, data) {
+            var releaseSource = $wizardRoot.data('releaseSource'),
+                releaseTarget = $wizardRoot.data('releaseTarget'),
+                displayInformation = $wizardRoot.data('displayInformation'),
+                usageInformation = $wizardRoot.data('usageInformation');
+
+            $stepElement.data('releaseSourceId', data.releaseSourceId);
+            $stepElement.data('releaseSelection', data.releaseSelection);
+
+            $stepElement.html('<div class="stepFeedback"></div>');
+
+            $stepElement.append(renderNotice(usageInformation));
+
+            $stepElement.append(wizard.createCategoryLine('General'));
+            $stepElement.append(wizard.createSingleDisplayLine('Vendor', 
+                data.releaseSelection.vendor ? data.releaseSelection.vendor.id : null, 
+                vendorFormatter(releaseTarget.vendor, releaseSource.vendor)
+            ));
+            $stepElement.append(wizard.createSingleDisplayLine('Name', data.releaseSelection.name));
+            $stepElement.append(wizard.createSingleDisplayLine('Version', data.releaseSelection.version));
+            $stepElement.append(wizard.createMultiDisplayLine('Programming Languages', data.releaseSelection.languages));
+            $stepElement.append(wizard.createMultiDisplayLine('Operating Systems', data.releaseSelection.operatingSystems));
+            $stepElement.append(wizard.createSingleDisplayLine('CPE ID', data.releaseSelection.cpeid));
+            $stepElement.append(wizard.createMultiDisplayLine('Software Platforms', data.releaseSelection.softwarePlatforms));
+            $stepElement.append(wizard.createSingleDisplayLine('Release Date', data.releaseSelection.releaseDate));
+            $stepElement.append(wizard.createMultiDisplayLine('Licenses', data.releaseSelection.mainLicenseIds));
+            $stepElement.append(wizard.createSingleDisplayLine('Download URL', data.releaseSelection.downloadurl));
+            $stepElement.append(wizard.createSingleDisplayLine('Release Mainline State', data.releaseSelection.mainlineState, mapFormatter(displayInformation, 'mainlineState')));
+            $stepElement.append(wizard.createSingleDisplayLine('Created on', data.releaseSelection.createdOn));
+            $stepElement.append(
+                renderCreatedBy(
+                    wizard.createSingleDisplayLine('Created by', data.releaseSelection.createdBy),
+                    releaseSource.createdBy != releaseTarget.createdBy,
+                    data.releaseSelection.createdBy === releaseSource.createdBy ? releaseTarget.createdBy : releaseSource.createdBy,
+                    'pl-3'
+                )
+            );
+            $stepElement.append(wizard.createMultiDisplayLine('Contributors', data.releaseSelection.contributors));
+            $stepElement.append(wizard.createMultiDisplayLine('Moderators', data.releaseSelection.moderators));
+            $stepElement.append(wizard.createMultiDisplayLine('Subscribers', data.releaseSelection.subscribers));
+            $stepElement.append(wizard.createSingleDisplayLine('Repository', data.releaseSelection.repository, repositoryFormatter(displayInformation)));
+            $stepElement.append(wizard.createMultiMapDisplayLine('Additional Roles', data.releaseSelection.roles));
+            $stepElement.append(wizard.createMapDisplayLine('External ids', data.releaseSelection.externalIds));
+            $stepElement.append(wizard.createMapDisplayLine('Additional Data', data.releaseSelection.additionalData));
+            
+            $stepElement.append(wizard.createCategoryLine('Linked Releases'));
+            $stepElement.append(wizard.createMultiDisplayLine('Linked Releases', Object.keys(data.releaseSelection.releaseIdToRelationship), mapFormatter(displayInformation, 'release')));
+
+            $stepElement.append(wizard.createCategoryLine('Clearing Details'));
+            $stepElement.append(wizard.createSingleDisplayLine('Binaries Original from Community', data.releaseSelection.clearingInformation.binariesOriginalFromCommunity, flagFormatter));
+            $stepElement.append(wizard.createSingleDisplayLine('Binaries Self-Made', data.releaseSelection.clearingInformation.binariesSelfMade, flagFormatter));
+            $stepElement.append(wizard.createSingleDisplayLine('Component License Information', data.releaseSelection.clearingInformation.componentLicenseInformation, flagFormatter));
+            $stepElement.append(wizard.createSingleDisplayLine('Source Code Delivery', data.releaseSelection.clearingInformation.sourceCodeDelivery, flagFormatter));
+            $stepElement.append(wizard.createSingleDisplayLine('Source Code Original from Community', data.releaseSelection.clearingInformation.sourceCodeOriginalFromCommunity, flagFormatter));
+            $stepElement.append(wizard.createSingleDisplayLine('Source Code Tool-Made', data.releaseSelection.clearingInformation.sourceCodeToolMade, flagFormatter));
+            $stepElement.append(wizard.createSingleDisplayLine('Source Code Self-Made', data.releaseSelection.clearingInformation.sourceCodeSelfMade, flagFormatter));
+            $stepElement.append(wizard.createSingleDisplayLine('Screenshot of Website', data.releaseSelection.clearingInformation.screenshotOfWebSite, flagFormatter));
+            $stepElement.append(wizard.createSingleDisplayLine('Finalized License Scan Report', data.releaseSelection.clearingInformation.finalizedLicenseScanReport, flagFormatter));
+            $stepElement.append(wizard.createSingleDisplayLine('License Scan Report Result', data.releaseSelection.clearingInformation.licenseScanReportResult, flagFormatter));
+            $stepElement.append(wizard.createSingleDisplayLine('Legal Evaluation', data.releaseSelection.clearingInformation.legalEvaluation, flagFormatter));
+            $stepElement.append(wizard.createSingleDisplayLine('License Agreement', data.releaseSelection.clearingInformation.licenseAgreement, flagFormatter));
+            $stepElement.append(wizard.createSingleDisplayLine('Scanned', data.releaseSelection.clearingInformation.scanned));
+            $stepElement.append(wizard.createSingleDisplayLine('Component Clearing Report', data.releaseSelection.clearingInformation.componentClearingReport, flagFormatter));
+            $stepElement.append(wizard.createSingleDisplayLine('Clearing Standard', data.releaseSelection.clearingInformation.clearingStandard));
+            $stepElement.append(wizard.createSingleDisplayLine('External URL', data.releaseSelection.clearingInformation.externalUrl));
+            $stepElement.append(wizard.createSingleDisplayLine('Comment', data.releaseSelection.clearingInformation.comment));
+
+            $stepElement.append(wizard.createCategoryLine('Request Information'));
+            $stepElement.append(wizard.createSingleDisplayLine('Request ID', data.releaseSelection.clearingInformation.requestID));
+            $stepElement.append(wizard.createSingleDisplayLine('Additional Request Info', data.releaseSelection.clearingInformation.additionalRequestInfo));
+            $stepElement.append(wizard.createSingleDisplayLine('Evaluation Start', data.releaseSelection.clearingInformation.procStart));
+            $stepElement.append(wizard.createSingleDisplayLine('Evalutation End', data.releaseSelection.clearingInformation.evaluated));
+
+            $stepElement.append(wizard.createCategoryLine('Supplemental Information'));
+            $stepElement.append(wizard.createSingleDisplayLine('External Supplier ID', data.releaseSelection.clearingInformation.externalSupplierID));
+            $stepElement.append(wizard.createSingleDisplayLine('Count of Security Vulnerabilities', data.releaseSelection.clearingInformation.countOfSecurityVn));
+
+            $stepElement.append(wizard.createCategoryLine('ECC Information'));
+            $stepElement.append(wizard.createSingleDisplayLine('ECC Status', data.releaseSelection.eccInformation.eccStatus, mapFormatter(displayInformation, 'eccStatus')));
+            $stepElement.append(wizard.createSingleDisplayLine('ECC Comment', data.releaseSelection.eccInformation.eccComment));
+            $stepElement.append(wizard.createSingleDisplayLine('Ausfuhrliste', data.releaseSelection.eccInformation.AL));
+            $stepElement.append(wizard.createSingleDisplayLine('ECCN', data.releaseSelection.eccInformation.ECCN));
+            $stepElement.append(wizard.createSingleDisplayLine('Material Index Number', data.releaseSelection.eccInformation.materialIndexNumber));
+            $stepElement.append(
+                renderAssessorContactPerson(
+                    wizard.createSingleDisplayLine('Assessor Contact Person', data.releaseSelection.eccInformation.assessorContactPerson),
+                    false,
+                    !wizard.getEnhancedFinalSingleValue('Assessor Contact Person').target,
+                    true,
+                    'pl-3'
+                )
+            );
+
+            $stepElement.append(wizard.createCategoryLine('Commercial Details Administration'));
+            $stepElement.append(wizard.createSingleDisplayLine('Usage Right Available', data.releaseSelection.cotsDetails.usageRightAvailable, flagFormatter));
+            $stepElement.append(wizard.createSingleDisplayLine('COTS Responsible', data.releaseSelection.cotsDetails.cotsResponsible));
+            $stepElement.append(wizard.createSingleDisplayLine('COTS Clearing Deadline', data.releaseSelection.cotsDetails.clearingDeadline));
+            $stepElement.append(wizard.createSingleDisplayLine('COTS Clearing Report URL', data.releaseSelection.cotsDetails.licenseClearingReportURL));
+
+            $stepElement.append(wizard.createCategoryLine('COTS OSS Information'));
+            $stepElement.append(wizard.createSingleDisplayLine('Used License', data.releaseSelection.cotsDetails.usedLicense));
+            $stepElement.append(wizard.createSingleDisplayLine('Contains OSS', data.releaseSelection.cotsDetails.containsOSS, flagFormatter));
+            $stepElement.append(wizard.createSingleDisplayLine('OSS contract signed', data.releaseSelection.cotsDetails.ossContractSigned, flagFormatter));
+            $stepElement.append(wizard.createSingleDisplayLine('OSS Information URL', data.releaseSelection.cotsDetails.ossInformationURL));
+            $stepElement.append(wizard.createSingleDisplayLine('Source Code Available', data.releaseSelection.cotsDetails.sourceCodeAvailable, flagFormatter));
+
+            $stepElement.append(wizard.createCategoryLine('Attachments'));
+            $stepElement.append(wizard.createMultiDisplayLine('Attachments', data.releaseSelection.attachments, attachmentFormatter(displayInformation)));
+        }
+
+        function submitConfirmedMergedRelease($stepElement) {
+            /* componentSourceId still as data at stepElement */
+            /* componentSelection still as data at stepElement */
+        }
+
+        function errorHook($stepElement, textStatus, error) {
+            if($stepElement.find('.stepFeedback').length === 0) {
+                // initial loading
+                $stepElement.html('<div class="stepFeedback"></div>');
+            }
+
+            $stepElement.find('.stepFeedback').html('<div class="alert alert-danger">Cannot continue to merge of releases: ' + textStatus + error + '</div>');
+            $('html, body').stop().animate({ scrollTop: 0 }, 300, 'swing');
+        }
+
+        function mapFormatter(data, key) {
+            return function(value) {
+                return value ? data[key][value] : '';
+            }
+        }
+
+        function flagFormatter(flag) {
+            if(flag) {
+                return  '<span class=\"text-success\">' +
+                        '   <svg class=\"lexicon-icon\"><title>Yes</title><use href=\"/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#check-circle\"/></svg>' +
+                        '   &nbsp;Yes' +
+                        '</span>';
+            } else {
+                return  '<span class=\"text-danger\">' +
+                        '   <svg class=\"lexicon-icon\"><title>Yes</title><use href=\"/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#times-circle\"/></svg>' +
+                        '   &nbsp;No' +
+                        '</span>';
+            }
+        }
+
+        function vendorFormatter(vendor1, vendor2) {
+            return function(id) {
+                if(vendor1 && id === vendor1.id) {
+                    return vendor1.fullname + ' (' + vendor1.shortname + ')<br/>' + vendor1.url;
+                }
+                if(vendor2 && id === vendor2.id) {
+                    return vendor2.fullname + ' (' + vendor2.shortname + ')<br/>' + vendor2.url;
+                }
+                return '';
+            };
+        }
+
+        function repositoryFormatter(data) {
+            return function(repository) {
+                return repository ? repository.url + ' (' + data['repositorytype'][repository.repositorytype] + ')' : '';
+            }
+        }
+
+        function attachmentFormatter(data) {
+            return function(attachment) {
+                if (!attachment) {
+                    return '';
+                }
+                return (attachment.filename || '-no-filename-') + ' (' + matchAttachmentType(data, attachment.attachmentType) + ')';
+            };
+        }
+
+        function renderCreatedBy($line, renderInfo, user, alignment) {
+            var $info = "<small class='merge-info-createdby form-text mt-0 pb-2 " + alignment + "'>" + 
+                "<svg class='lexicon-icon'><use href='/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#info-circle-open' /></svg> " + 
+                "The user <b class='user'>" + (user || '') + "</b> will be added to the list of moderators." +
+                "</small>";
+
+            if(renderInfo) {
+                $line.append($info);
+            }
+
+            return $line;
+        }
+
+        function renderAssessorContactPerson($line, useTarget, renderInfo, user, alignment) {
+            $line.append(renderAssessorContactPersonInfo(useTarget, user, renderInfo, alignment));
+            return $line;
+        }
+
+        function renderAssessorContactPersonInfo(useTarget, user, renderInfo, alignment) {
+            var message = '';
+
+            if(!renderInfo) {
+                message = '';
+            } else {       
+                message = "<svg class='lexicon-icon'><use href='/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#info-circle-open' /></svg> ";
+                if(useTarget) {
+                    message += "Changing the assessor contact person to <b>" + (user || '') + "</b> will change the fields <b>Assessor Department</b> and <b>Assessement Date</b> accordingly.";
+                } else {
+                    message += "The fields <b>Assessor Department</b> and <b>Assessement Date</b> will be taken as well.";
+                }
+            }
+
+            return "<small class='merge-info-assessor form-text mt-0 pb-2 " + alignment + "'>" + message + "</small>";
+        }
+
+        function createSourceCodeAttachmentsMultiMergeLine(data, targetAttachments, sourceAttachments) {
+            var result = {
+                    sourceCodeAttachmentIds: {}
+                };
+
+            targetAttachments = targetAttachments || [];
+            sourceAttachments = sourceAttachments || [];
+
+            result.$element = wizard.createCustomMergeLines('Matching Source Attachments', function(container, createSingleMergeContent) {
+                var rowIndex = 0;
+
+                targetAttachments.forEach(function(targetAttachment) {
+                    if(!isSourceAttachment(targetAttachment)) {
+                        return;
+                    }
+                    
+                    var sourceAttachment = sourceAttachments.find(function(sourceAttachment) {
+                        return isSourceAttachment(sourceAttachment) && targetAttachment.sha1 == sourceAttachment.sha1; 
+                    });
+                    if(sourceAttachment) {
+                        result.sourceCodeAttachmentIds[targetAttachment.sha1] = true;
+                        container.append(createSingleMergeContent(targetAttachment, sourceAttachment, rowIndex++, attachmentFormatter(data), true));
+                    }
+                });
+            });
+
+            result.$element.append('' +
+                "<small class='merge-info-attachments form-text mt-0 pb-2 text-center'>" +
+                    "<svg class='lexicon-icon'><use href='/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#info-circle-open' /></svg> " +
+                    "Source Code Attachments are always taken from source release and cannot be deselected." +
+                "</small>"
+            );
+
+            return result;
+        }
+
+        function isSourceAttachment(attachment) {
+            return attachment.attachmentType == 1 || attachment.attachmentType == 9;
+        }
+
+        function matchAttachmentType(displayInformation, attachmentType) {
+            if(!attachmentType) {
+                return '-no-type-';
+            }
+            return displayInformation.attachmentType[attachmentType];
+        }
+
+        function filterAttachments(attachments, ids) {
+            attachments = attachments || [];
+            return attachments.filter(function(attachment) {
+                return !isSourceAttachment(attachment) || !ids[attachment.sha1];
+            });
+        }
+
+        function renderNotice(usageInformation) {
+            var $note = $(
+                '<div class="alert mt-4">' +
+                    'The following documents will be affected by this merge and are changed accordingly:' +
+                    '<ul>' +
+                    '</ul>' +
+                '</div>'
+            );
+            if(usageInformation.projects == 0 && 
+                usageInformation.releases == 0 &&
+                usageInformation.releaseVulnerabilities == 0 &&
+                usageInformation.attachmentUsages == 0 &&
+                usageInformation.projectRatings == 0
+            ) {
+                return $();
+            }
+            
+            if(usageInformation.projects > 0) {
+                var $li = $('<li><b class="number"></b> project(s)</li>');
+                $li.find('.number').text(usageInformation.projects)
+                
+                $note.find('ul').append($li);
+            }
+            if(usageInformation.releases > 0) {
+                var $li = $('<li><b class="number"></b> release(s)</li>');
+                $li.find('.number').text(usageInformation.releases)
+                
+                $note.find('ul').append($li);
+            }
+            if(usageInformation.releaseVulnerabilities > 0) {
+                var $li = $('<li><b class="number"></b> vulnerabilities</li>');
+                $li.find('.number').text(usageInformation.releaseVulnerabilities)
+                
+                $note.find('ul').append($li);
+            }
+            if(usageInformation.attachmentUsages > 0) {
+                var $li = $('<li><b class="number"></b> attachment usage(s)</li>');
+                $li.find('.number').text(usageInformation.attachmentUsages)
+                
+                $note.find('ul').append($li);
+            }
+            if(usageInformation.projectRatings > 0) {
+                var $li = $('<li><b class="number"></b> project rating(s)</li>');
+                $li.find('.number').text(usageInformation.projectRatings)
+                
+                $note.find('ul').append($li);
+            }
+
+            if(usageInformation.projects + usageInformation.releases + usageInformation.releaseVulnerabilities + usageInformation.attachmentUsages + usageInformation.projectRatings > 1000) {
+                $note.append('<b>More than 1000 documents affected. The merge operation might time out. In consequence only some of ' +
+                    'the documents might be changed accordingly. In this case just restart the operation as long as the source release ' + 
+                    'continues to exist.');
+                $note.addClass('alert-warning');
+            } else {
+                $note.addClass('alert-info');
+            }
+            return $note;
+        }
+    });
+</script>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/modules/sw360Wizard.js
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/modules/sw360Wizard.js
@@ -179,7 +179,9 @@ define('modules/sw360Wizard', [ 'jquery', 'modules/button' ], function($, button
                 }).done(function(data, textStatus, xhr) {
                     try {
                         var dataJson = JSON.parse(data);
-                        if (activeElement[0] === lastStep[0]) {
+                        if(dataJson.error) {
+                            stepFailed(activeIndex, activeElement, '', dataJson.error);
+                        } else if (activeElement[0] === lastStep[0]) {
                             if(!config.finishCb(activeElement, dataJson)) {
                                 $('.wizardNext, .wizardBack', $wizardRoot).remove();
                                 $('.wizardAbort', $wizardRoot).removeClass('hide');

--- a/libraries/lib-datahandler/src/main/thrift/attachments.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/attachments.thrift
@@ -290,4 +290,9 @@ service AttachmentService {
      * Returns the sources/owners (project, component, release) of the attachment by attachmentContentId
      */
     list<Source> getAttachmentOwnersByIds(1: set<string> ids)
+
+    /**
+     * Returns all attachments usages by release id
+     */
+    list<AttachmentUsage> getAttachmentUsagesByReleaseId(1: string releaseId);
 }

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -505,6 +505,14 @@ service ComponentService {
      **/
     RequestSummary updateReleases(1: set<Release> releases, 2: User user);
 
+     /**
+     * merge release identified by releaseSourceId into release identified by releaseTargetId.
+     * the releaseSelection shows which data has to be set on the target. the source will be deleted afterwards.
+     * if user does not have permissions, RequestStatus.ACCESS_DENIED is returned
+     * if any of the releases has an active moderation request, it's a noop and RequestStatus.IN_USE is returned
+     **/
+    RequestStatus mergeReleases(1: string releaseTargetId, 2: string releaseSourceId, 3: Release releaseSelection, 4: User user);
+
     /**
      * delete release from database if user has permissions
      * otherwise create moderation request
@@ -632,4 +640,9 @@ service ComponentService {
      * get a set of releases based on the external id external ids can have multiple values to one key
      */
     set<Release> searchReleasesByExternalIds(1: map<string, set<string>> externalIds);
+
+    /**
+     * Gets releases referencing the given release id
+     */ 
+    list<Release> getReferencingReleases(1: string releaseId);
 }

--- a/libraries/lib-datahandler/src/main/thrift/vulnerabilities.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/vulnerabilities.thrift
@@ -246,4 +246,14 @@ service VulnerabilityService {
       * returns null otherwise
       **/
     VulnerabilityWithReleaseRelations getVulnerabilityWithReleaseRelationsByExternalId(1: string externalId, 2: User user);
+
+    /**
+     * returns a list of relations where the given release id is involved.
+     */
+    list<ReleaseVulnerabilityRelation> getReleaseVulnerabilityRelationsByReleaseId(1: string releaseId, 2: User user);
+
+    /**
+     * returns a list of all ratings involving the given release id
+     */
+    list<ProjectVulnerabilityRating> getProjectVulnerabilityRatingsByReleaseId(1: string releaseId, 2: User user);
 }


### PR DESCRIPTION
This commit adds a merge wizard for releases. It is build upon the merge framework therefore
it works the same as the component and the vendor merge wizard: click merge on the target, select
a source and takeover the needed fields.

Merging releases is only possible inside a single component. In addition both releases need to have
at least on pair of equal source attachemnts nor no source attachments at all.

The fossology status is not merges since it will be superseeded by external tool requests in the
near future.

Signed-off-by: Leo von Klenze <leo.vonklenze@scansation.de>