### PR TITLE
feat(ProjectUI): Project Clearing Report

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/entitlement/ProjectModerator.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/entitlement/ProjectModerator.java
@@ -10,9 +10,11 @@
 package org.eclipse.sw360.datahandler.entitlement;
 
 import org.eclipse.sw360.datahandler.common.Moderator;
+import org.eclipse.sw360.datahandler.thrift.Comment;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationService;
+import org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectRelationship;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -59,6 +61,46 @@ public class ProjectModerator extends Moderator<Project._Fields, Project> {
         } catch (TException e) {
             log.error("Could not moderate delete project " + project.getId() + " for User " + user.getEmail(), e);
             return  RequestStatus.FAILURE;
+        }
+    }
+
+    public String createClearingRequest(ClearingRequest clearingRequest, User user) {
+        ModerationService.Iface client = thriftClients.makeModerationClient();
+        try {
+            return client.createClearingRequest(clearingRequest, user);
+        } catch (TException e) {
+            log.error("Could not create CR for Project: " + clearingRequest.getProjectId() + " by User " + user.getEmail(), e);
+            return null;
+        }
+    }
+
+    public RequestStatus addCommentToClearingRequest(String id, Comment comment, User user) {
+        ModerationService.Iface client = thriftClients.makeModerationClient();
+        try {
+            return client.addCommentToClearingRequest(id, comment, user);
+        } catch (TException e) {
+            log.error("Failed to add comment in clearing request: " + id, e);
+            return RequestStatus.FAILURE;
+        }
+    }
+
+    public ClearingRequest getClearingRequestByProjectId(String projectId, User user) {
+        ModerationService.Iface client = thriftClients.makeModerationClient();
+        try {
+            return client.getClearingRequestByProjectId(projectId);
+        } catch (TException e) {
+            log.error("Could not find CR for Project: " + projectId + " by User " + user.getEmail(), e);
+            return null;
+        }
+    }
+
+
+    public void unlinkClearingRequestForProjectDeletion(Project project, User user) {
+        try {
+            ModerationService.Iface client = thriftClients.makeModerationClient();
+            client.updateClearingRequestForProjectDeletion(project, user);
+        } catch (TException e) {
+            log.error("Failed to unlink CR : " + project.getClearingRequestId() + " for project: " + project.getId() + ", by User " + user.getEmail(), e);
         }
     }
 

--- a/backend/src-common/src/main/java/org/eclipse/sw360/mail/MailConstants.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/mail/MailConstants.java
@@ -22,6 +22,7 @@ public class MailConstants {
     public static final String DEFAULT_END = "defaultEnd";
     public static final String UNSUBSCRIBE_NOTICE_BEFORE = "unsubscribeNoticeBefore";
     public static final String UNSUBSCRIBE_NOTICE_AFTER = "unsubscribeNoticeAfter";
+    public static final String DASH = " - ";
 
     public static final String SUBJECT_FOR_NEW_MODERATION_REQUEST = "subjectForNewModerationRequest";
     public static final String SUBJECT_FOR_UPDATE_MODERATION_REQUEST = "subjectForUpdateModerationRequest";
@@ -34,6 +35,11 @@ public class MailConstants {
     public static final String SUBJECT_FOR_UPDATE_RELEASE = "subjectForUpdateRelease";
     public static final String SUBJECT_FOR_NEW_PROJECT = "subjectForNewProject";
     public static final String SUBJECT_FOR_UPDATE_PROJECT = "subjectForUpdateProject";
+    public static final String SUBJECT_FOR_NEW_CLEARING_REQUEST = "subjectForNewClearingRequest";
+    public static final String SUBJECT_FOR_UPDATED_CLEARING_REQUEST = "subjectForUpdatedClearingRequest";
+    public static final String SUBJECT_FOR_APPROVED_CLEARING_REQUEST = "subjectForApprovedClearingRequest";
+    public static final String SUBJECT_FOR_DECLINED_CLEARING_REQUEST = "subjectForDeclinedClearingRequest";
+    public static final String SUBJECT_FOR_UPDATED_PROJECT_WITH_CLEARING_REQUEST = "subjectForUpdatedProjectWithClearingRequest";
 
     public static final String TEXT_FOR_NEW_MODERATION_REQUEST = "textForNewModerationRequest";
     public static final String TEXT_FOR_UPDATE_MODERATION_REQUEST = "textForUpdateModerationRequest";
@@ -46,6 +52,8 @@ public class MailConstants {
     public static final String TEXT_FOR_UPDATE_RELEASE = "textForUpdateRelease";
     public static final String TEXT_FOR_NEW_PROJECT = "textForNewProject";
     public static final String TEXT_FOR_UPDATE_PROJECT = "textForUpdateProject";
+    public static final String TEXT_FOR_APPROVED_CLEARING_REQUEST = "textForApprovedClearingRequest";
+    public static final String TEXT_FOR_DECLINED_CLEARING_REQUEST = "textForDeclinedClearingRequest";
 
     private MailConstants() {
         // Utility class with only static functions

--- a/backend/src-common/src/main/resources/NewClearingRequestEmailTemplate.html
+++ b/backend/src-common/src/main/resources/NewClearingRequestEmailTemplate.html
@@ -1,0 +1,58 @@
+<!--
+  ~ Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+-->
+<!doctype html>
+<html>
+  <head>
+    <style type="text/css">
+        table {border: 1px solid black; border-collapse:collapse; text-align:center}
+        table tr th {border: 1px solid black; padding: 7px;}
+        table tr td {border: 1px solid black; padding: 7px;}
+    </style>
+  </head>
+  <body>
+	<p>*** This is an automatically generated email, please do not reply. ***</p>
+	<p>Dear SW360-user,
+	    <br>sw360 <b>%s</b>, has raised clearing request <b>%s</b> for project: <b><a href="%s">%s</a></b>
+	</p>
+
+	<label>Linked Project / Release count</label>
+	<table>
+	    <tr>
+	        <th>Linked Project(s)</th>
+	        <th>Linked Release(s)</th>
+	    </tr>
+	    <tr>
+	        <td><b>%s</b></td>
+	        <td><b>%s</b></td>
+	    </tr>
+	</table>
+	<br>
+	<label>Linked Release clearing status (excluding sub-projects).</label>
+	<table>
+	    <tr>
+	        <th>Total Release(s)</th>
+	        <th >Approved Release(s)</th>
+	    </tr>
+	    <tr>
+	        <td><b>%s</b></td>
+	        <td><b>%s</b></td>
+	    </tr>
+	</table>
+	<br>
+	<p>Requested clearing Date: <b>%s</b>
+	<br>
+	List of Releases with Clearing Status <b>New</b>
+	<ul>%s</ul>
+	<br>
+	<p>With best regards,
+	    <br>SW360-support
+	</p>
+  </body>
+</html>

--- a/backend/src-common/src/main/resources/UpdateClearingRequestEmailTemplate.html
+++ b/backend/src-common/src/main/resources/UpdateClearingRequestEmailTemplate.html
@@ -1,0 +1,34 @@
+<!--
+  ~ Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+-->
+<!doctype html>
+<html>
+  <body>
+	<p>*** This is an automatically generated email, please do not reply. ***</p>
+	<p>Dear SW360-user,
+	    <br>sw360 <b>%s</b>, has updated the clearing request <b>%s</b> for project: <b><a href="%s">%s</a></b>
+	</p>
+	<p>
+		<br>
+		Request Status: <b>%s</b>
+		<br>
+		Requested clearing Date: <b>%s</b>
+		<br>
+		Agreed clearing Date: <b>%s</b>
+		<br>
+		The clearing team has agreed to provide the clearing reports for this request by the above date.
+	</p>
+	List of Releases with Clearing Status <b>New</b>
+	<ul>%s</ul>
+	<br>
+	<p>With best regards,
+	    <br>SW360-support
+	</p>
+  </body>
+</html>

--- a/backend/src-common/src/main/resources/UpdateProjectWithCREmailTemplate.html
+++ b/backend/src-common/src/main/resources/UpdateProjectWithCREmailTemplate.html
@@ -1,0 +1,66 @@
+<!--
+  ~ Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+-->
+<!doctype html>
+<html>
+  <head>
+    <style type="text/css">
+        table {border: 1px solid black; border-collapse:collapse; text-align:center}
+        table tr th {border: 1px solid black; padding: 7px;}
+        table tr td {border: 1px solid black; padding: 7px;}
+    </style>
+  </head>
+  <body>
+	<p>*** This is an automatically generated email, please do not reply. ***</p>
+	<p>Dear SW360-user,
+	    <br>sw360 <b>%s</b>, has updated the project: <b>%s</b> with clearing request id: <b>%s</b>
+	    <br>Here is the updated information
+	</p>
+
+	<label>Linked Project / Release count</label>
+	<table>
+	    <tr>
+	        <th>Linked Project(s)</th>
+	        <th>Linked Release(s)</th>
+	    </tr>
+	    <tr>
+	        <td><b>%s</b></td>
+	        <td><b>%s</b></td>
+	    </tr>
+	</table>
+	<br>
+	<label>Linked Release clearing status (excluding sub-projects).</label>
+	<table>
+	    <tr>
+	        <th>Total Release(s)</th>
+	        <th>Approved Release(s)</th>
+	    </tr>
+	    <tr>
+	        <td><b>%s</b></td>
+	        <td><b>%s</b></td>
+	    </tr>
+	</table>
+	<p>
+	<br>
+	Request Status: <b>%s</b>
+	<br>
+	Requested clearing Date: <b>%s</b>
+	<br>
+	Agreed clearing Date: <b>%s</b>
+	<br>
+	The accepted clearing date may vary, due to the changes in Linked Releases.
+	</p>
+	List of Releases with Clearing Status <b>New</b>
+	<ul>%s</ul>
+	<br>
+	<p>With best regards,
+	    <br>SW360-support
+	</p>
+  </body>
+</html>

--- a/backend/src-common/src/main/resources/sw360.properties
+++ b/backend/src-common/src/main/resources/sw360.properties
@@ -47,6 +47,11 @@ subjectForNewRelease= New release created
 subjectForUpdateRelease= Release updated
 subjectForNewProject= New project created
 subjectForUpdateProject= Project updated
+subjectForNewClearingRequest= New clearing request
+subjectForUpdatedClearingRequest= Your clearing request has been updated
+subjectForApprovedClearingRequest= Your clearing request has been approved
+subjectForDeclinedClearingRequest= Your clearing request has been declined
+subjectForUpdatedProjectWithClearingRequest= Project with clearing request updated
 
 textForNewModerationRequest= a new moderation request has been added to your SW360-account.\n\n
 textForUpdateModerationRequest= \
@@ -61,3 +66,5 @@ textForNewRelease= a new release %s %s, in which you take part, has been created
 textForUpdateRelease= the release %s %s, in which you take part, has been updated.\n\n
 textForNewProject= a new project %s %s, in which you take part, has been created.\n\n
 textForUpdateProject= the project %s %s, in which you take part, has been updated.\n\n
+textForApprovedClearingRequest= your clearing request with id: %s for the project %s has been approved by the clearing team.\n\n
+textForDeclinedClearingRequest= your clearing request with id: %s for the project %s has been declined by the clearing team.\n\n

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -61,9 +61,9 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
     private static final int CACHE_TIMEOUT_MINUTES = 15;
     private static final int CACHE_MAX_ITEMS = 100;
     private static final String DEFAULT_LICENSE_INFO_HEADER_FILE = "/DefaultLicenseInfoHeader.txt";
-    private static final String DEFAULT_LICENSE_INFO_TEXT = dropCommentedLine(DEFAULT_LICENSE_INFO_HEADER_FILE);
+    private static final String DEFAULT_LICENSE_INFO_TEXT = SW360Utils.dropCommentedLine(LicenseInfoHandler.class, DEFAULT_LICENSE_INFO_HEADER_FILE);
     private static final String DEFAULT_OBLIGATIONS_FILE = "/DefaultObligations.txt";
-    private static final String DEFAULT_OBLIGATIONS_TEXT = dropCommentedLine(DEFAULT_OBLIGATIONS_FILE);
+    private static final String DEFAULT_OBLIGATIONS_TEXT = SW360Utils.dropCommentedLine(LicenseInfoHandler.class, DEFAULT_OBLIGATIONS_FILE);
     private static final String MSG_NO_RELEASE_GIVEN = "No release given";
 
     protected List<LicenseInfoParser> parsers;
@@ -609,10 +609,5 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
                 .filter(outputGenerator -> generatorClassname.equals(outputGenerator.getClass().getSimpleName()))
                 .filter(outputGenerator -> generatorVariant.equals(outputGenerator.getOutputVariant()))
                 .findFirst().orElseThrow(() -> new TException("Unknown output generator: " + generatorClassname));
-    }
-
-    private static String dropCommentedLine(String TEMPLATE_FILE) {
-        String text = new String( CommonUtils.loadResource(LicenseInfoHandler.class, TEMPLATE_FILE).orElse(new byte[0]) );
-        return text.replaceAll("(?m)^#.*(?:\r?\n)?", ""); // ignore comments in template file
     }
 }

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/ModerationHandler.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/ModerationHandler.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.moderation;
 
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.thrift.Comment;
 import org.eclipse.sw360.datahandler.thrift.ModerationState;
 import org.eclipse.sw360.datahandler.thrift.RemoveModeratorRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
@@ -21,12 +22,14 @@ import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationService;
+import org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.moderation.db.ModerationDatabaseHandler;
 
 import java.net.MalformedURLException;
 import java.util.List;
+import java.util.Set;
 
 import static org.eclipse.sw360.datahandler.common.SW360Assert.*;
 
@@ -205,4 +208,70 @@ public class ModerationHandler implements ModerationService.Iface {
         return handler.getRequestsByRequestingUser(user.getEmail());
     }
 
+    @Override
+    public ClearingRequest getClearingRequestByProjectId(String projectId) throws TException {
+        assertId(projectId);
+
+        return handler.getClearingRequestByProjectId(projectId);
+    }
+
+    @Override
+    public Set<ClearingRequest> getMyClearingRequests(User user) throws TException {
+        assertUser(user);
+
+        return handler.getMyClearingRequests(user.getEmail());
+    }
+
+    @Override
+    public String createClearingRequest(ClearingRequest clearingRequest, User user) throws TException {
+        assertNotNull(clearingRequest);
+        assertEmpty(clearingRequest.getId());
+        assertUser(user);
+
+        return handler.createClearingRequest(clearingRequest, user);
+    }
+
+    @Override
+    public ClearingRequest getClearingRequestById(String id, User user) throws TException {
+        assertId(id);
+        assertUser(user);
+
+        return handler.getClearingRequestById(id, user);
+    }
+
+    @Override
+    public ClearingRequest getClearingRequestByIdForEdit(String id, User user) throws TException {
+        assertId(id);
+        assertUser(user);
+
+        return handler.getClearingRequestByIdForEdit(id, user);
+    }
+
+    @Override
+    public RequestStatus updateClearingRequest(ClearingRequest clearingRequest, User user, String projectUrl) throws TException {
+        assertNotNull(clearingRequest);
+        assertId(clearingRequest.getId());
+        assertNotEmpty(projectUrl);
+        assertUser(user);
+
+        return handler.updateClearingRequest(clearingRequest, user, projectUrl);
+    }
+
+    @Override
+    public void updateClearingRequestForProjectDeletion(Project project, User user) throws TException {
+        assertNotNull(project);
+        assertId(project.getClearingRequestId());
+        assertUser(user);
+
+        handler.updateClearingRequestForProjectDeletion(project, user);
+    }
+
+    @Override
+    public RequestStatus addCommentToClearingRequest(String id, Comment comment, User user) throws TException {
+        assertId(id);
+        assertNotNull(comment);
+        assertUser(user);
+
+        return handler.addCommentToClearingRequest(id, comment, user);
+    }
 }

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ClearingRequestRepository.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ClearingRequestRepository.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.moderation.db;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
+import org.eclipse.sw360.datahandler.couchdb.DatabaseRepository;
+import org.eclipse.sw360.datahandler.thrift.ClearingRequestState;
+import org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest;
+import org.ektorp.support.View;
+
+/**
+ * CRUD access for the ClearingRequest class
+ *
+ * @author abdul.mannankapti@siemens.com
+ */
+@View(name = "all", map = "function(doc) { if (doc.type == 'clearingRequest') emit(null, doc._id) }")
+public class ClearingRequestRepository extends DatabaseRepository<ClearingRequest> {
+
+    private static final String BY_PROJECT_ID = "function(doc) { " +
+            "  if (doc.type == 'clearingRequest') {" +
+            "    emit(doc.projectId, doc);" +
+            "    }" +
+            "}";
+
+    private static final String MY_CLEARING_REQUESTS = "function(doc) { " +
+            "    if (doc.type == 'clearingRequest') {" +
+            "        var acc = {};" +
+            "        if (doc.requestingUser) {" +
+            "            acc[doc.requestingUser] = 1;" +
+            "        }" +
+            "        if (doc.clearingTeam) {" +
+            "            acc[doc.clearingTeam] = 1 ;" +
+            "        }" +
+            "        for (var i in acc) {" +
+            "            emit(i, doc);" +
+            "        }" +
+            "    }" +
+            "}";
+
+    public ClearingRequestRepository(DatabaseConnector db) {
+        super(ClearingRequest.class, db);
+
+        initStandardDesignDocument();
+    }
+
+    @View(name = "byProjectId", map = BY_PROJECT_ID)
+    public ClearingRequest getClearingRequestByProjectId(String projectId) {
+        List<ClearingRequest> requests = queryView("byProjectId", projectId);
+        if (CommonUtils.isNotEmpty(requests)) {
+            ClearingRequest request = requests.stream()
+                    .filter(r -> !ClearingRequestState.REJECTED.equals(r.getClearingState()))
+                    .sorted(Comparator.comparingLong(ClearingRequest::getTimestamp).reversed()).findFirst()
+                    .orElse(null);
+            return request;
+        }
+        return null;
+    }
+
+    @View(name = "myClearingRequests", map = MY_CLEARING_REQUESTS)
+    public Set<ClearingRequest> getMyClearingRequests(String user) {
+        return new HashSet<ClearingRequest>(queryView("myClearingRequests", user));
+    }
+}

--- a/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -21,6 +21,7 @@ import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStatusData;
+import org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectLink;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectObligation;
@@ -117,6 +118,17 @@ public class ProjectHandler implements ProjectService.Iface {
     public Set<Project> searchLinkingProjects(String id, User user) throws TException {
         assertId(id);
         return handler.searchLinkingProjects(id, user);
+    }
+
+    ////////////////////////////
+    // CLEARING REQUEST EMAIL //
+    ////////////////////////////
+    @Override
+    public AddDocumentRequestSummary createClearingRequest(ClearingRequest clearingRequest, User user, String projectUrl) throws TException {
+        assertNotNull(clearingRequest);
+        assertNotEmpty(projectUrl);
+        assertUser(user);
+        return handler.createClearingRequest(clearingRequest, user, projectUrl);
     }
 
     ////////////////////////////

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
@@ -51,6 +51,7 @@ public class ErrorMessages {
     public static final String REST_API_EXPIRE_DATE_NOT_VALID = "Your selected token expiration date is not valid.";
     public static final String ERROR_PROJECT_OR_DEPENDENCIES_NOT_FOUND = "Error fetching project. Project or its dependencies are not found.";
     public static final String ERROR_PROJECT_OR_LINKEDPROJECT_NOT_ACCESSIBLE = "Error fetching project. Project or its Linked Projects are not accessible.";
+    public static final String ERROR_GETTING_CLEARING_REQUEST = "Error fetching clearing request from backend.";
 
     //this map is used in errorKeyToMessage.jspf to generate key-value pairs for the liferay-ui error tag
     public static final ImmutableList<String> allErrorMessages = ImmutableList.<String>builder()
@@ -89,6 +90,7 @@ public class ErrorMessages {
             .add(REST_API_EXPIRE_DATE_NOT_VALID)
             .add(ERROR_PROJECT_OR_DEPENDENCIES_NOT_FOUND)
             .add(ERROR_PROJECT_OR_LINKEDPROJECT_NOT_ACCESSIBLE)
+            .add(ERROR_GETTING_CLEARING_REQUEST)
             .build();
 
     private ErrorMessages() {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -13,6 +13,8 @@ package org.eclipse.sw360.portal.common;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
@@ -78,6 +80,7 @@ public class PortalConstants {
     public static final String DOCUMENT_TYPE = "documentType";
     public static final String VIEW_SIZE = "viewSize";
     public static final String TOTAL_ROWS = "totalRows";
+    public static final String RESULT = "result";
 
     public static final String IS_USER_AT_LEAST_CLEARING_ADMIN = "isUserAtLeastClearingAdmin";
     public static final String IS_USER_AT_LEAST_ECC_ADMIN = "isUserAtLeastECCAdmin";
@@ -106,6 +109,21 @@ public class PortalConstants {
     public static final String CLOSED_MODERATION_REQUESTS = "closedModerationRequests";
     public static final String DELETE_MODERATION_REQUEST = "deleteModerationRequest";
     public static final String MODERATION_ACTIONS_ALLOWED = "moderationAllowed";
+
+    //! Specialized keys for clearing
+    public static final String CLEARING_REQUEST = "clearingRequest";
+    public static final String CLEARING_REQUESTS = "clearingRequests";
+    public static final String CLEARING_REQUEST_ID = "clearingId";
+    public static final String CLOSED_CLEARING_REQUESTS = "closedClearingRequests";
+    public static final String CREATE_CLEARING_REQUEST = "create_clearing_request";
+    public static final String VIEW_CLEARING_REQUEST = "view_clearing_request";
+    public static final String AGREED_CLEARING_DATE = "agreedClearingDate";
+    public static final String CLEARING_TEAM_COMMENT = "clearingTeamComment";
+    public static final String PAGENAME_DETAIL_CLEARING_REQUEST = "detailClearingRequest";
+    public static final String PAGENAME_EDIT_CLEARING_REQUEST = "editClearingRequest";
+    public static final String ADD_COMMENT = "addComment";
+    public static final String CLEARING_REQUEST_COMMENT = "clearingRequestComment";
+
 
     //! Specialized keys for components
     public static final String COMPONENT_PORTLET_NAME = PORTLET_NAME_PREFIX + "components";
@@ -183,7 +201,8 @@ public class PortalConstants {
     public static final String SPDX_LICENSE_INFO = "spdxLicenseInfo";
 
     //! Specialized keys for projects
-    public static final String PROJECT_PORTLET_NAME = PORTLET_NAME_PREFIX + "projects";
+    public static final String PROJECTS = "projects";
+    public static final String PROJECT_PORTLET_NAME = PORTLET_NAME_PREFIX + PROJECTS;
     public static final String PROJECT_BDPIMPORT_PORTLET_NAME = PORTLET_NAME_PREFIX + "projectbdpimport";
     public static final String PROJECT_WSIMPORT_PORTLET_NAME = PORTLET_NAME_PREFIX + "projectwsimport";
     public static final String PROJECT_ID = "projectid";
@@ -230,6 +249,8 @@ public class PortalConstants {
     public static final String PROJECT_RELEASE_TO_RELATION = "projectReleaseToRelation";
     public static final String PROJECT_USED_RELEASE_RELATIONS = "usedProjectReleaseRelations";
     public static final String SELECTED_PROJECT_RELEASE_RELATIONS = "selectedProjectReleaseRelations";
+    public static final String PROJECT_URL = "projectUrl";
+
 
     public static final String FOSSOLOGY_PORTLET_NAME = PORTLET_NAME_PREFIX + "fossology";
     public static final String USER_LIST = "userList";
@@ -537,7 +558,6 @@ public class PortalConstants {
         PROJECT_OBLIGATIONS_ACTION_SET = CommonUtils.splitToSet(props.getProperty("project.obligation.actions", "Action 1,Action 2,Action 3"));
         IS_PROJECT_OBLIGATIONS_ENABLED = Boolean.parseBoolean(props.getProperty("project.obligations.enabled", "true"));
         CUSTOM_WELCOME_PAGE_GUIDELINE = Boolean.parseBoolean(props.getProperty("custom.welcome.page.guideline", "false"));
-
         // SW360 REST API Constants
         API_TOKEN_ENABLE_GENERATOR = Boolean.parseBoolean(props.getProperty("rest.apitoken.generator.enable", "false"));
         API_TOKEN_MAX_VALIDITY_READ_IN_DAYS = props.getProperty("rest.apitoken.read.validity.days", "90");

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/page/PortletDefaultPage.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/page/PortletDefaultPage.java
@@ -18,7 +18,8 @@ import org.eclipse.sw360.portal.common.PortalConstants;
 public enum PortletDefaultPage implements PortletPage {
     DETAIL(PortalConstants.PAGENAME_DETAIL),
     RELEASE_DETAIL(PortalConstants.PAGENAME_RELEASE_DETAIL),
-    EDIT(PortalConstants.PAGENAME_EDIT);
+    EDIT(PortalConstants.PAGENAME_EDIT),
+    CLEARING_REQUEST_DETAIL(PortalConstants.PAGENAME_DETAIL_CLEARING_REQUEST);
 
     private final String pagename;
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
@@ -123,7 +123,7 @@ abstract public class Sw360Portlet extends MVCPortlet {
     }
 
     protected void renderRequestSummary(PortletRequest request, MimeResponse response, RequestSummary requestSummary, JSONObject jsonObject) {
-        jsonObject.put("result", requestSummary.requestStatus.toString());
+        jsonObject.put(PortalConstants.RESULT, requestSummary.requestStatus.toString());
         if (requestSummary.isSetTotalAffectedElements())
             jsonObject.put("totalAffectedObjects", requestSummary.totalAffectedElements);
         if (requestSummary.isSetTotalElements())
@@ -140,7 +140,7 @@ abstract public class Sw360Portlet extends MVCPortlet {
 
     protected void renderRequestStatus(PortletRequest request, MimeResponse response, RequestStatus requestStatus) {
         JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
-        jsonObject.put("result", requestStatus.toString());
+        jsonObject.put(PortalConstants.RESULT, requestStatus.toString());
         try {
             writeJSON(request, response, jsonObject);
         } catch (IOException e) {
@@ -150,7 +150,7 @@ abstract public class Sw360Portlet extends MVCPortlet {
 
     protected void renderRemoveModerationRequestStatus(PortletRequest request, MimeResponse response, RemoveModeratorRequestStatus status) {
         JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
-        jsonObject.put("result", status.toString());
+        jsonObject.put(PortalConstants.RESULT, status.toString());
         try {
             writeJSON(request, response, jsonObject);
         } catch (IOException e) {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortletUtils.java
@@ -11,13 +11,29 @@ package org.eclipse.sw360.portal.portlets.moderation;
 
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.thrift.ClearingRequestState;
+import org.eclipse.sw360.datahandler.thrift.Comment;
 import org.eclipse.sw360.datahandler.thrift.ModerationState;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationService;
+import org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.portal.common.PortalConstants;
 import org.eclipse.sw360.portal.users.UserCacheHolder;
+
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.portlet.LiferayPortletURL;
+import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
+
+import static java.lang.Integer.parseInt;
+
+import java.util.Optional;
 
 import javax.portlet.PortletRequest;
 
@@ -45,7 +61,72 @@ public class ModerationPortletUtils {
         return RequestStatus.FAILURE;
     }
 
+    public static RequestStatus addCommentToClearingRequest(PortletRequest request, Logger log) {
+        String id = request.getParameter(PortalConstants.CLEARING_REQUEST_ID);
+        String commentText = request.getParameter(PortalConstants.CLEARING_REQUEST_COMMENT);
+        if (CommonUtils.isNullEmptyOrWhitespace(commentText)) {
+            log.warn("Invalid comment, (empty or whitespace)");
+            return RequestStatus.FAILURE;
+        }
+        User user = UserCacheHolder.getUserFromRequest(request);
+        Comment comment = new Comment(commentText, user.getEmail());
+        try {
+            ModerationService.Iface client = new ThriftClients().makeModerationClient();
+            return client.addCommentToClearingRequest(id, comment, user);
+        } catch (TException e) {
+            log.error("failed to add comment in clearing reuest: " + id, e);
+        }
+        return RequestStatus.FAILURE;
+    }
+
+    public static RequestStatus updateClearingRequest(PortletRequest request, Logger log) {
+        String id = request.getParameter(PortalConstants.CLEARING_REQUEST_ID);
+        User user = UserCacheHolder.getUserFromRequest(request);
+        String agreedDate = request.getParameter(ClearingRequest._Fields.AGREED_CLEARING_DATE.toString());
+        String clearingTeamComment = request.getParameter(ClearingRequest._Fields.CLEARING_TEAM_COMMENT.toString());
+        String status = request.getParameter(ClearingRequest._Fields.CLEARING_STATE.toString());
+        if (null != id && null != agreedDate) {
+            try {
+                ModerationService.Iface client = new ThriftClients().makeModerationClient();
+                ClearingRequest clearingRequest = client.getClearingRequestByIdForEdit(id, user);
+                if (null == clearingRequest) {
+                    return RequestStatus.FAILURE;
+                }
+                clearingRequest.setAgreedClearingDate(agreedDate);
+                if (CommonUtils.isNotNullEmptyOrWhitespace(clearingTeamComment)) {
+                    clearingRequest.setClearingTeamComment(clearingTeamComment);
+                }
+                clearingRequest.setClearingState(ClearingRequestState.findByValue(parseInt(status)));
+                LiferayPortletURL projectUrl = getProjectPortletUrl(request);
+                if (null != projectUrl) {
+                    projectUrl.setParameter(PortalConstants.PROJECT_ID, clearingRequest.getProjectId());
+                    projectUrl.setParameter(PortalConstants.PAGENAME, PortalConstants.PAGENAME_DETAIL);
+                }
+                return client.updateClearingRequest(clearingRequest, user, CommonUtils.nullToEmptyString(projectUrl));
+            } catch (TException e) {
+                log.error("Failed to update clearing request", e);
+            }
+        }
+        log.error("Clearing request Id or Agreed clearing date cannot be null.");
+        return RequestStatus.FAILURE;
+    }
+
+    private static LiferayPortletURL getProjectPortletUrl(PortletRequest request) {
+        Portlet portlet = PortletLocalServiceUtil.getPortletById(PortalConstants.PROJECT_PORTLET_NAME);
+        Optional<Layout> layout = LayoutLocalServiceUtil.getLayouts(portlet.getCompanyId()).stream()
+                .filter(l -> ("/" + PortalConstants.PROJECTS.toLowerCase()).equals(l.getFriendlyURL())).findFirst();
+        if (layout.isPresent()) {
+            long plId = layout.get().getPlid();
+            return PortletURLFactoryUtil.create(request, PortalConstants.PROJECT_PORTLET_NAME, plId, PortletRequest.RENDER_PHASE);
+        }
+        return null;
+    }
+
     public static boolean isOpenModerationRequest(ModerationRequest mr) {
         return mr.getModerationState() == ModerationState.PENDING || mr.getModerationState() == ModerationState.INPROGRESS;
+    }
+
+    public static boolean isClosedClearingRequest(ClearingRequest cr) {
+        return cr.getClearingState() == ClearingRequestState.CLOSED;
     }
 }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToClearingRequest.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/links/DisplayLinkToClearingRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ * With contributions by Siemens Healthcare Diagnostics Inc, 2018.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.portal.tags.links;
+
+import static org.eclipse.sw360.portal.tags.urlutils.UrlWriterImpl.renderUrl;
+
+import javax.servlet.jsp.JspException;
+
+import org.eclipse.sw360.portal.common.PortalConstants;
+import org.eclipse.sw360.portal.common.page.PortletDefaultPage;
+import org.eclipse.sw360.portal.portlets.LinkToPortletConfiguration;
+
+/**
+ * @author abdul.mannankapti@siemens.com
+ */
+public class DisplayLinkToClearingRequest extends DisplayLinkAbstract {
+    private String clearingRequestId;
+
+    public void setClearingRequestId(String clearingRequestId) {
+        this.clearingRequestId = clearingRequestId;
+    }
+
+    @Override
+    protected String getTextDisplay() {
+        return clearingRequestId;
+    }
+
+    @Override
+    protected void writeUrl() throws JspException {
+        renderUrl(pageContext)
+                .toPortlet(LinkToPortletConfiguration.MODERATION, scopeGroupId)
+                .toPage(PortletDefaultPage.CLEARING_REQUEST_DETAIL)
+                .withParam(PortalConstants.CLEARING_REQUEST_ID, clearingRequestId)
+                .writeUrlToJspWriter();
+    }
+}

--- a/frontend/sw360-portlet/src/main/resources/META-INF/customTags.tld
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/customTags.tld
@@ -729,6 +729,23 @@
         </attribute>
     </tag>
     <tag>
+        <name>DisplayClearingRequestLink</name>
+        <tag-class>org.eclipse.sw360.portal.tags.links.DisplayLinkToClearingRequest</tag-class>
+        <body-content>JSP</body-content>
+        <attribute>
+            <name>clearingRequestId</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <name>bare</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+    </tag>
+    <tag>
         <name>ProjectName</name>
         <tag-class>org.eclipse.sw360.portal.tags.ProjectName</tag-class>
         <body-content>empty</body-content>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/components/_table.scss
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/components/_table.scss
@@ -59,8 +59,13 @@ table.table-lowspace {
 }
 
 table  {
-	td .form-group {
-		margin-bottom: 0;
+	td {
+        .form-group {
+            margin-bottom: 0;
+        }
+        .comment-text {
+            white-space: pre-wrap;
+        }
 	}
 
 	&.aligned-top td {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/components/_tooltips.scss
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/components/_tooltips.scss
@@ -348,6 +348,35 @@
     content: "A person who has received the moderation request (which could be creator of the document, a clearing admin, a moderator, etc.) has opened / viewed the moderation request, but did not decide.";
 }
 
+/** ClearingRequestState **/
+.sw360-tt-ClearingRequestState:hover:after {
+    content: "New: CR is pending to be Accepted by the Clearing Team.\A A sanity check for the artifacts required for Clearing will be done prior to Accepting a CR. \A Accepted: CR has passed SanityCheck and is accepted into the clearing queue. \A Rejected: CR has failed SanityCheck. Contact Clearing Team. \A In Queue: CR is next in queue for clearing. \A In Progress: CR is being worked on by the clearing team. \A Closed: Clearings requested in the CR is complete.";
+}
+
+.sw360-tt-ClearingRequestState-NEW:hover:after {
+    content: "CR is pending to be Accepted by the Clearing Team.\A A sanity check for the artifacts required for Clearing will be done prior to Accepting a CR.";
+}
+
+.sw360-tt-ClearingRequestState-ACCEPTED:hover:after {
+    content: "CR has passed SanityCheck and is accepted into the clearing queue.";
+}
+
+.sw360-tt-ClearingRequestState-REJECTED:hover:after {
+    content: "CR has failed SanityCheck. Contact Clearing Team.";
+}
+
+.sw360-tt-ClearingRequestState-INQUEUE:hover:after {
+    content: "CR is next in queue for clearing.";
+}
+
+.sw360-tt-ClearingRequestState-INPROGRESS:hover:after {
+    content: "CR is being worked on by the clearing team.";
+}
+
+.sw360-tt-ClearingRequestState-CLOSED:hover:after {
+    content: "Clearings requested in the CR is complete.";
+}
+
 /** ProjectRelationShip **/
 .sw360-tt-ProjectRelationship:hover:after {
     content: "Unknown: \A Duplicate: \A Contained: \A Refered: ";

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/clearing/clearingRequest.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/clearing/clearingRequest.jsp
@@ -1,0 +1,368 @@
+<%--
+  ~ Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  --%>
+
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions"%>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+
+<%@ include file="/html/init.jsp"%>
+<%@ include file="/html/utils/includes/logError.jspf" %>
+<%@ include file="/html/utils/includes/requirejs.jspf" %>
+<%@ include file="/html/utils/includes/errorKeyToMessage.jspf"%>
+
+<%@page import="org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest"%>
+<%@page import="org.eclipse.sw360.datahandler.thrift.ClearingRequestState"%>
+<%@page import="org.eclipse.sw360.portal.common.PortalConstants"%>
+
+<portlet:defineObjects/>
+<liferay-theme:defineObjects/>
+
+<jsp:useBean id="clearingRequest" class="org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest" scope="request"/>
+<jsp:useBean id="project" class="java.lang.String" scope="request"/>
+<jsp:useBean id="writeAccessUser" type="java.lang.Boolean" scope="request"/>
+<jsp:useBean id="printDate" class="java.util.Date"/>
+
+<core_rt:if test="${not empty clearingRequest.id}">
+
+<core_rt:set var="clearingRequestId"  value="${clearingRequest.id}" />
+
+<portlet:actionURL var="updateClearingRequestURL" name="updateClearingRequest">
+    <portlet:param name="<%=PortalConstants.CLEARING_REQUEST_ID%>" value="${clearingRequestId}"/>
+</portlet:actionURL>
+
+<portlet:renderURL var="cancelURL">
+    <portlet:param name="<%=PortalConstants.PAGENAME%>" value="<%=PortalConstants.PAGENAME_VIEW%>" />
+</portlet:renderURL>
+
+<portlet:renderURL var="editlURL">
+    <portlet:param name="<%=PortalConstants.PAGENAME%>" value="<%=PortalConstants.PAGENAME_EDIT_CLEARING_REQUEST%>" />
+    <portlet:param name="<%=PortalConstants.CLEARING_REQUEST_ID%>" value="${clearingRequestId}"/>
+</portlet:renderURL>
+
+<portlet:resourceURL var="addCommentUrl">
+    <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.ADD_COMMENT%>'/>
+    <portlet:param name="<%=PortalConstants.CLEARING_REQUEST_ID%>" value="${clearingRequestId}"/>
+</portlet:resourceURL>
+
+<core_rt:set var="pageName"  value="<%= request.getParameter("pagename") %>" />
+<core_rt:set var="user" value="<%=themeDisplay.getUser()%>"/>
+<core_rt:set var="isRequestingUser" value='${clearingRequest.requestingUser eq user.emailAddress}'/>
+<core_rt:set var="isClearingTeam" value='${clearingRequest.clearingTeam eq user.emailAddress}'/>
+<core_rt:set var="isClosedOrRejected" value="${clearingRequest.clearingState eq 'CLOSED' or clearingRequest.clearingState eq 'REJECTED' or empty project}"/>
+<core_rt:set var="isEditableForClearingTeam" value="${isClearingTeam and not isClosedOrRejected and pageName eq 'editClearingRequest'}"/>
+
+<div class="container" id="clearing-request">
+<div class="row portlet-toolbar">
+    <div class="col-auto">
+        <div class="btn-toolbar" role="toolbar">
+            <core_rt:if test="${pageName eq 'detailClearingRequest' and not empty project and isClearingTeam and not isClosedOrRejected}">
+                <div class="btn-group" role="group">
+                    <button type="button" class="btn btn-primary" onclick="window.location.href='<%=editlURL%>' + window.location.hash">Edit Request</button>
+                </div>
+            </core_rt:if>
+            <core_rt:if test="${isEditableForClearingTeam}">
+	           <div class="btn-group" role="group">
+	               <button type="button" id="formSubmit" class="btn btn-primary">Update Request</button>
+	           </div>
+	           <div class="btn-group" role="group">
+                   <button type="button" class="btn btn-light" onclick="window.location.href='<%=cancelURL%>' + window.location.hash">Cancel</button>
+               </div>
+	        </core_rt:if>
+        </div>
+    </div>
+    <div class="col portlet-title text-truncate" title="${clearingRequestId}">
+        ${clearingRequestId}
+    </div>
+</div>
+
+<div class="row">
+    <div class="col">
+        <div id="clearing-wizard" class="accordion">
+            <div class="card">
+                <form id="updateCRForm" name="updateCRForm" action="<%=updateClearingRequestURL%>" class="needs-validation" method="post" novalidate>
+                    <div id="clearing-header-heading" class="card-header">
+                        <h2 class="mb-0">
+                            <button class="btn btn-secondary btn-block" type="button" data-toggle="collapse" data-target="#clearing-header" aria-expanded="true" aria-controls="clearing-header">
+                                <svg class="lexicon-icon"><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#info-circle"/></svg>
+                                <core_rt:choose>
+                                    <core_rt:when test="${not empty project}">
+                                        Clearing request information for project: <a href="<sw360:DisplayProjectLink projectId="${clearingRequest.projectId}" bare="true" />"><sw360:out value="${project}" maxChar="50"/></a>
+                                    </core_rt:when>
+                                    <core_rt:otherwise>
+                                        Clearing request information for DELETED project:
+                                    </core_rt:otherwise>
+                                </core_rt:choose>
+                            </button>
+                        </h2>
+                    </div>
+                    <div id="clearing-header" class="collapse show" aria-labelledby="clearing-header-heading" data-parent="#clearing-wizard">
+                        <div class="card-body">
+                            <div class="row">
+                                <div class="col-6">
+                                    <table class="table label-value-table mt-2" id="clearingRequestData">
+                                        <thead>
+                                            <tr>
+                                                <th colspan="2">Clearing Request</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr>
+                                                <td><label class="form-group">Requesting user:</label></td>
+                                                <td><sw360:DisplayUserEmail email="${clearingRequest.requestingUser}" /></td>
+                                            </tr>
+                                            <tr>
+                                                <td><label class="form-group">Request submitted on:</label></td>
+                                                <td>
+                                                    <jsp:setProperty name="printDate" property="time" value="${clearingRequest.timestamp}"/>
+                                                    <fmt:formatDate value="${printDate}" pattern="yyyy-MM-dd"/>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td><label class="form-group">Requested clearing date:</label></td>
+                                                <td><sw360:out value="${clearingRequest.requestedClearingDate}" bare="true"/></td>
+                                            </tr>
+                                            <tr>
+                                                <td><label class="form-group">Project BU:</label></td>
+                                                <td><sw360:out value="${clearingRequest.projectBU}" bare="true"/></td>
+                                            </tr>
+                                            <tr>
+                                                <td><label class="form-group">Requester comment:</label></td>
+                                                <td><sw360:out value="${clearingRequest.requestingUserComment}" bare="true"/></td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                                <div class="col-6">
+                                    <table class="table label-value-table mt-2" id="clearingDecisionData">
+                                        <thead>
+                                            <tr>
+                                                <th colspan="2">Clearing Decision</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr>
+                                                <td><label class="form-group">Status:</label></td>
+                                                <td>
+                                                <core_rt:choose>
+                                                    <core_rt:when test="${isEditableForClearingTeam}">
+                                                        <select class="form-control"
+                                                            name="<portlet:namespace/><%=ClearingRequest._Fields.CLEARING_STATE%>">
+                                                            <sw360:DisplayEnumOptions type="<%=ClearingRequestState.class%>" selected="${clearingRequest.clearingState}"/>
+                                                        </select>
+                                                        <small class="form-text">
+                                                            <sw360:DisplayEnumInfo type="<%=ClearingRequestState.class%>"/>
+                                                            Learn more about clearing request status.
+                                                        </small>
+                                                    </core_rt:when>
+                                                    <core_rt:otherwise>
+                                                        <sw360:DisplayEnum value="${clearingRequest.clearingState}"/>
+                                                    </core_rt:otherwise>
+                                                </core_rt:choose>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td><label class="form-group">Clearing team:</label></td>
+                                                <td><sw360:DisplayUserEmail email="${clearingRequest.clearingTeam}" /></td>
+                                            </tr>
+                                            <tr>
+                                                <td>
+                                                    <label class="form-group <core_rt:if test='${isEditableForClearingTeam}'> mandatory</core_rt:if>">Agreed clearing date:</label>
+                                                </td>
+                                                <td>
+                                                <core_rt:choose>
+                                                    <core_rt:when test="${isEditableForClearingTeam}">
+                                                        <input class="form-control datepicker" required
+                                                            name="<portlet:namespace/><%=ClearingRequest._Fields.AGREED_CLEARING_DATE%>" type="text" pattern="\d{4}-\d{2}-\d{2}"
+                                                            value="<sw360:out value="${clearingRequest.agreedClearingDate}"/>" placeholder="Agreed clearing date YYYY-MM-DD"/>
+                                                    </core_rt:when>
+                                                    <core_rt:otherwise>
+                                                        <sw360:out value="${clearingRequest.agreedClearingDate}" bare="true"/>
+                                                    </core_rt:otherwise>
+                                                </core_rt:choose>
+                                                </td>
+                                            </tr>
+                                            <core_rt:if test="${clearingRequest.isSetTimestampOfDecision()}">
+                                                <tr>
+                                                    <td><label class="form-group">Request closed on:</label></td>
+                                                    <td>
+                                                        <jsp:setProperty name="printDate" property="time" value="${clearingRequest.timestampOfDecision}"/>
+                                                        <fmt:formatDate value="${printDate}" pattern="yyyy-MM-dd"/>
+                                                    </td>
+                                                </tr>
+                                            </core_rt:if>
+                                            <tr>
+                                                <td>
+                                                    <label class="form-group">
+                                                        Comment on clearing decision:
+                                                    </label>
+                                                </td>
+                                                <td>
+                                                <core_rt:choose>
+                                                    <core_rt:when test="${isEditableForClearingTeam and empty clearingRequest.clearingTeamComment}">
+                                                        <textarea name="<portlet:namespace/><%=ClearingRequest._Fields.CLEARING_TEAM_COMMENT%>" placeholder="Comment your decision..."
+                                                            class="form-control"><sw360:out value="${clearingRequest.clearingTeamComment}" /></textarea>
+                                                    </core_rt:when>
+                                                    <core_rt:otherwise>
+                                                        <sw360:out value="${clearingRequest.clearingTeamComment}" bare="true"/>
+                                                    </core_rt:otherwise>
+                                                </core_rt:choose>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <div class="card">
+                <div id="clearing-comments-heading" class="card-header">
+                    <h2 class="mb-0">
+                        <button class="btn btn-secondary btn-block" type="button" data-toggle="collapse" data-target="#clearing-comments" aria-expanded="false" aria-controls="clearing-comments">
+                            <svg class="lexicon-icon"><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#comments"/></svg>
+                                Clearing request comments: <span id="commentCount" class="badge badge-light text-dark"><sw360:out default="(0)" value="(${not empty clearingRequest.comments ? clearingRequest.comments.size() : '0'})"/></span>
+                        </button>
+                    </h2>
+                </div>
+                <div id="clearing-comments" class="collapse" aria-labelledby="clearing-comments-heading" data-parent="#clearing-wizard">
+                    <div class="card-body">
+                        <div class="m-auto">
+                            <table class="table label-value-table mt-2" id="clearingCommentsTable">
+                                <thead>
+                                    <tr><th>Comments</th></tr>
+                                <thead>
+                                <tbody>
+                                    <core_rt:forEach items="${clearingRequest.comments}" var="comment" varStatus="loop">
+                                        <tr>
+                                            <td>
+                                                <core_rt:set var="by" value="${comment.commentedBy}" />
+                                                <core_rt:set var="iconTextArray" value="${fn:split(by, '_|.')}"/>
+                                                <core_rt:set var="iconText" value="NA"/>
+                                                <core_rt:choose>
+                                                    <core_rt:when test="${fn:length(iconTextArray) gt 2}">
+                                                        <core_rt:set var="iconText" value="${fn:substring(iconTextArray[0], 0, 1)}${fn:substring(iconTextArray[1], 0, 1)}"/>
+                                                    </core_rt:when>
+                                                    <core_rt:otherwise>
+                                                        <core_rt:set var="iconText" value="${fn:substring(iconTextArray[0], 0, 1)}${fn:substring(iconTextArray[0], 1, 2)}"/>
+                                                    </core_rt:otherwise>
+                                                </core_rt:choose>
+                                                <jsp:setProperty name="printDate" property="time" value="${comment.commentedOn}"/>
+                                                <div class="m-auto row">
+                                                    <div class="col-0 user-icon user-icon-info text-uppercase"><span>${iconText}</span></div>
+                                                    <div class="col-11">
+                                                        <div class="comment-text"><sw360:out value="${comment.text}" stripNewlines="false" bare="true"/></div>
+                                                            <footer class="blockquote-footer">by <cite><b><sw360:DisplayUserEmail email="${by}"/></b></cite> on <cite>
+                                                                <b><fmt:formatDate value="${printDate}" pattern="yyyy-MM-dd HH:mm"/></b></cite>
+                                                            </footer>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                        </core_rt:forEach>
+                                        <tr>
+                                            <td>
+                                                <core_rt:if test="${not empty project and (isClearingTeam or writeAccessUser)}">
+	                                                <textarea id="clearingRequestComment" placeholder="Enter comment..." class="h-25 form-control"></textarea>
+	                                                <div class="mt-3 btn-group" role="group">
+	                                                    <button id="addComment" type="button" class="btn btn-success">Add comment</button>
+	                                                </div>
+	                                                <span id="addCommentStatusMessage" class="my-0 mb-0 alert alert-danger" style="display: none;"></span>
+                                                </core_rt:if>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="dialogs auto-dialogs"></div>
+
+<script>
+require(['jquery', 'modules/dialog', 'modules/validation', 'bridges/jquery-ui' ], function($, dialog, validation) {
+    validation.enableForm('#updateCRForm');
+    validation.jumpToFailedTab('#updateCRForm');
+
+    $('#formSubmit').click(
+        function() {
+            $('#updateCRForm').submit();
+        }
+    );
+
+    $('.datepicker').datepicker({
+        minDate: new Date(),
+        changeMonth: true,
+        changeYear: true,
+        dateFormat: "yy-mm-dd"
+    });
+
+    /* Add event listener for saving the comment */
+    $("#addComment").on("click", function (event) {
+
+        if (!$.trim($("#clearingRequestComment").val())) {
+            displayErrorMessage('Invalid comment!');
+            return;
+        }
+
+        let comment = $("#clearingRequestComment").val(),
+            email = '${user.emailAddress}',
+            by = '<sw360:DisplayUserEmail email="${user.emailAddress}"/>',
+            on = new Date().toISOString().slice(0,16).replace('T', ' '),
+            count = Number($('#commentCount').text().replace(/[()]/g, '')) + 1,
+            iconTextArray = email.split(/[_.]/),
+            iconText = 'NA';
+
+            if (iconTextArray.length > 2) {
+                iconText = iconTextArray[0].substring(0,1) + iconTextArray[1].substring(0,1);
+            } else {
+                iconText = iconTextArray[0].substring(0,1) + iconTextArray[0].substring(1,2);
+            }
+
+        jQuery.ajax({
+            type: 'POST',
+            url: '<%=addCommentUrl%>',
+            cache: false,
+            data: {
+                "<portlet:namespace/><%=PortalConstants.CLEARING_REQUEST_COMMENT%>": $("#clearingRequestComment").val()
+            },
+            success: function (data) {
+                if (data.result == 'SUCCESS') {
+                    $('#clearingRequestComment').val('');
+                    $('#commentCount').text('('+count+')');
+                    $('#clearingCommentsTable tbody tr:last')
+                        .before('<tr><td>'
+                                    +'<div class="m-auto row">'
+                                    +'<div class="col-0 user-icon user-icon-info text-uppercase"><span>'+iconText+'</span></div>'
+                                    +'<div class="col-11">'
+                                    +'<div class="comment-text">' + comment +'<footer class="blockquote-footer">by <cite><b>'+by+'</b></cite> on <cite><b>'+on+'</b></cite></footer></div>'
+                                    +'</div></div>'
+                                +'</td></tr>');
+                }
+                else {
+                    displayErrorMessage('Failed to add comment!');
+                }
+            },
+            error: function () {
+                displayErrorMessage('Error addimng comment to clearing request!');
+            }
+        });
+    });
+
+    function displayErrorMessage(message) {
+        $("#addCommentStatusMessage").html(message).show().delay(5000).fadeOut();
+    }
+});
+</script>
+</core_rt:if>
+

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/modules/dialog.js
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/modules/dialog.js
@@ -84,7 +84,7 @@ define('modules/dialog', [
 		$(this).find('.modal-title').html(title);
 	}
 
-	function open(selector, data, submitCallback, beforeShowFn, afterShowFn) {
+	function open(selector, data, submitCallback, beforeShowFn, afterShowFn, isHtml) {
 		var $dialog = $(selector);
 
 		if($dialog.length === 0) {
@@ -114,10 +114,17 @@ define('modules/dialog', [
 			var $dialog = $(this);
 
 			$dialog.find('[data-name]').text('');
+			if (isHtml) {
+					Object.keys(data).forEach(function(key) {
+					$dialog.find('[data-name="' + key + '"]').filter(':not(input)').html(data[key]);
+					$dialog.find('input[data-name="' + key + '"]').val(data[key]);
+				});
+			} else  {
 			Object.keys(data).forEach(function(key) {
 				$dialog.find('[data-name="' + key + '"]').filter(':not(input)').text(data[key]);
 				$dialog.find('input[data-name="' + key + '"]').val(data[key]);
 			});
+		}
 
 			$dialog.find('[data-hide]').show();
 			$dialog.find('[data-hide]').each(function(index, element) {
@@ -344,7 +351,7 @@ define('modules/dialog', [
 	return {
 		open: open,
 		confirm: confirm,
-		warn, warn,
+		warn: warn,
 		info: info
 	};
 });

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/modules/validation.js
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/modules/validation.js
@@ -115,6 +115,24 @@ define('modules/validation', [ 'jquery' ], function($) {
 
 			$field.on('change', matchFields);
 			$confirm.on('keyup', matchFields);
+		},
+
+		isValidDate: function isValidDate(dateString, greaterThanDays) {
+		    let pattern = /^\d{4}-\d{2}-\d{2}$/, currentDate = new Date();
+		    if (!dateString.match(pattern)) {
+		        return false; // Invalid format
+		    }
+		    let selectedDate = new Date(dateString), time = selectedDate.getTime();
+		    if (!time && time !== 0) {
+		        return false; // NaN value, Invalid date
+		    }
+		    if (greaterThanDays) {
+		        currentDate.setHours(0, 0, 0, 0);
+		        let currentTime = currentDate.getTime() + (greaterThanDays * 24 * 60 * 60 * 1000);
+		        if (currentTime > time)
+		            return false; // not greater then mentioned days
+		    }
+		    return selectedDate.toISOString().slice(0, 10) === dateString;
 		}
 	};
 });

--- a/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/moderation-friendly-url-routes.xml
+++ b/frontend/sw360-portlet/src/main/resources/org/eclipse/sw360/portal/mapper/moderation-friendly-url-routes.xml
@@ -18,4 +18,10 @@
         <generated-parameter name="moderationId">{id}</generated-parameter>
         <implicit-parameter name="p_p_id">sw360_portlet_moderations</implicit-parameter>
     </route>
+    <route>
+        <pattern>/clearing/{page}/{clearingId}</pattern>
+        <generated-parameter name="pagename">{page}</generated-parameter>
+        <generated-parameter name="clearingId">{clearingId}</generated-parameter>
+        <implicit-parameter name="p_p_id">sw360_portlet_moderations</implicit-parameter>
+    </route>
 </routes>

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -59,6 +59,7 @@ public class SW360Constants {
     public static final String TYPE_PROJECT = "project";
     public static final String TYPE_PROJECT_OBLIGATION = "projectObligation";
     public static final String TYPE_MODERATION = "moderation";
+    public static final String TYPE_CLEARING = "clearing";
 
     /**
      * Hashmap containing the name field for each type.

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
@@ -255,6 +255,15 @@ public class ThriftEnumUtils {
             ObligationStatus.IN_PROGRESS, "In Progress"
     );
 
+    private static final ImmutableMap<ClearingRequestState, String> MAP_CLEARING_REQUEST_STATE_STRING = ImmutableMap.<ClearingRequestState, String>builder()
+            .put(ClearingRequestState.NEW, "New")
+            .put(ClearingRequestState.ACCEPTED, "Accepted")
+            .put(ClearingRequestState.REJECTED, "Rejected")
+            .put(ClearingRequestState.IN_QUEUE, "In Queue")
+            .put(ClearingRequestState.IN_PROGRESS, "In Progress")
+            .put(ClearingRequestState.CLOSED, "Closed")
+            .build();
+
     public static final ImmutableMap<Class<? extends TEnum>, Map<? extends TEnum, String>>
             MAP_ENUMTYPE_MAP = ImmutableMap.<Class<? extends TEnum>, Map<? extends TEnum, String>>builder()
             .put(ComponentType.class, MAP_COMPONENT_TYPE_STRING)
@@ -279,6 +288,7 @@ public class ThriftEnumUtils {
             .put(ECCStatus.class, MAP_ECC_STATUS_STRING)
             .put(DocumentType.class, MAP_DOCUMENT_TYPE_STRING)
             .put(ObligationStatus.class, MAP_OBLIGATION_STATUS_STRING)
+            .put(ClearingRequestState.class, MAP_CLEARING_REQUEST_STATE_STRING)
             .build();
 
     public static String enumToString(TEnum value) {

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
@@ -22,6 +22,7 @@ import org.eclipse.sw360.datahandler.thrift.attachments.*;
 import org.eclipse.sw360.datahandler.thrift.components.*;
 import org.eclipse.sw360.datahandler.thrift.licenses.*;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
+import org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectObligation;
 import org.eclipse.sw360.datahandler.thrift.projects.UsedReleaseRelations;
@@ -55,7 +56,7 @@ public class ThriftUtils {
             .add(License.class).add(Todo.class).add(Obligation.class) // License service
             .add(LicenseType.class).add(Risk.class).add(RiskCategory.class) // License service
             .add(CustomProperties.class) // License service
-            .add(Project.class).add(ProjectObligation.class).add(UsedReleaseRelations.class) // Project service
+            .add(Project.class).add(ProjectObligation.class).add(UsedReleaseRelations.class).add(ClearingRequest.class)  // Project service
             .add(User.class) // User service
             .add(Vendor.class) // Vendor service
             .add(ModerationRequest.class) // Moderation service‚

--- a/libraries/lib-datahandler/src/main/thrift/moderation.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/moderation.thrift
@@ -21,6 +21,7 @@ namespace php sw360.thrift.moderation
 typedef sw360.RequestStatus RequestStatus
 typedef sw360.RemoveModeratorRequestStatus RemoveModeratorStatus
 typedef sw360.ModerationState ModerationState
+typedef sw360.Comment Comment
 typedef components.Component Component
 typedef components.Release Release
 typedef projects.Project Project
@@ -28,6 +29,7 @@ typedef users.User User
 typedef licenses.License License
 typedef licenses.Todo Todo
 typedef components.ComponentType ComponentType
+typedef projects.ClearingRequest ClearingRequest
 
 enum DocumentType {
     COMPONENT = 1,
@@ -199,4 +201,44 @@ service ModerationService {
      * delete moderation request specified by id if user is requesting user of moderation request
      **/
     RequestStatus deleteModerationRequest(1: string id, 2: User user);
+
+    /**
+     * write clearing request for project to database
+     **/
+    string createClearingRequest(1: ClearingRequest clearingRequest, 2: User user);
+
+    /**
+     * update clearing request in database
+     **/
+    RequestStatus updateClearingRequest(1: ClearingRequest clearingRequest, 2: User user, 3: string projectUrl);
+
+    /**
+     * get list of clearing requests where user is requesting user or clearing team
+     **/
+    set<ClearingRequest> getMyClearingRequests(1: User user);
+
+    /**
+     * get clearing request by project Id
+     **/
+    ClearingRequest getClearingRequestByProjectId(1: string projectId);
+
+    /**
+     * update clearing request for associated project deletion
+     **/
+    oneway void updateClearingRequestForProjectDeletion(1: Project project, 2: User user);
+
+    /**
+     * get clearing request by Id for view/read
+     **/
+    ClearingRequest getClearingRequestById(1: string id, 2: User user);
+
+    /**
+     * get clearing request by Id for edit
+     **/
+    ClearingRequest getClearingRequestByIdForEdit(1: string id, 2: User user);
+
+    /**
+     * add comment to clearing request
+     **/
+    RequestStatus addCommentToClearingRequest(1: string id, 2: Comment comment, 3: User user);
 }

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -13,7 +13,6 @@ include "attachments.thrift"
 include "vendors.thrift"
 include "components.thrift"
 include "sw360.thrift"
-include "commonobligations.thrift"
 include "licenses.thrift"
 
 namespace java org.eclipse.sw360.datahandler.thrift.projects
@@ -28,6 +27,8 @@ typedef sw360.MainlineState MainlineState
 typedef sw360.ProjectReleaseRelationship ProjectReleaseRelationship
 typedef sw360.ObligationStatus ObligationStatus
 typedef sw360.SW360Exception SW360Exception
+typedef sw360.ClearingRequestState ClearingState
+typedef sw360.Comment Comment
 typedef components.Release Release
 typedef components.ReleaseClearingStateSummary ReleaseClearingStateSummary
 typedef users.User User
@@ -135,6 +136,7 @@ struct Project {
 
     // Information for ModerationRequests
     70: optional DocumentState documentState,
+    80: optional string clearingRequestId,
 
     // Optional fields for summaries!
 //    100: optional set<string> releaseIds, //deleted
@@ -199,6 +201,27 @@ struct UsedReleaseRelations {
     3: optional string type = "usedReleaseRelation",
     4: required string projectId,
     5: optional set<ReleaseRelationship> usedReleaseRelations = [],
+}
+
+struct ClearingRequest {
+    // Basic information
+    1: optional string id,
+    2: optional string revision,
+    3: optional string type = "clearingRequest",
+
+    // Clearing Request
+    5: required string requestedClearingDate, // date YYYY-MM-dd
+    6: optional string projectId,
+    7: required ClearingState clearingState,
+    8: required string requestingUser,
+    9: optional string projectBU,
+    10: optional string requestingUserComment,
+    11: required string clearingTeam,
+    12: optional string clearingTeamComment,
+    13: optional string agreedClearingDate,
+    14: required i64 timestamp,
+    15: optional i64 timestampOfDecision,
+    16: optional list<Comment> comments
 }
 
 service ProjectService {
@@ -413,4 +436,9 @@ service ProjectService {
      * parse a bom file and write the information to SW360
      **/
     RequestSummary importBomFromAttachmentContent(1: User user, 2:string attachmentContentId);
+
+    /**
+     * create clearing request for project
+     */
+    AddDocumentRequestSummary createClearingRequest(1: ClearingRequest clearingRequest, 2: User user, 3: string projectUrl);
 }

--- a/libraries/lib-datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/sw360.thrift
@@ -54,7 +54,16 @@ enum ModerationState {
     PENDING = 0,
     APPROVED = 1,
     REJECTED = 2,
-    INPROGRESS =3,
+    INPROGRESS = 3,
+}
+
+enum ClearingRequestState {
+    NEW = 0,
+    ACCEPTED = 1,
+    REJECTED = 2,
+    IN_QUEUE = 3,
+    IN_PROGRESS = 4,
+    CLOSED = 5
 }
 
 enum Visibility {
@@ -102,6 +111,12 @@ enum ObligationStatus {
     IN_PROGRESS = 2,
 }
 
+enum ClearingRequestEmailTemplate {
+    NEW = 0,
+    UPDATED = 1,
+    PROJECT_UPDATED = 2,
+}
+
 struct ConfigContainer {
     1: optional string id,
     2: optional string revision,
@@ -136,6 +151,7 @@ struct RequestSummary {
 struct AddDocumentRequestSummary {
     1: optional AddDocumentRequestStatus requestStatus;
     2: optional string id;
+    3: optional string message;
 }
 
 struct CustomProperties {
@@ -149,6 +165,12 @@ struct CustomProperties {
 struct RequestStatusWithBoolean {
   1: required RequestStatus requestStatus;
   2: optional bool answerPositive;
+}
+
+struct Comment {
+    1: required string text,
+    2: required string commentedBy,
+    3: optional i64 commentedOn // timestamp of comment
 }
 
 /**

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -156,7 +156,9 @@ class JacksonCustomizations {
                 "additionalDataSize",
                 "setAdditionalData",
                 "setLinkedObligationId",
-                "linkedObligationId"
+                "linkedObligationId",
+                "clearingRequestId",
+                "setClearingRequestId"
         })
         static abstract class ProjectMixin extends Project {
 


### PR DESCRIPTION
Completed:
* Create clearing request for project (user with `WRITE` access to project and all user with role `CLEARING_ADMIN` and above are allowed to create clearing request.) by clicking on 'check-square` icon in `Project list` page.
* CR cannot be created for `PRIVATE` and `CLOSED` projects.
* View and edit clearing request in `moderation` portlet -> `clearing request` tab.
* Commenting system in each CR.
* `RequestingUser` and user with `WRITE` access to project are allowed to add `comments` to `CR`.
* `ClearingTeam` is allowed to `EDIT` the status of a `CR` and add `comments`.
* Any user with `READ` access to project can `view` the CR.
* Creating new CR and updating existing CR (change in CR `status` or `Accepted Clearing Date`) will trigger an email to requesting user / clearing team. (also updating a CR will be logged in comments section.)
* Trigger email whenever there is change in `linked releases` of a project with `CR`. (this information will also be logged in CR comments section.)
* Friendly url to `edit` CR: `group/guest/moderation/-/moderation/clearing/editClearingRequest/<clearingRequestId>`
* Friendly url to `view` CR: `group/guest/moderation/-/moderation/clearing/detailClearingRequest/<clearingRequestId>`

<br>

closes #722 
Signed-off-by: Abdul Kapti <abdul.mannankapti@siemens.com>