### PR TITLE
fix(Project/Admin): Set to default text feature is not working correctly for Obligation

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/administrationEdit.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/administrationEdit.jspf
@@ -69,7 +69,7 @@
                 <button id="setToDefaultObligationsTextButton" class="btn btn-link btn-right" type="button">Set To Default Text</button>
                 <textarea name="<portlet:namespace/><%=Project._Fields.OBLIGATIONS_TEXT%>"
                     class="form-control" rows="5" id="obligationsText"
-                    data-defaulttext="${defaultObligationsText}"><sw360:DisplayObligations project="${project}"
+                    data-defaulttext="<c:out value="${defaultObligationsText}"/>"><sw360:DisplayObligations project="${project}"
                     defaultText="${defaultObligationsText}"/></textarea>
             </div>
         </td>


### PR DESCRIPTION
Edit Project , under administration tab "set to default" for obligation not working properly if default Obligation message contains quotes

 Closes : #582 

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>