### PR TITLE
fix(REST): added support for createdComment field for uploadAttachements

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
@@ -128,6 +128,11 @@ public class Sw360AttachmentService {
             attachment.setCheckStatus(checkStatus);
         }
 
+        String createdComment = newAttachment.getCreatedComment();
+        if (createdComment != null) {
+            attachment.setCreatedComment(createdComment);
+        }
+
         return attachment;
     }
 


### PR DESCRIPTION
While uploading attachments through REST API , createdComment field was not updating. Changes done to resolve the issue.

closes: #646 

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>