### PR TITLE
feat(rest): get attachmentUsages for a project

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -292,3 +292,17 @@ include::{snippets}/should_document_get_usedbyresource_for_project/curl-request.
 
 ===== Example response
 include::{snippets}/should_document_get_usedbyresource_for_project/http-response.adoc[]
+
+[[resources-project-get-attachmentusage]]
+==== AttachmentUsages of the project
+
+A `GET` request will display all attachmentUsages of the projects.
+
+===== Response structure
+include::{snippets}/should_document_get_attachment_usage_for_project/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_attachment_usage_for_project/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_attachment_usage_for_project/http-response.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
@@ -200,4 +200,9 @@ public class Sw360AttachmentService {
         }
         return new Resources<>(attachmentResources);
     }
+
+    public List<AttachmentUsage> getAllAttachmentUsage(String projectId) throws TException {
+        AttachmentService.Iface attachmentClient = getThriftAttachmentClient();
+        return attachmentClient.getUsedAttachments(Source.projectId(projectId), null);
+    }
 }


### PR DESCRIPTION
Added Rest API to get attachmentUsages of a Project.

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>