### PR TITLE
feat(rest): Added support to upload role category fields while creating project

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -14,6 +14,7 @@
 package org.eclipse.sw360.rest.resourceserver.core;
 
 import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -77,9 +78,6 @@ class JacksonCustomizations {
                 "attachments",
                 "createdBy",
                 "state",
-                "leadArchitect",
-                "moderators",
-                "contributors",
                 "visbility",
                 "clearingTeam",
                 "phaseOutSince",
@@ -182,6 +180,18 @@ class JacksonCustomizations {
             @Override
             @JsonProperty("id")
             abstract public String getId();
+
+            @Override
+            @JsonProperty(access = Access.WRITE_ONLY)
+            abstract public Set<String> getContributors();
+
+            @Override
+            @JsonProperty(access = Access.WRITE_ONLY)
+            abstract public Set<String> getModerators();
+
+            @Override
+            @JsonProperty(access = Access.WRITE_ONLY)
+            abstract public String getLeadArchitect();
         }
 
 	static abstract class EmbeddedProjectMixin extends ProjectMixin {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -216,6 +216,32 @@ public class RestControllerHelper<T> {
         }
     }
 
+    public void addEmbeddedContributors(HalResource halResource, Set<String> contributors) {
+        User sw360User;
+        for (String contributorEmail : contributors) {
+            try {
+                sw360User = userService.getUserByEmail(contributorEmail);
+            } catch (RuntimeException e) {
+                sw360User = new User();
+                sw360User.setId(contributorEmail).setEmail(contributorEmail);
+                LOGGER.debug("Could not get user object from backend with email: " + contributorEmail);
+            }
+            addEmbeddedUser(halResource, sw360User, "sw360:contributors");
+        }
+    }
+
+    public void addEmbeddedLeadArchitect(HalResource halResource, String leadArchitect) {
+        User sw360User;
+        try {
+              sw360User = userService.getUserByEmail(leadArchitect);
+            } catch (RuntimeException e) {
+                sw360User = new User();
+                sw360User.setId(leadArchitect).setEmail(leadArchitect);
+                LOGGER.debug("Could not get user object from backend with email: " + leadArchitect);
+            }
+            addEmbeddedUser(halResource, sw360User, "leadArchitect");
+    }
+
     public void addEmbeddedReleases(
             HalResource halResource,
             Set<String> releases,
@@ -239,7 +265,7 @@ public class RestControllerHelper<T> {
         User embeddedUser = convertToEmbeddedUser(user);
         Resource<User> embeddedUserResource = new Resource<>(embeddedUser);
         try {
-            Link userLink = linkTo(UserController.class).slash("api/users/" + URLEncoder.encode(user.getId(), "UTF-8")).withSelfRel();
+            Link userLink = linkTo(UserController.class).slash("api/users/byid/" + URLEncoder.encode(user.getId(), "UTF-8")).withSelfRel();
             embeddedUserResource.add(userLink);
             halResource.addEmbeddedResource(relation, embeddedUserResource);
         } catch (UnsupportedEncodingException e) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -421,6 +421,15 @@ public class ProjectController implements ResourceProcessor<RepositoryLinksResou
             restControllerHelper.addEmbeddedAttachments(halProject, sw360Project.getAttachments());
         }
 
+        if(sw360Project.getLeadArchitect() != null) {
+            restControllerHelper.addEmbeddedLeadArchitect(halProject, sw360Project.getLeadArchitect());
+        }
+
+        if (sw360Project.getContributors() != null) {
+            Set<String> contributors = sw360Project.getContributors();
+            restControllerHelper.addEmbeddedContributors(halProject, contributors);
+        }
+
         return halProject;
     }
 }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -508,6 +508,9 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         Map<String, ProjectRelationship> linkedProjects = new HashMap<String, ProjectRelationship>();
         linkedProjects.put("376576", ProjectRelationship.CONTAINED);
         project.put("linkedProjects", linkedProjects);
+        project.put("leadArchitect", "lead@sw360.org");
+        project.put("moderators", new HashSet<>(Arrays.asList("moderator1@sw360.org", "moderator2@sw360.org")));
+        project.put("contributors", new HashSet<>(Arrays.asList("contributor1@sw360.org", "contributor2@sw360.org")));
 
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
         this.mockMvc.perform(post("/api/projects")
@@ -524,7 +527,10 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("visibility").description("The project visibility, possible values are: " + Arrays.asList(Visibility.values())),
                                 fieldWithPath("projectType").description("The project type, possible values are: " + Arrays.asList(ProjectType.values())),
                                 fieldWithPath("linkedReleases").description("The relationship between linked releases of the project"),
-                                fieldWithPath("linkedProjects").description("The relationship between linked projects of the project")
+                                fieldWithPath("linkedProjects").description("The relationship between linked projects of the project"),
+                                fieldWithPath("leadArchitect").description("The lead architect of the project"),
+                                fieldWithPath("contributors").description("An array of contributors to the project"),
+                                fieldWithPath("moderators").description("An array of moderators")
                         ),
                         responseFields(
                                 fieldWithPath("name").description("The name of the project"),


### PR DESCRIPTION
* While creating project through rest endpoint, some of the fields( like contributors, moderators, lead architect) were not able to de-serialized. added support to de-serialize the same. 
* Exposed leadArchitect, moderators, contributotrs as hypermedia resource.

Signed-off-by: Smruti Sahoo <smruti.sahoo@siemens.com>