### PR TITLE
feat(release): Save Hashes to known binaries without uploading attachments

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -1429,6 +1429,10 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return releaseRepository.searchByExternalIds(externalIds);
     }
 
+    public List<Release> searchReleasesByFileHashes(Set<String> hashes) {
+        return releaseRepository.searchReleasesByFileHashes(hashes);
+    }
+
     /**
      * Returns full documents straight from repository. Don't want this to get abused, that's why it's package-private.
      * Used for bulk-computing ReleaseClearingStateSummaries by ProjectDatabaseHandler.

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRepository.java
@@ -84,6 +84,17 @@ import static com.google.common.base.Strings.isNullOrEmpty;
                         "       emit( [externalId, doc.externalIds[externalId]] , doc._id);" +
                         "    }" +
                         "  }" +
+                        "}"),
+        @View(name = "byHash",
+                map = "function(doc) {" +
+                        "  if (doc.type == 'release'){" +
+                        "    for(var i in doc.attachments) { " +
+                        "      emit(doc.attachments[i].sha1, doc);" +
+                        "    }" +
+                        "    for(var i in doc.otherKnownHashes) { " +
+                        "      emit(doc.otherKnownHashes[i].hash, doc);" +
+                        "    }" +
+                        "  }" +
                         "}")
 
 })
@@ -155,5 +166,9 @@ public class ReleaseRepository extends SummaryAwareRepository<Release> {
 
     public List<Release> getReferencingReleases(String releaseId) {
         return queryView("usedInReleaseRelation", releaseId);
+    }
+
+    public List<Release> searchReleasesByFileHashes(Set<String> hashes) {
+        return queryByIds("byHash", hashes);
     }
 }

--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -490,4 +490,10 @@ public class ComponentHandler implements ComponentService.Iface {
         assertNotNull(externalIds);
         return handler.searchReleasesByExternalIds(externalIds);
     }
+
+    @Override
+    public List<Release> searchReleasesByFileHashes(Set<String> hashes) throws TException {
+        assertNotNull(hashes);
+        return handler.searchReleasesByFileHashes(hashes);
+    }
 }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -165,6 +165,7 @@ public class PortalConstants {
 
     //! Specialized keys for attachments
     public static final String ATTACHMENTS = "attachments";
+    public static final String OTHER_KNOWN_HASHES = "otherKnownHashes";
     public static final String ATTACHMENT_NAME = "attachmentName";
     public static final String SPDX_ATTACHMENTS = "spdxAttachments";
     public static final String ADDED_ATTACHMENTS = "added_attachments";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/AttachmentAwarePortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/AttachmentAwarePortlet.java
@@ -72,7 +72,7 @@ public abstract class AttachmentAwarePortlet extends Sw360Portlet {
 
         @Override
         public void serialize(Attachment attachment, JsonGenerator jsonGenerator, SerializerProvider provider)
-                throws IOException, JsonGenerationException {
+                throws IOException {
             try {
                 jsonGenerator.writeRawValue(JSON_SERIALIZER.toString(attachment));
             } catch (TException exception) {
@@ -115,8 +115,14 @@ public abstract class AttachmentAwarePortlet extends Sw360Portlet {
 
 
     private void setAttachmentsInRequest(PortletRequest request, Set<Attachment> attachments, Source owner) {
+        setAttachmentsInRequest(request, attachments, Collections.emptySet(), owner);
+    }
+
+    private void setAttachmentsInRequest(PortletRequest request, Set<Attachment> attachments, Set<KnownHash> otherKnownHashes, Source owner) {
         Set<Attachment> atts = CommonUtils.nullToEmptySet(attachments);
         request.setAttribute(ATTACHMENTS, atts);
+        Set<KnownHash> okhs = CommonUtils.nullToEmptySet(otherKnownHashes);
+        request.setAttribute(OTHER_KNOWN_HASHES, okhs);
         if (owner == null) {
             setEmptyUsages(request);
             return;
@@ -185,7 +191,7 @@ public abstract class AttachmentAwarePortlet extends Sw360Portlet {
     }
 
     protected void setAttachmentsInRequest(PortletRequest request, Release release) {
-        setAttachmentsInRequest(request, release.getAttachments(), release.getId() == null ? null : Source.releaseId(release.getId()));
+        setAttachmentsInRequest(request, release.getAttachments(), release.getOtherKnownHashes(), release.getId() == null ? null : Source.releaseId(release.getId()));
     }
 
     protected void setAttachmentsInRequest(PortletRequest request, Project project) {
@@ -198,7 +204,7 @@ public abstract class AttachmentAwarePortlet extends Sw360Portlet {
 
     protected abstract Set<Attachment> getAttachments(String documentId, String documentType, User user);
 
-    protected void dealWithAttachments(ResourceRequest request, ResourceResponse response, String action) throws IOException, PortletException {
+    protected void dealWithAttachments(ResourceRequest request, ResourceResponse response, String action) throws IOException {
         if (PortalConstants.ATTACHMENT_DOWNLOAD.equals(action)) {
             attachmentPortletUtils.serveFile(request, response);
         } else if (PortalConstants.ATTACHMENT_LIST.equals(action)) {
@@ -226,7 +232,7 @@ public abstract class AttachmentAwarePortlet extends Sw360Portlet {
         }
     }
 
-    private void doGetAttachmentForDisplay(ResourceRequest request, ResourceResponse response) throws IOException, PortletException {
+    private void doGetAttachmentForDisplay(ResourceRequest request, ResourceResponse response) throws IOException {
         final String attachmentId = request.getParameter(PortalConstants.ATTACHMENT_ID);
         final User user = UserCacheHolder.getUserFromRequest(request);
 
@@ -238,7 +244,7 @@ public abstract class AttachmentAwarePortlet extends Sw360Portlet {
         }
     }
 
-    private void serveAttachmentSet(ResourceRequest request, ResourceResponse response) throws IOException, PortletException {
+    private void serveAttachmentSet(ResourceRequest request, ResourceResponse response) throws IOException {
         final String documentType = getDocumentType(request);
         final String documentId = request.getParameter(PortalConstants.DOCUMENT_ID);
         final User user = UserCacheHolder.getUserFromRequest(request);

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/attachmentsDetail.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/attachmentsDetail.jsp
@@ -18,6 +18,7 @@
 
 <core_rt:catch var="attributeNotFoundException">
     <jsp:useBean id="attachments" type="java.util.Set<org.eclipse.sw360.datahandler.thrift.attachments.Attachment>" scope="request" />
+    <jsp:useBean id="otherKnownHashes" type="java.util.Set<org.eclipse.sw360.datahandler.thrift.attachments.KnownHash>" scope="request" />
     <jsp:useBean id="attachmentUsages" type="java.util.Map<java.lang.String, java.util.List<org.eclipse.sw360.datahandler.thrift.projects.Project>>" scope="request" />
     <jsp:useBean id="attachmentUsagesRestrictedCounts" type="java.util.Map<java.lang.String, java.lang.Long>" scope="request" />
     <jsp:useBean id="documentType" type="java.lang.String" scope="request" />
@@ -95,16 +96,40 @@
                         "type": "<sw360:DisplayEnumShort value="${attachment.attachmentType}"/>",
                         "uploadedTeam": "<sw360:DisplayEllipsisString value="${attachment.createdTeam}"/>",
                         "uploadedBy": "<sw360:DisplayEllipsisString value="${attachment.createdBy}"/>",
-                        "checkedTeam":  "<sw360:DisplayEllipsisString value="${attachment.checkedTeam}"/>",
-                        "checkedBy":  "<sw360:DisplayEllipsisString value="${attachment.checkedBy}"/>",
-                        "usage":  {links: usageLinks, restrictedCount: ${attachmentUsagesRestrictedCounts.getOrDefault(attachment.attachmentContentId, 0)}},
-                        "actions":     "<div class=\"actions\"><sw360:DisplayDownloadAttachmentFile attachment="${attachment}" contextType="${documentType}" contextId="${documentID}"/></div>",
-                        "sha1": "<sw360:out value="${attachment.sha1}"/>",
+                        "checkedTeam": "<sw360:DisplayEllipsisString value="${attachment.checkedTeam}"/>",
+                        "checkedBy": "<sw360:DisplayEllipsisString value="${attachment.checkedBy}"/>",
+                        "usage": {links: usageLinks, restrictedCount: ${attachmentUsagesRestrictedCounts.getOrDefault(attachment.attachmentContentId, 0)}},
+                        "actions": "<div class=\"actions\"><sw360:DisplayDownloadAttachmentFile attachment="${attachment}" contextType="${documentType}" contextId="${documentID}"/></div>",
+                        "sha1": "sha1: <sw360:out value="${attachment.sha1}"/>",
                         "uploadedOn": "<sw360:out value="${attachment.createdOn}"/>",
                         "uploadedComment": "<core_rt:if test="${not empty attachment.createdComment}">Comment: <sw360:DisplayEllipsisString value="${attachment.createdComment}"/></core_rt:if>",
                         "checkedOn": "<sw360:out value="${attachment.checkedOn}"/>",
                         "checkedComment": "<core_rt:if test="${not empty attachment.checkedComment}">Comment: <sw360:DisplayEllipsisString value="${attachment.checkedComment}"/></core_rt:if>",
                         "checkStatus": "<sw360:out value="${attachment.checkStatus}"/>"
+                    });
+                </core_rt:forEach>
+                <core_rt:forEach items="${otherKnownHashes}" var="otherKnownHash">
+                    attachmentJSON.push({
+                        <core_rt:if test="${not empty otherKnownHash.filename}">
+                        "fileName": "<sw360:out value="${otherKnownHash.filename}"/>",
+                        </core_rt:if>
+                        <core_rt:if test="${empty otherKnownHash.filename}">
+                        "fileName": "<sw360:out value="${otherKnownHash.hashType}"/>: <sw360:out value="${otherKnownHash.hash}"/>",
+                        </core_rt:if>
+                        "size": "n/a",
+                        "type": "<sw360:DisplayEnumShort value="${otherKnownHash.attachmentType}"/>",
+                        "uploadedTeam": "n/a",
+                        "uploadedBy": "n/a",
+                        "checkedTeam": "n/a",
+                        "checkedBy": "n/a",
+                        "usage": {},
+                        "actions": "",
+                        "sha1": "<sw360:out value="${otherKnownHash.hashType}"/>: <sw360:out value="${otherKnownHash.hash}"/>",
+                        "uploadedOn": "",
+                        "uploadedComment": "",
+                        "checkedOn": "",
+                        "checkedComment": "",
+                        "checkStatus": "n/a"
                     });
                 </core_rt:forEach>
 
@@ -149,12 +174,14 @@
                             "createdCell": function (td, cellData, rowData, row, col) {
                                 $(td).on('click', 'a', function() {
                                     var dialogContent = '';
-                                    dialogContent += rowData.usage.links.join(", ");
-                                    if (rowData.usage.restrictedCount > 0){
-                                        if (rowData.usage.links.length > 0) {
-                                            dialogContent += ", and ";
+                                    if (rowData.usages !== null && rowData.usages !== {}) {
+                                        dialogContent += rowData.usage.links.join(", ");
+                                        if (rowData.usage.restrictedCount > 0){
+                                            if (rowData.usage.links.length > 0) {
+                                                dialogContent += ", and ";
+                                            }
+                                            dialogContent += rowData.usage.restrictedCount + " restricted project(s)";
                                         }
-                                        dialogContent += rowData.usage.restrictedCount + " restricted project(s)";
                                     }
                                     dialog.info(
                                         'Projects using this attachment',
@@ -207,7 +234,7 @@
                 function renderAttachmentUsages(data, type, row, meta) {
                     if (type === 'display') {
                         var usagesHtml = '';
-                        if (data.links.length === 0 && data.restrictedCount === 0) {
+                        if (data === null || data === {} || data.links == null || data.links.length === 0 && data.restrictedCount === 0) {
                             usagesHtml += 'n/a';
                         } else {
                             usagesHtml += '<a href="javascript:;" title="visible / restricted">' + data.links.length + ' / ' + data.restrictedCount + '</a>';

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/attachmentsDetail.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/attachmentsDetail.jsp
@@ -30,7 +30,7 @@
 
 <core_rt:if test="${empty attributeNotFoundException}">
 
-    <core_rt:if test="${empty attachments}">
+    <core_rt:if test="${empty attachments && empty otherKnownHashes}">
         <div class="alert alert-info" role="alert">
             No attachments yet.
         </div>
@@ -42,7 +42,7 @@
         </script>
     </core_rt:if>
 
-    <core_rt:if test="${not empty attachments}">
+    <core_rt:if test="${not (empty attachments && empty otherKnownHashes)}">
         <table id="attachmentsDetail" class="table table-bordered" title="Attachment Information">
             <colgroup>
                 <col />  <!-- set by class -->

--- a/libraries/lib-datahandler/src/main/thrift/attachments.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/attachments.thrift
@@ -81,6 +81,15 @@ struct AttachmentContent {
     22: optional string partsCount,
 }
 
+struct KnownHash {
+    3: required string hash,
+    4: required string hashType = "sha1",
+    5: optional string filename,
+
+    10: optional AttachmentType attachmentType
+    11: optional string remoteUrl,
+}
+
 /**
  * Describe the usage of an attachment. Each usage results in one usage object.
  * The usage can store additional data for more information about the specific usage.

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -26,6 +26,8 @@ typedef sw360.ReleaseRelationship ReleaseRelationship
 typedef sw360.MainlineState MainlineState
 typedef sw360.ProjectReleaseRelationship ProjectReleaseRelationship
 typedef attachments.Attachment Attachment
+typedef attachments.KnownHash KnownHash
+typedef attachments.AttachmentType AttachmentType
 typedef attachments.FilledAttachment FilledAttachment
 typedef users.User User
 typedef users.RequestedAction RequestedAction
@@ -230,6 +232,7 @@ struct Release {
     12: optional Repository repository, // Repository where the release is maintained
     16: optional MainlineState mainlineState, // enum: specific, open, mainline, phaseout
     17: optional ClearingState clearingState, // TODO we probably need to map by clearing team?
+    18: optional set<KnownHash> otherKnownHashes,
 
     // FOSSology Information
     // 20: optional string fossologyId,
@@ -704,4 +707,9 @@ service ComponentService {
      * Gets releases referencing the given release id
      */ 
     list<Release> getReferencingReleases(1: string releaseId);
+
+   /**
+     * get a set of releases based on the external id external ids can have multiple values to one key
+     */
+    list<Release> searchReleasesByFileHashes(1: set<string> hashes);
 }

--- a/rest/resource-server/src/docs/asciidoc/attachments.adoc
+++ b/rest/resource-server/src/docs/asciidoc/attachments.adoc
@@ -29,3 +29,8 @@ include::{snippets}/should_document_get_attachment/http-response.adoc[]
 
 ===== Links
 include::{snippets}/should_document_get_attachment/links.adoc[]
+
+[[resources-hashes]]
+=== KnownHashes
+
+The KnownHashes or Hashes resource is used to list hashes from attachments and also other known hashes.

--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -127,6 +127,21 @@ include::{snippets}/should_document_get_release_attachment/curl-request.adoc[]
 include::{snippets}/should_document_get_release_attachment/http-response.adoc[]
 
 
+[[resources-releases-get-hashes-info]]
+==== Listing all known hashes
+
+A `GET` request will get all known hashes, including the one implied from attachments, and also the other known hashes, of a release
+
+==== Response structure
+include::{snippets}/should_document_get_release_hashes_info/response-fields.adoc[]
+
+==== Example request
+include::{snippets}/should_document_get_release_hashes_info/curl-request.adoc[]
+
+==== Example response
+include::{snippets}/should_document_get_release_hashes_info/http-response.adoc[]
+
+
 [[resources-release-get]]
 ==== Get a single release
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.Visibility;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.KnownHash;
 import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
@@ -57,6 +58,7 @@ class JacksonCustomizations {
             setMixInAnnotation(Component.class, Sw360Module.ComponentMixin.class);
             setMixInAnnotation(Release.class, Sw360Module.ReleaseMixin.class);
             setMixInAnnotation(Attachment.class, Sw360Module.AttachmentMixin.class);
+            setMixInAnnotation(KnownHash.class, Sw360Module.KnownHashMixin.class);
             setMixInAnnotation(Vendor.class, Sw360Module.VendorMixin.class);
             setMixInAnnotation(License.class, Sw360Module.LicenseMixin.class);
             setMixInAnnotation(Vulnerability.class, Sw360Module.VulnerabilityMixin.class);
@@ -375,6 +377,9 @@ class JacksonCustomizations {
                 "setReleaseIdToRelationship",
                 "setDocumentState",
                 "permissionsSize",
+                "setOtherKnownHashes",
+                "otherKnownHashesIterator",
+                "otherKnownHashesSize",
                 "setId",
                 "setRevision",
                 "setType",
@@ -434,6 +439,17 @@ class JacksonCustomizations {
                 "setCheckStatus"
         })
         static abstract class AttachmentMixin {
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JsonIgnoreProperties({
+                "setFilename",
+                "setHash",
+                "setHashType",
+                "setAttachmentType",
+                "setRemoteUrl"
+        })
+        static abstract class KnownHashMixin {
         }
 
         @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -292,9 +292,9 @@ public class ReleaseController implements ResourceProcessor<RepositoryLinksResou
         return new ResponseEntity<>(resources, HttpStatus.OK);
     }
 
-    @RequestMapping(value = RELEASES_URL + "/{releaseId}/hashes", method = RequestMethod.POST, consumes = {"multipart/mixed", "multipart/form-data"})
+    @RequestMapping(value = RELEASES_URL + "/{releaseId}/hashes", method = RequestMethod.POST)
     public ResponseEntity<HalResource> addKnownHashToRelease(@PathVariable("releaseId") String releaseId,
-                                                             @RequestPart("knownHash") KnownHash knownHash) throws TException {
+                                                             @RequestBody KnownHash knownHash) throws TException {
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
 
         final Release release = releaseService.getReleaseForUserById(releaseId, sw360User);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -90,10 +90,17 @@ public class ReleaseController implements ResourceProcessor<RepositoryLinksResou
         }
 
         List<Resource> releaseResources = new ArrayList<>();
-        for (Release sw360Release : sw360Releases) {
-            Release embeddedRelease = restControllerHelper.convertToEmbeddedRelease(sw360Release, fields);
-            Resource<Release> releaseResource = new Resource<>(embeddedRelease);
-            releaseResources.add(releaseResource);
+        if (fields.contains("all")) {
+            for (Release sw360Release : sw360Releases) {
+                Resource<Release> releaseResource = new Resource<>(sw360Release);
+                releaseResources.add(releaseResource);
+            }
+        } else {
+            for (Release sw360Release : sw360Releases) {
+                Release embeddedRelease = restControllerHelper.convertToEmbeddedRelease(sw360Release, fields);
+                Resource<Release> releaseResource = new Resource<>(embeddedRelease);
+                releaseResources.add(releaseResource);
+            }
         }
         Resources<Resource> resources = new Resources<>(releaseResources);
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -72,6 +72,11 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         return sw360ComponentClient.searchReleasesByExternalIds(externalIds);
     }
 
+    public List<Release> searchByFileHashes(Set<String> hashes) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        return sw360ComponentClient.searchReleasesByFileHashes(hashes);
+    }
+
     @Override
     public Release convertToEmbeddedWithExternalIds(Release sw360Object) {
         return rch.convertToEmbeddedRelease(sw360Object).setExternalIds(sw360Object.getExternalIds());


### PR DESCRIPTION
This PR adds `otherKnownHashes` to releases. The goal is to be able to save known hashes to a release, without having to upload the corresponding attachment (maybe one even does not have the corresponding attachment at hand).

Also the rest search by `sha1` is extended to search for `knownHashes`.

Rest is further extended by the new endpoint `.../releases/{id}/hashes` which allows to get all hashes (hashes from attachments and from otherHashes) and to add knownHashes to the database.