### PR TITLE
feat(Rest): New end points for project/component/release usage summary

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/components.adoc
+++ b/rest/resource-server/src/docs/asciidoc/components.adoc
@@ -227,3 +227,17 @@ include::{snippets}/should_document_delete_components/curl-request.adoc[]
 
 ===== Example response
 include::{snippets}/should_document_delete_components/http-response.adoc[]
+
+[[resources-component-usedby-list]]
+==== Resources using the component
+
+A `GET` request will display all the resources where the component is used.
+
+===== Response structure
+include::{snippets}/should_document_get_usedbyresource_for_components/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_usedbyresource_for_components/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_usedbyresource_for_components/http-response.adoc[]

--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -278,3 +278,17 @@ include::{snippets}/should_document_get_download_license_info/curl-request.adoc[
 
 ===== Example response
 include::{snippets}/should_document_get_download_license_info/http-response.adoc[]
+
+[[resources-project-usedby-list]]
+==== Resources using the project
+
+A `GET` request will display all the projects where the project is used.
+
+===== Response structure
+include::{snippets}/should_document_get_usedbyresource_for_project/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_usedbyresource_for_project/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_usedbyresource_for_project/http-response.adoc[]

--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -191,3 +191,17 @@ include::{snippets}/should_document_delete_releases/curl-request.adoc[]
 
 ===== Example response
 include::{snippets}/should_document_delete_releases/http-response.adoc[]
+
+[[resources-release-usedby-list]]
+==== Resources using the release
+
+A `GET` request will display all the resources where the release is used.
+
+===== Response structure
+include::{snippets}/should_document_get_usedbyresource_for_release/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_usedbyresource_for_release/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_usedbyresource_for_release/http-response.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -392,6 +392,23 @@ public class ProjectController implements ResourceProcessor<RepositoryLinksResou
         return restControllerHelper.searchByExternalIds(externalIdsMultiMap, projectService, sw360User);
     }
 
+    @RequestMapping(value = PROJECTS_URL + "/usedBy" + "/{id}", method = RequestMethod.GET)
+    public ResponseEntity<Resources<Resource<Project>>> getUsedByProjectDetails(@PathVariable("id") String id) throws TException{
+        User user = restControllerHelper.getSw360UserFromAuthentication();
+        //Project sw360Project = projectService.getProjectForUserById(id, user);
+        Set<Project> sw360Projects = projectService.searchLinkingProjects(id, user);
+
+        List<Resource<Project>> projectResources = new ArrayList<>();
+        sw360Projects.stream()
+                .forEach(p -> {
+                    Project embeddedProject = restControllerHelper.convertToEmbeddedProject(p);
+                    projectResources.add(new Resource<>(embeddedProject));
+                });
+
+        Resources<Resource<Project>> resources = new Resources<>(projectResources);
+        return new ResponseEntity<>(resources, HttpStatus.OK);
+    }
+
     @Override
     public RepositoryLinksResource process(RepositoryLinksResource resource) {
         resource.add(linkTo(ProjectController.class).slash("api" + PROJECTS_URL).withRel("projects"));

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -60,6 +60,23 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         return sw360ProjectClient.getProjectById(projectId, sw360User);
     }
 
+    public Set<Project> searchLinkingProjects(String projectId, User sw360User) throws TException {
+        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        return sw360ProjectClient.searchLinkingProjects(projectId, sw360User);
+    }
+
+    public Set<Project> getProjectsByReleaseIds(Set<String> releaseids, User sw360User)
+            throws TException {
+        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        return sw360ProjectClient.searchByReleaseIds(releaseids, sw360User);
+    }
+
+    public Set<Project> getProjectsByRelease(String releaseid, User sw360User)
+            throws TException {
+        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        return sw360ProjectClient.searchByReleaseId(releaseid, sw360User);
+    }
+
     public Project createProject(Project project, User sw360User) throws TException {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
         AddDocumentRequestSummary documentRequestSummary = sw360ProjectClient.addProject(project, sw360User);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -21,14 +21,18 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.THttpClient;
 import org.apache.thrift.transport.TTransportException;
+import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.AwareOfRestServices;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
+import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -48,6 +52,9 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
 
     @NonNull
     private RestControllerHelper rch;
+
+    @NonNull
+    private final Sw360ProjectService projectService;
 
     public List<Release> getReleasesForUser(User sw360User) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
@@ -94,6 +101,17 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
     public RequestStatus deleteRelease(String releaseId, User sw360User) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
         return sw360ComponentClient.deleteRelease(releaseId, sw360User);
+    }
+
+    public Set<Project> getProjectsByRelease(String releaseId, User sw360User) throws TException {
+        Set<Project> usedByProjects = projectService.getProjectsByRelease(releaseId, sw360User);
+        return usedByProjects;
+    }
+
+    public Set<Component> getUsingComponentsForRelease(String releaseId, User sw360User) throws TException {
+        ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
+        Set<Component> usingComponentsForComponent = sw360ComponentClient.getUsingComponentsForRelease(releaseId);
+        return usingComponentsForComponent;
     }
 
     private ComponentService.Iface getThriftComponentClient() throws TTransportException {


### PR DESCRIPTION
Created three rest end points like

* http://sw360.com/resource/api/projects/usedBy/b7b07cadabb084a68c746b0c0705581d
* http://sw360.com/resource/api/components/usedBy/b7b07cadabb084a68c746b0c07007b99
* http://sw360.com/resource/api/releases/usedBy/ac8a53df29af6391bd76f61aea001336

which will display a short detail of the project/component/release usage summary along with the hyperlink to navigate to the resource . 

![image](https://user-images.githubusercontent.com/46559892/66989311-c2526b80-f0e1-11e9-801a-a09279286c4c.png)

closes : #704 


