### PR TITLE
fix(LicenseInfo): NPE in ProjectPortlet.prepareLicenseInfo and downloadLicenseInfo

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -283,7 +283,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
         String outputGenerator = request.getParameter(PortalConstants.LICENSE_INFO_SELECTED_OUTPUT_FORMAT);
         String extIdsFromRequest = request.getParameter(PortalConstants.EXTERNAL_ID_SELECTED_KEYS);
 
-        String externalIds = Optional.of(extIdsFromRequest).orElse(StringUtils.EMPTY);
+        String externalIds = Optional.ofNullable(extIdsFromRequest).orElse(StringUtils.EMPTY);
 
         Set<String> selectedAttachmentIdsWithPath = Sets
                 .newHashSet(request.getParameterValues(PortalConstants.LICENSE_INFO_RELEASE_TO_ATTACHMENT));
@@ -942,7 +942,9 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 request.setAttribute(DOCUMENT_ID, id);
 
                 Map<String,String> extIdMap = project.getExternalIds();
-                request.setAttribute("externalIds", extIdMap.keySet());
+                if (extIdMap != null) {
+                    request.setAttribute("externalIds", extIdMap.keySet());
+                }
 
                 LicenseInfoService.Iface licenseInfoClient = thriftClients.makeLicenseInfoClient();
                 List<OutputFormatInfo> outputFormats = licenseInfoClient.getPossibleOutputFormats();


### PR DESCRIPTION
Check that `extIdMap` is not null, before accessing it.

closes #715

Signed-off-by: Kalle Soranko <ksoranko@verifa.io>