### PR TITLE
feat(licenseinfo): Added filter to exclude releases based on selected relationship

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRelationsUsageRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ReleaseRelationsUsageRepository.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import java.util.List;
+
+import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
+import org.eclipse.sw360.datahandler.couchdb.DatabaseRepository;
+import org.eclipse.sw360.datahandler.thrift.projects.UsedReleaseRelations;
+import org.ektorp.ViewQuery;
+import org.ektorp.support.View;
+
+/**
+ * CRUD access for the ReleaseRelationsUsageRepository class
+ *
+ * @author smruti.sahoo@siemens.com
+ *
+ */
+
+@View(name = "all", map = "function(doc) { if (doc.type == 'usedReleaseRelation') emit(null, doc._id); }")
+public class ReleaseRelationsUsageRepository extends DatabaseRepository<UsedReleaseRelations> {
+
+    public ReleaseRelationsUsageRepository(DatabaseConnector db) {
+        super(UsedReleaseRelations.class, db);
+        initStandardDesignDocument();
+    }
+
+    private static final String BY_PROJECT_ID =
+            "function(doc) {" +
+                    "  if (doc.type == 'usedReleaseRelation') {" +
+                    "    emit(doc.projectId, doc);" +
+                    "  }" +
+                    "}";
+
+    @View(name = "byProjectId", map = BY_PROJECT_ID)
+    public List<UsedReleaseRelations> getUsedRelationsByProjectId(String projectId) {
+        ViewQuery viewQuery = createQuery("byProjectId").includeDocs(true).reduce(false).key(projectId);
+        return queryView(viewQuery);
+    }
+}

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
@@ -152,10 +152,20 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
             replaceText(document, "$project-name", projectName);
             replaceText(document, "$project-version", projectVersion);
 
+            printErrorForNoRelease(document, projectLicenseInfoResults);
             fillExternalIds(document, externalIds);
             fillReleaseBulletList(document, projectLicenseInfoResults);
             fillReleaseDetailList(document, projectLicenseInfoResults, includeObligations, licenseToReferenceId);
             fillLicenseList(document, projectLicenseInfoResults, licenseToReferenceId);
+    }
+
+    private void printErrorForNoRelease(XWPFDocument document,
+            Collection<LicenseInfoParsingResult> projectLicenseInfoResults) {
+        if(!CommonUtils.isNotEmpty(projectLicenseInfoResults)) {
+            XWPFRun errorRun = document.createParagraph().createRun();
+            String errorText = "Either there is no releases based on your selection or the selected project does not contain any release";
+            addFormattedText(errorRun, errorText, FONT_SIZE, false, ALERT_COLOR);
+        }
     }
 
     private Map<LicenseNameWithText, Integer> populatelicenseToReferenceId(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, Map<LicenseNameWithText, Integer> licenseToReferenceId) {

--- a/backend/src/src-licenseinfo/src/main/resources/textLicenseInfoFile.vm
+++ b/backend/src/src-licenseinfo/src/main/resources/textLicenseInfoFile.vm
@@ -28,6 +28,10 @@ Open Source Software Contained in this Product/Device:
 
 #end
 
+#if($licenseInfoResults.keySet().size() == 0)
+Either there is no releases based on your selection or the selected project does not contain any release
+#end
+
 
 #if($licenseInfoResults.keySet().size() > 0)
 Details

--- a/backend/src/src-licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
+++ b/backend/src/src-licenseinfo/src/main/resources/xhtmlLicenseInfoFile.vm
@@ -103,6 +103,10 @@
 
     <h2 id="releaseHeader">Releases</h2>
 
+    #if($licenseInfoResults.keySet().size() == 0)
+        <div class="inset error">Either there is no releases based on your selection or the selected project does not contain any release</div>
+    #end
+
     #if($licenseInfoResults.keySet().size() > 0)
         <ul id="releaseOverview">
             #foreach($releaseName in $licenseInfoResults.keySet())

--- a/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -25,6 +25,9 @@ import org.eclipse.sw360.datahandler.thrift.projects.ProjectLink;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectObligation;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
+import org.eclipse.sw360.datahandler.thrift.projects.UsedReleaseRelations;
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 
 import java.io.IOException;
@@ -307,5 +310,29 @@ public class ProjectHandler implements ProjectService.Iface {
         assertId(obligation.getProjectId());
         assertUser(user);
         return handler.updateLinkedObligations(obligation, user);
+    }
+
+    public void deleteReleaseRelationsUsage(UsedReleaseRelations usedReleaseRelations) throws TException {
+        assertNotNull(usedReleaseRelations);
+        handler.deleteReleaseRelationsUsage(usedReleaseRelations);
+    }
+
+    @Override
+    public void addReleaseRelationsUsage(UsedReleaseRelations usedReleaseRelations) throws TException {
+        assertNotNull(usedReleaseRelations);
+        handler.addReleaseRelationsUsage(usedReleaseRelations);
+
+    }
+
+    @Override
+    public void updateReleaseRelationsUsage(UsedReleaseRelations usedReleaseRelations) throws TException {
+        assertNotNull(usedReleaseRelations);
+        handler.updateReleaseRelationsUsage(usedReleaseRelations);
+    }
+
+    @Override
+    public List<UsedReleaseRelations> getUsedReleaseRelationsByProjectId(String projectId) throws TException {
+        assertNotNull(projectId);
+        return handler.getUsedReleaseRelationsByProjectId(projectId);
     }
 }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -225,7 +225,10 @@ public class PortalConstants {
     public static final String LINKED_OBLIGATIONS = "linkedObligations";
     public static final String APPROVED_OBLIGATIONS_COUNT = "approvedObligationsCount";
     public static final String EXCLUDED_RELEASES = "excludedReleases";
-
+    public static final String RELATIONSHIPS = "relations";
+    public static final String PROJECT_RELEASE_TO_RELATION = "projectReleaseToRelation";
+    public static final String PROJECT_USED_RELEASE_RELATIONS = "usedProjectReleaseRelations";
+    public static final String SELECTED_PROJECT_RELEASE_RELATIONS = "selectedProjectReleaseRelations";
 
     public static final String FOSSOLOGY_PORTLET_NAME = PORTLET_NAME_PREFIX + "fossology";
     public static final String USER_LIST = "userList";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -310,18 +310,26 @@ public class ProjectPortlet extends FossologyAwarePortlet {
         final String projectId = request.getParameter(PROJECT_ID);
         String outputGenerator = request.getParameter(PortalConstants.LICENSE_INFO_SELECTED_OUTPUT_FORMAT);
         String extIdsFromRequest = request.getParameter(PortalConstants.EXTERNAL_ID_SELECTED_KEYS);
+        List<String> selectedReleaseRelationships =  getSelectedReleaseRationships(request);
+        final Set<ReleaseRelationship> listOfSelectedRelationships = selectedReleaseRelationships.stream()
+                .map(rel -> ThriftEnumUtils.stringToEnum(rel, ReleaseRelationship.class)).filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        final Set<String> listOfSelectedRelationshipsInString = listOfSelectedRelationships.stream().map(ReleaseRelationship::name)
+                .collect(Collectors.toSet());
 
         String externalIds = Optional.ofNullable(extIdsFromRequest).orElse(StringUtils.EMPTY);
 
         Set<String> selectedAttachmentIdsWithPath = Sets
                 .newHashSet(request.getParameterValues(PortalConstants.LICENSE_INFO_RELEASE_TO_ATTACHMENT));
+        Set<String> filteredSelectedAttachmentIdsWithPath = filterSelectedAttachmentIdsWithPath(selectedAttachmentIdsWithPath, listOfSelectedRelationshipsInString);
         final Map<String, Set<LicenseNameWithText>> excludedLicensesPerAttachmentIdWithPath = ProjectPortletUtils
-                .getExcludedLicensesPerAttachmentIdFromRequest(selectedAttachmentIdsWithPath, request);
+                .getExcludedLicensesPerAttachmentIdFromRequest(filteredSelectedAttachmentIdsWithPath, request);
 
         final Map<String, Set<String>> releaseIdsToSelectedAttachmentIds = new HashMap<>();
-        selectedAttachmentIdsWithPath.stream().forEach(selectedAttachmentIdWithPath -> {
+        filteredSelectedAttachmentIdsWithPath.stream().forEach(selectedAttachmentIdWithPath -> {
             String[] pathParts = selectedAttachmentIdWithPath.split(":");
-            String releaseId = pathParts[pathParts.length - 2];
+            String releaseId = pathParts[pathParts.length - 3];
             String attachmentId = pathParts[pathParts.length - 1];
             if (releaseIdsToSelectedAttachmentIds.containsKey(releaseId)) {
                 // since we have a set as value, we can just add without getting duplicates
@@ -352,13 +360,54 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             Project project = thriftClients.makeProjectClient().getProjectById(projectId, user);
             LicenseInfoFile licenseInfoFile = licenseInfoClient.getLicenseInfoFile(project, user, outputGenerator,
                     releaseIdsToSelectedAttachmentIds, excludedLicensesPerAttachmentId, externalIds);
-            saveLicenseInfoAttachmentUsages(project, user, selectedAttachmentIdsWithPath,
+            saveLicenseInfoAttachmentUsages(project, user, filteredSelectedAttachmentIdsWithPath,
                     excludedLicensesPerAttachmentIdWithPath);
+            saveSelectedReleaseRelations(projectId, listOfSelectedRelationships);
             sendLicenseInfoResponse(request, response, project, licenseInfoFile);
         } catch (TException e) {
             log.error("Error getting LicenseInfo file for project with id " + projectId + " and generator " + outputGenerator, e);
             response.setProperty(ResourceResponse.HTTP_STATUS_CODE, Integer.toString(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
         }
+    }
+
+    private void saveSelectedReleaseRelations(String projectId, Set<ReleaseRelationship> listOfSelectedRelationships) {
+        UsedReleaseRelations usedReleaseRelation = new UsedReleaseRelations();
+        try {
+            ProjectService.Iface client = thriftClients.makeProjectClient();
+            List<UsedReleaseRelations> usedReleaseRelations = nullToEmptyList(
+                    client.getUsedReleaseRelationsByProjectId(projectId));
+            if (CommonUtils.isNotEmpty(usedReleaseRelations)) {
+                usedReleaseRelation = usedReleaseRelations.get(0)
+                        .setUsedReleaseRelations(listOfSelectedRelationships);
+                client.updateReleaseRelationsUsage(usedReleaseRelation);
+            } else {
+                usedReleaseRelation.setProjectId(projectId);
+                usedReleaseRelation.setUsedReleaseRelations(listOfSelectedRelationships);
+                client.addReleaseRelationsUsage(usedReleaseRelation);
+            }
+        } catch (TException exception) {
+            log.error("Error saving selected release relations", exception);
+        }
+    }
+
+    private Set<String> filterSelectedAttachmentIdsWithPath(Set<String> selectedAttachmentIdsWithPath,
+            Set<String> listOfSelectedRelationships) {
+        return selectedAttachmentIdsWithPath.stream().filter(selectedAttachmentIdWithPath -> {
+            String pathParts[] = selectedAttachmentIdWithPath.split(":");
+            String relation = pathParts[pathParts.length - 2];
+            return listOfSelectedRelationships.contains(relation);
+        }).collect(Collectors.toSet());
+    }
+
+    private List<String> getSelectedReleaseRationships(ResourceRequest request) {
+        List<String> selectedReleaseRelationships = Lists.newArrayList();
+        String relationshipsToBeIncluded = request.getParameter(PortalConstants.SELECTED_PROJECT_RELEASE_RELATIONS);
+
+        if (!CommonUtils.isNullEmptyOrWhitespace(relationshipsToBeIncluded)) {
+            selectedReleaseRelationships = Arrays.asList(relationshipsToBeIncluded.split(","));
+        }
+
+        return selectedReleaseRelationships;
     }
 
     private void sendLicenseInfoResponse(ResourceRequest request, ResourceResponse response, Project project, LicenseInfoFile licenseInfoFile) throws IOException {
@@ -388,8 +437,8 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                         .collect(Collectors.toSet());
                 LicenseInfoUsage licenseInfoUsage = new LicenseInfoUsage(licenseIds);
                 // until second last occurence of ":" (strip releaseId and attachmentId)
-                String projectPath = attachmentContentId.substring(0,
-                        attachmentContentId.lastIndexOf(":", attachmentContentId.lastIndexOf(":") - 1));
+                String splittedAttachmentContentId[] = attachmentContentId.split(":");
+                String projectPath = String.join(":", Arrays.copyOf(splittedAttachmentContentId, splittedAttachmentContentId.length-3));
                 licenseInfoUsage.setProjectPath(projectPath);
                 return UsageData.licenseInfo(licenseInfoUsage);
             };
@@ -992,6 +1041,9 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 }
 
                 request.setAttribute(PROJECT_LIST, mappedProjectLinks);
+                request.setAttribute(PortalConstants.RELATIONSHIPS, fetchReleaseRelationships(mappedProjectLinks));
+                request.setAttribute(PortalConstants.PROJECT_RELEASE_TO_RELATION, fetchProjectReleaseToRelation(mappedProjectLinks));
+                request.setAttribute(PortalConstants.PROJECT_USED_RELEASE_RELATIONS, fetchUsedReleaseRelationships(id));
                 addProjectBreadcrumb(request, response, project);
 
                 storePathsMapInRequest(request, mappedProjectLinks);
@@ -1001,6 +1053,41 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 setSW360SessionError(request, ErrorMessages.ERROR_GETTING_PROJECT);
             }
         }
+    }
+
+    private Set<ReleaseRelationship> fetchReleaseRelationships(List<ProjectLink> mappedProjectLinks) {
+        return mappedProjectLinks.stream().map(ProjectLink::getLinkedReleases).flatMap(List::stream)
+                .map(ReleaseLink::getReleaseRelationship).collect(Collectors.toSet());
+    }
+
+    private JSONObject fetchProjectReleaseToRelation(List<ProjectLink> mappedProjectLinks) {
+        Map<String, String> projectPathToReleaseToRelation = new HashMap<String, String>();
+        for (ProjectLink projectlink : mappedProjectLinks) {
+            if (projectlink.getLinkedReleasesSize() > 0) {
+                for (ReleaseLink relLink : projectlink.getLinkedReleases()) {
+                    projectPathToReleaseToRelation.put(projectlink.getId() + ":" + relLink.getId(),
+                            relLink.getReleaseRelationship().name());
+                }
+            }
+        }
+        JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
+        jsonObject.put("projectReleaseToRel", projectPathToReleaseToRelation);
+        return jsonObject;
+    }
+
+    private Set<ReleaseRelationship> fetchUsedReleaseRelationships(String projectId) {
+        Set<ReleaseRelationship> usedReleaseRealations = Sets.newHashSet();
+        try {
+            ProjectService.Iface client = thriftClients.makeProjectClient();
+            List<UsedReleaseRelations> usedRelRelation = nullToEmptyList(
+                    client.getUsedReleaseRelationsByProjectId(projectId));
+            if (CommonUtils.isNotEmpty(usedRelRelation)) {
+                usedReleaseRealations = usedRelRelation.get(0).getUsedReleaseRelations();
+            }
+        } catch (TException exception) {
+            log.error("cannot retrieve information about release relations.", exception);
+        }
+        return usedReleaseRealations;
     }
 
     /**
@@ -1082,6 +1169,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 }
 
                 request.setAttribute(PROJECT_LIST, mappedProjectLinks);
+                request.setAttribute(PortalConstants.PROJECT_RELEASE_TO_RELATION, fetchProjectReleaseToRelation(mappedProjectLinks));
                 addProjectBreadcrumb(request, response, project);
                 storeAttachmentUsageCountInRequest(request, mappedProjectLinks, UsageData.sourcePackage(new SourcePackageUsage()));
             } catch (TException e) {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtils.java
@@ -292,12 +292,18 @@ public class ProjectPortletUtils {
                 continue;
             }
 
+            List<String> pathParts = new ArrayList<String>(Arrays.asList(attachmentContentIdWithPath.split(":")));
+            if (pathParts.size() > 2) {
+                pathParts.remove(pathParts.size() - 2);
+            }
+            String attachmentContentIdWithPathWithoutRel = pathParts.stream().collect(Collectors.joining(":"));
+
             @SuppressWarnings("unchecked")
             Map<String, LicenseNameWithText> licenseStore = (Map<String, LicenseNameWithText>) request.getPortletSession()
-                    .getAttribute(ProjectPortlet.LICENSE_STORE_KEY_PREFIX + attachmentContentIdWithPath);
+                    .getAttribute(ProjectPortlet.LICENSE_STORE_KEY_PREFIX + attachmentContentIdWithPathWithoutRel);
             if (licenseStore == null) {
                 throw new IllegalStateException(
-                        "No license store found for attachment content id with path " + attachmentContentIdWithPath);
+                        "No license store found for attachment content id with path " + attachmentContentIdWithPathWithoutRel);
             }
 
             Set<Integer> includedIds = Arrays.stream(checkboxes).map(s -> Integer.valueOf(s)).collect(Collectors.toSet());
@@ -332,7 +338,7 @@ public class ProjectPortletUtils {
             AttachmentUsage usage = new AttachmentUsage();
             String[] pathParts = attachmentIdWithPath.split(":");
             usage.setUsedBy(Source.projectId(pathParts[0]));
-            usage.setOwner(Source.releaseId(pathParts[pathParts.length - 2]));
+            usage.setOwner(Source.releaseId(pathParts[pathParts.length - 3]));
             usage.setAttachmentContentId(pathParts[pathParts.length - 1]);
 
             UsageData usageData = usageDataGenerator.apply(attachmentIdWithPath);

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentSelectTable.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentSelectTable.jspf
@@ -141,6 +141,7 @@
                     data-tree-level="${projectLink.treeLevel + 1}"
                     data-release-id="${releaseLink.id}"
                     data-attachment-id="${attachment.attachmentContentId}"
+                    <core_rt:if test="${projectLinkTableMode == tableModeLicenseInfo}">data-release-relationship="${releaseLink.releaseRelationship}"</core_rt:if>
                     <core_rt:if test="${empty releaseLink.attachments}">class="selectable"</core_rt:if>
                     <core_rt:if test="${fn:length(releaseLink.attachments) == 1}">class="selectable highlightSuccess"</core_rt:if>
                     <core_rt:if test="${fn:length(releaseLink.attachments) gt 1}">class="selectable highlightWarning"</core_rt:if>
@@ -148,7 +149,7 @@
                     <td>
                         <input type="checkbox" class="form-check-input"
                                 name="<portlet:namespace/><%=PortalConstants.LICENSE_INFO_RELEASE_TO_ATTACHMENT%>"
-                                <core_rt:if test="${projectLinkTableMode == tableModeLicenseInfo}">value='${projectPath.concat(":").concat(releaseLink.id).concat(":").concat(attachment.attachmentContentId)}'</core_rt:if>
+                                <core_rt:if test="${projectLinkTableMode == tableModeLicenseInfo}">value='${projectPath.concat(":").concat(releaseLink.id).concat(":").concat(releaseLink.releaseRelationship).concat(":").concat(attachment.attachmentContentId)}'</core_rt:if>
                                 <core_rt:if test="${projectLinkTableMode != tableModeLicenseInfo}">value='${releaseLink.id.concat(":").concat(attachment.attachmentContentId)}'</core_rt:if>
                                 <core_rt:if test="${!attachmentSelected && (releaseLink.attachments.size() == 1 || attachment.createdTeam == sw360User.department)}">checked="checked" class="defaultChecked"
                                     <core_rt:set var="attachmentSelected" value="true" scope="request"/>
@@ -202,7 +203,9 @@
         require(['jquery', 'modules/button', 'modules/ajax-treetable', 'bridges/jquery-ui'], function($, button, treetable) {
 
             var $linkedProjectsInfoTable = $("#LinkedProjectsInfo"),
-                data = $linkedProjectsInfoTable.data();
+                data = $linkedProjectsInfoTable.data(),
+                releaseRelationDataAttr,
+                licenseinfoTableMode = ${projectLinkTableMode == tableModeLicenseInfo};
 
             if(data.tableMode === data.tableModeLicenseInfo) {
                 initializeTableForLicenseInfo($linkedProjectsInfoTable);
@@ -326,7 +329,7 @@
                     }
 
                     $rows = convertDataToRows(urlData.portletNamespace, data.ttId, data.treeLevel, data.projectPath,
-                                    data.releaseId, data.attachmentId, node.row.find('input[type=checkbox]:first').is(':checked'), licenses);
+                                    data.releaseId, data.releaseRelationship, data.attachmentId, node.row.find('input[type=checkbox]:first').is(':checked'), licenses);
                     $rows.find('.license-text').tooltip({
                         delay: 0,
                         content: function () {
@@ -339,17 +342,17 @@
 
                     // synchronize checkbox of each license with checkbox of attachment
                     node.row.find('input[type=checkbox]:first').on('change', function() {
-                        $linkedProjectsInfoTable.find('tr input[name="' + urlData.portletNamespace + data.projectPath + ':' + data.releaseId + ':' + data.attachmentId + '"]').
+                        $linkedProjectsInfoTable.find('tr input[name="' + urlData.portletNamespace + data.projectPath + ':' + data.releaseId + ':' + data.releaseRelationship + ':' + data.attachmentId + '"]').
                             prop('checked', this.checked).trigger('change');
                     });
                     // be sure that attachment is checked if at least one license is checked and that attachment is not checked
                     // if no license is checked
-                    $linkedProjectsInfoTable.find('tr input[name="' + urlData.portletNamespace + data.projectPath + ':' + data.releaseId + ':' + data.attachmentId + '"]').on('change', function() {
+                    $linkedProjectsInfoTable.find('tr input[name="' + urlData.portletNamespace + data.projectPath + ':' + data.releaseId + ':' + data.releaseRelationship + ':' + data.attachmentId + '"]').on('change', function() {
                         if(this.checked) {
                             // do not trigger change here, otherwise all license would be selected.
                             node.row.find('input[type=checkbox]:first').prop('checked', true);
                         } else {
-                            if($linkedProjectsInfoTable.find('tr input[name="' + urlData.portletNamespace + data.projectPath + ':' + data.releaseId + ':' + data.attachmentId + '"]:checked').length == 0) {
+                            if($linkedProjectsInfoTable.find('tr input[name="' + urlData.portletNamespace + data.projectPath + ':' + data.releaseId + ':' + data.releaseRelationship + ':' + data.attachmentId + '"]:checked').length == 0) {
                                 // do not trigger change here, otherwise all license would be selected.
                                 node.row.find('input[type=checkbox]:first').prop('checked', false);
                             }
@@ -364,7 +367,7 @@
                 });
             }
 
-            function convertDataToRows(portletNamespace, parentNodeId, treeLevel, projectPath, releaseId, attachmentContentId, initialCheck, licenses) {
+            function convertDataToRows(portletNamespace, parentNodeId, treeLevel, projectPath, releaseId, releaseRelationship, attachmentContentId, initialCheck, licenses) {
                 var index = 0,
                     $rows = $();
 
@@ -381,7 +384,7 @@
                     $checkbox = $('<input/>', {
                         type:         'checkbox',
                         'class': 'form-check-input',
-                        name:         portletNamespace + projectPath + ':' + releaseId + ":" + attachmentContentId,
+                        name:         portletNamespace + projectPath + ':' + releaseId + ':' + releaseRelationship + ':' + attachmentContentId,
                         value:        index++,
                     });
                     if(initialCheck) {
@@ -391,7 +394,7 @@
                         $checkbox,
                         $('<input/>', {
                             type:     'hidden',
-                            name:     portletNamespace + projectPath + ':' + releaseId + ":" + attachmentContentId + '_key',
+                            name:     portletNamespace + projectPath + ':' + releaseId + ':' + releaseRelationship + ':' +attachmentContentId + '_key',
                             value:    license.key
                         })
                     ).appendTo($row);
@@ -544,7 +547,19 @@
                         node;
                     // check all checkboxes by checking the parent one because we are storing exclusions and only
                     // excluded ones will be unchecked
-                    $linkedProjectsInfoTable.find('tr input[value="' + inputPrefix + usage.owner.releaseId + ':' + usage.attachmentContentId + '"]:first').prop('checked', true).trigger('change');
+                    var releaseRelationFromMap = '';
+                    if (licenseinfoTableMode) {
+                        var inputPrefixSplitted = inputPrefix.split(":");
+                        var projOrSubProjId = inputPrefixSplitted[inputPrefixSplitted.length-2];
+                        var projToRel = projOrSubProjId + ":" + usage.owner.releaseId;
+                        var projRelToReln = JSON.parse(JSON.stringify(${projectReleaseToRelation}));
+                        releaseRelationFromMap = projRelToReln.projectReleaseToRel[projToRel];
+                    }
+                    releaseRelationDataAttr = licenseinfoTableMode?'[data-release-relationship=' + releaseRelationFromMap + ']':'';
+                    var relationPlusColon = releaseRelationFromMap + ':';
+                    var releaseRelation = licenseinfoTableMode ? relationPlusColon : '';
+
+                    $linkedProjectsInfoTable.find('tr input[value="' + inputPrefix + usage.owner.releaseId + ':' + releaseRelation + usage.attachmentContentId + '"]:first').prop('checked', true).trigger('change');
 
                     if(usage.usageData.licenseInfo && usage.usageData.licenseInfo.excludedLicenseIds.length > 0) {
                         if (!usage.usageData.licenseInfo.projectPath) {
@@ -586,7 +601,7 @@
                                             text: 'License "' + licenseId + '" is not unique. License is not excluded.'
                                         });
                                     } else {
-                                        $row.find('input[name="' + config.portletNamespace + prefix + usage.usageData.licenseInfo.projectPath + ':' + usage.owner.releaseId + ':' + usage.attachmentContentId + '"]').prop('checked', false).trigger('change');
+                                        $row.find('input[name="' + config.portletNamespace + prefix + usage.usageData.licenseInfo.projectPath + ':' + usage.owner.releaseId + ':' + releaseRelation + usage.attachmentContentId + '"]').prop('checked', false).trigger('change');
                                     }
                                 });
                                 loadCountdown.decrement();
@@ -609,7 +624,7 @@
             }
 
             function findNode($linkedProjectsInfoTable, usage, prefix) {
-                var $row = $linkedProjectsInfoTable.find('tr[data-project-path="' + prefix + usage.usageData.licenseInfo.projectPath + '"][data-release-id=' + usage.owner.releaseId + '][data-attachment-id=' + usage.attachmentContentId + ']:first');
+                var $row = $linkedProjectsInfoTable.find('tr[data-project-path="' + prefix + usage.usageData.licenseInfo.projectPath + '"][data-release-id=' + usage.owner.releaseId + ']' + releaseRelationDataAttr + '[data-attachment-id=' + usage.attachmentContentId + ']:first');
                 if ($row.length > 0) {
                     return $linkedProjectsInfoTable.treetable("node", $row.data().ttId);
                 } else {
@@ -618,7 +633,7 @@
             }
 
             function findAttachmentName($linkedProjectsInfoTable, usage, prefix) {
-                var $row = $linkedProjectsInfoTable.find('tr[data-project-path="' + prefix + usage.usageData.licenseInfo.projectPath + '"][data-release-id=' + usage.owner.releaseId + '][data-attachment-id=' + usage.attachmentContentId + ']:first');
+                var $row = $linkedProjectsInfoTable.find('tr[data-project-path="' + prefix + usage.usageData.licenseInfo.projectPath + '"][data-release-id=' + usage.owner.releaseId + ']' + releaseRelationDataAttr + '[data-attachment-id=' + usage.attachmentContentId + ']:first');
                 return $row.find('td.filename').text();
             }
 

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/licenseInfo.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/licenseInfo.jsp
@@ -72,7 +72,25 @@
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
-      <div class="modal-body">
+      <div class="modal-body"
+                    style="position: relative; overflow-y: auto; max-height: 400px;">
+                    <c:if test="${not empty relations}">
+                        <div class="form-group form-check">
+                            <label for="projectRelation"
+                                class="font-weight-bold h3">Uncheck project
+                                release relationships to be excluded:</label>
+                            <c:forEach var="projectReleaseRelation" items="${relations}">
+                                <div class="checkbox form-check">
+                                    <label> <input name="releaseRelationSelection" type="checkbox"
+                                        <c:if test = "${empty usedProjectReleaseRelations}">checked="checked"</c:if>
+                                        <c:if test = "${not empty usedProjectReleaseRelations and (fn:contains(usedProjectReleaseRelations, projectReleaseRelation))}">checked="checked"</c:if>
+                                        value="${projectReleaseRelation}">
+                                        <sw360:DisplayEnum value='${projectReleaseRelation}' bare="true" /> </input>
+                                    </label>
+                                </div>
+                            </c:forEach>
+                        </div>
+                    </c:if>
 						<c:if test="${not empty externalIds}">
 								<div class="form-group form-check">
 									<label for="externalIdLabel" class="font-weight-bold h3">Select the external Ids:</label>
@@ -110,16 +128,24 @@ require(['jquery', 'modules/dialog'], function($, dialog) {
     function downloadFile(){
         var licenseInfoSelectedOutputFormat = $('input[name="outputFormat"]:checked').val();
         var externalIds = [];
+        var releaseRelations = [];
         $.each($("input[name='externalIdsSelection']:checked"), function(){
             externalIds.push($(this).val());
         });
         var extIdsHidden = externalIds.join(',');
 
+        $.each($("input[name='releaseRelationSelection']:checked"), function(){
+            releaseRelations.push($(this).val());
+        });
+        var releaseRelationsHidden = releaseRelations.join();
+
         $('#downloadLicenseInfoForm').append('<input id="extIdHidden" type="hidden" name="<portlet:namespace/><%=PortalConstants.EXTERNAL_ID_SELECTED_KEYS%>"/>');
         $('#downloadLicenseInfoForm').append('<input id="licensInfoFileFormat" type="hidden" name="<portlet:namespace/><%=PortalConstants.LICENSE_INFO_SELECTED_OUTPUT_FORMAT%>"/>');
+        $('#downloadLicenseInfoForm').append('<input id="releaseRelationship" type="hidden" name="<portlet:namespace/><%=PortalConstants.SELECTED_PROJECT_RELEASE_RELATIONS%>"/>');
 
         $("#extIdHidden").val(extIdsHidden);
         $("#licensInfoFileFormat").val(licenseInfoSelectedOutputFormat);
+        $("#releaseRelationship").val(releaseRelationsHidden);
 
         $('#downloadLicenseInfoForm').submit();
     }

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
@@ -25,6 +25,7 @@ import org.eclipse.sw360.datahandler.thrift.licenses.*;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectObligation;
+import org.eclipse.sw360.datahandler.thrift.projects.UsedReleaseRelations;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.*;
@@ -55,7 +56,7 @@ public class ThriftUtils {
             .add(License.class).add(Todo.class).add(Obligation.class) // License service
             .add(LicenseType.class).add(Risk.class).add(RiskCategory.class) // License service
             .add(CustomProperties.class) // License service
-            .add(Project.class).add(ProjectObligation.class) // Project service
+            .add(Project.class).add(ProjectObligation.class).add(UsedReleaseRelations.class) // Project service
             .add(User.class) // User service
             .add(Vendor.class) // Vendor service
             .add(ModerationRequest.class) // Moderation service‚

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -192,6 +192,14 @@ struct ObligationStatusInfo {
     9: optional map<string, string> releaseIdToAcceptedCLI
 }
 
+struct UsedReleaseRelations {
+    1: optional string id,
+    2: optional string revision,
+    3: optional string type = "usedReleaseRelation",
+    4: required string projectId,
+    5: optional set<ReleaseRelationship> usedReleaseRelations = [],
+}
+
 service ProjectService {
 
     // Summary getters
@@ -379,4 +387,24 @@ service ProjectService {
      * update linked obligations of a project
      */
     RequestStatus updateLinkedObligations(1: ProjectObligation obligation, 2: User user);
+
+    /**
+     * Deletes an UsedReleaseRelations object. The given usage object must exist in the database.
+     */
+    void deleteReleaseRelationsUsage(1: UsedReleaseRelations usedReleaseRelations);
+
+    /**
+     * Add an used release relations for a Project.
+     */
+    void addReleaseRelationsUsage(1: UsedReleaseRelations usedReleaseRelations);
+
+    /**
+     * Update an used release relations for a Project.
+     */
+    void updateReleaseRelationsUsage(1: UsedReleaseRelations usedReleaseRelations);
+
+    /**
+     * Get used release relations by project id
+     */
+    list<UsedReleaseRelations> getUsedReleaseRelationsByProjectId(1: string projectId);
 }


### PR DESCRIPTION
* User can chooses to exclude the releases with specific project release relationship while generating license disclosure document.
* Added warning message to the generated document, if no selection has been chosen.

Signed-off-by: Smruti Sahoo <smruti.sahoo@siemens.com>