### PR TITLE
feat(REST): linked release hierarchy is included in the response

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -205,11 +205,15 @@ public class ProjectController implements ResourceProcessor<RepositoryLinksResou
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
         final Set<String> releaseIds = projectService.getReleaseIds(id, sw360User, transitive);
 
+        boolean isTransitive = Boolean.parseBoolean(transitive);
         final List<Resource<Release>> releaseResources = new ArrayList<>();
         for (final String releaseId : releaseIds) {
             final Release sw360Release = releaseService.getReleaseForUserById(releaseId, sw360User);
             final Release embeddedRelease = restControllerHelper.convertToEmbeddedRelease(sw360Release);
-            final Resource<Release> releaseResource = new Resource<>(embeddedRelease);
+            final HalResource<Release> releaseResource = new HalResource<>(embeddedRelease);
+            if (isTransitive) {
+                projectService.addEmbeddedlinkedRelease(sw360Release, sw360User, releaseResource, releaseService);
+            }
             releaseResources.add(releaseResource);
         }
 


### PR DESCRIPTION
When requesting a single release, immediate child releases are embedded
When requesting all releases (transitive) for a project, entire release hierarchy is included

closes: #515 

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>