### PR TITLE
fix(projectUI): NPE in SW360Utils.getApprovedClxAttachmentForRelease

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -326,6 +326,12 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
                 .collect(Collectors.toList()).stream()
                 .collect(Collectors.toMap(ObligationParsingResult::getAttachmentContentId, Function.identity()));
 
+        Set<Release> releases = releaseToSelectedAttachmentIds.keySet().stream().filter(rel -> rel.getAttachmentsSize() > 0).collect(Collectors.toSet());
+        if (releases.isEmpty()) {
+            return null;
+        }
+        releaseToSelectedAttachmentIds.keySet().retainAll(releases);
+
         List<LicenseInfoParsingResult> licenseParsingResults = new ArrayList<LicenseInfoParsingResult>();
         for (Entry<Release, Set<String>> entry : releaseToSelectedAttachmentIds.entrySet()) {
             Attachment attachment = SW360Utils.getApprovedClxAttachmentForRelease(entry.getKey());

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -1486,10 +1486,15 @@ public class ProjectPortlet extends FossologyAwarePortlet {
         List<Release> releases;
         try {
             final ComponentService.Iface componentClient = thriftClients.makeComponentClient();
-            releases = componentClient.getFullReleasesById(project.getReleaseIdToUsage().keySet(), user);
-            final List<LicenseInfoParsingResult> licenseInfos = addLicenseInfos(request, project, releases);
-            sortLicenseInfo(licenseInfos);
-            request.setAttribute(PROJECT_RELEASE_LICENSE_INFO, licenseInfos);
+            releases = componentClient.getFullReleasesById(project.getReleaseIdToUsage().keySet(), user)
+                    .stream().filter(rel -> rel.getAttachmentsSize() > 0).collect(Collectors.toList());
+            if (CommonUtils.isNotEmpty(releases)) {
+                final List<LicenseInfoParsingResult> licenseInfos = addLicenseInfos(request, project, releases);
+                sortLicenseInfo(licenseInfos);
+                request.setAttribute(PROJECT_RELEASE_LICENSE_INFO, licenseInfos);
+            } else {
+                project.unsetLinkedObligations();
+            }
         } catch (TException exception) {
             log.error("Could not fetch Release Information: ", exception);
         }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/detail.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/detail.jsp
@@ -36,7 +36,7 @@
 
 <core_rt:if test="${empty attributeNotFoundException}">
     <core_rt:set var="inProjectDetailsContext" value="true" scope="request"/>
-    <core_rt:set var="isObligationPresent"  value="${not empty project.linkedObligations and project.linkedObligations.size() > 0}" />
+    <core_rt:set var="isObligationPresent"  value="${not empty project.linkedObligations}" />
     <core_rt:if test="${isObligationPresent}">
         <jsp:useBean id="projectReleaseLicenseInfo" type="java.util.List<org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult>" scope="request" />
         <jsp:useBean id="approvedObligationsCount" type="java.lang.Integer" scope="request"/>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/edit.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/edit.jsp
@@ -71,7 +71,7 @@
 
 <core_rt:set var="isObligationEnabled"  value="${hasWritePermissions and isUserAtLeastClearingAdmin}" />
 <core_rt:if test="${isObligationEnabled}">
-    <core_rt:set var="isObligationPresent"  value="${not empty project.linkedObligations and project.linkedObligations.size() > 0}" />
+    <core_rt:set var="isObligationPresent"  value="${not empty project.linkedObligations}" />
     <core_rt:if test="${isObligationPresent}">
         <jsp:useBean id="projectReleaseLicenseInfo" type="java.util.List<org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult>" scope="request" />
     <jsp:useBean id="approvedObligationsCount" type="java.lang.Integer" scope="request"/>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/linkedObligations.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/linkedObligations.jspf
@@ -23,9 +23,17 @@
 
 <core_rt:if test="${not isObligationPresent}">
     <div class="alert alert-info" role="alert">
-        No Linked Obligations.
-        <br>
-        Only <b>Approved</b> CLI files Obligations will be shown here.
+    <core_rt:choose>
+        <core_rt:when test="${empty project.releaseIdToUsage}">
+            No linked obligations.
+        </core_rt:when>
+        <core_rt:otherwise>
+            The possible reasons for not loading linked obligations:
+            <li>No <b>Accepted</b> CLI file in linked release. (Obligations from accepted CLI file will be loaded here)</li>
+            <li>More than <b>ONE</b> Accepted CLI file in linked release. (Each release should have only one accepted CLI file)</li>
+            <li>No obligations are present in CLI file.</li>
+        </core_rt:otherwise>
+    </core_rt:choose>
     </div>
 </core_rt:if>
 

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligationsByReleases.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligationsByReleases.jspf
@@ -114,13 +114,7 @@
 <script>
     require(['jquery', 'modules/ajax-treetable'], function($, ajaxTreeTable) {
         Liferay.on("allPortletsReady", function () {
-            var config = $("#poInfoTableByRelease").data();
-            ajaxTreeTable.setup("poInfoTableByRelease", config.loadNodeUrl,
-                function (node) {
-                var data = {};
-                data[config.portletNamespace + config.parentBranchKey] = node.id;
-                return data;
-	        });
+            $("#poInfoTableByRelease").treetable({ expandable: true });
         });
     });
 </script>

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
@@ -208,6 +208,14 @@ public class CommonUtils {
         return false;
     }
 
+    public static boolean isNullOrEmptyCollection(Collection collection) {
+        return collection == null || collection.isEmpty();
+    }
+
+    public static boolean isNotEmpty(Collection collection) {
+        return !isNullOrEmptyCollection(collection);
+    }
+
     public static boolean allAreEmptyOrNull(Collection... collections) {
         return !atLeastOneIsNotEmpty(collections);
     }

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -233,19 +233,19 @@ public class SW360Utils {
     }
 
     public static Attachment getApprovedClxAttachmentForRelease(Release release) {
-        // retaining attachments only with type as CLX and status as Accepted.
         Predicate<Attachment> isApprovedCLI = attachment -> attachment.getCheckStatus().equals(CheckStatus.ACCEPTED)
                 && AttachmentType.COMPONENT_LICENSE_INFO_XML.equals(attachment.getAttachmentType());
 
-        // Ideally there should be only one Accepted CLI attachment in each release.
-        // But, there are releases with multiple Accepted CLI files,
-        // that's why sorting the attachments by createdOn and file Name,
-        // and returning the first attachment.
-        // in order to avoid returning inconsistent attachment for different request.
-        return release
-                .getAttachments().stream().filter(isApprovedCLI).sorted(Comparator.comparing(Attachment::getCreatedOn)
-                        .thenComparing(Attachment::getFilename, String.CASE_INSENSITIVE_ORDER))
-                .findFirst().orElse(new Attachment());
+        List<Attachment> attachmentList = release.getAttachments().stream().filter(isApprovedCLI).collect(Collectors.toList());
+
+        if (CommonUtils.isNotEmpty(attachmentList)) {
+            if (attachmentList.size() == 1) {
+                return attachmentList.get(0);
+            } else {
+                log.warn("More then 1 Accepted CLI file for Release: " + release.getId() + " - " + printName(release));
+            }
+        }
+        return new Attachment();
     }
 
     public static String printFullname(Release release) {


### PR DESCRIPTION
fixed NPE in  SW360Utils.getApprovedClxAttachmentForRelease.
The issue was caused due to absence of `createdOn` field for old attachments.

closes #719 