### PR TITLE
fix(UI/REST): Remove Trailing and leading whitespace for all fields in component, release and project

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtil.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtil.java
@@ -11,14 +11,21 @@ package org.eclipse.sw360.datahandler.db;
 
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseRepository;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.components.COTSDetails;
+import org.eclipse.sw360.datahandler.thrift.components.ClearingInformation;
+import org.eclipse.sw360.datahandler.thrift.components.Component;
+import org.eclipse.sw360.datahandler.thrift.components.EccInformation;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -125,4 +132,111 @@ public class DatabaseHandlerUtil {
         return true;
     }
 
+    public static Set<String> trimSetOfString(Set<String> setOfString) {
+        if (setOfString != null) {
+            setOfString = setOfString.stream().filter(str -> CommonUtils.isNotNullEmptyOrWhitespace(str))
+                    .map(str -> str.trim()).collect(Collectors.toSet());
+        }
+        return setOfString;
+    }
+
+    public static Set<Attachment> trimSetOfAttachement(Set<Attachment> setOfAttachment) {
+        if (setOfAttachment != null) {
+            setOfAttachment = setOfAttachment.stream().filter(attachment -> attachment != null).map(attachment -> {
+                String createdComment = attachment.getCreatedComment();
+                if (createdComment != null) {
+                    attachment.setCreatedComment(createdComment.trim());
+                }
+                String checkedComment = attachment.getCheckedComment();
+                if (checkedComment != null) {
+                    attachment.setCheckedComment(checkedComment.trim());
+                }
+                return attachment;
+            }).collect(Collectors.toSet());
+        }
+        return setOfAttachment;
+    }
+
+    public static Map<String, String> trimMapOfStringKeyStringValue(Map<String, String> mapOfStringKeyStringValue) {
+        if (mapOfStringKeyStringValue != null) {
+            mapOfStringKeyStringValue = mapOfStringKeyStringValue.entrySet().stream()
+                    .filter(entry -> CommonUtils.isNotNullEmptyOrWhitespace(entry.getKey())
+                            && CommonUtils.isNotNullEmptyOrWhitespace(entry.getValue()))
+                    .collect(Collectors.toMap(entry -> entry.getKey().trim(), entry -> {
+                        String value = entry.getValue();
+                        if (value != null) {
+                            value = value.trim();
+                        }
+                        return value;
+                    }));
+        }
+        return mapOfStringKeyStringValue;
+    }
+
+    public static Map<String, Set<String>> trimMapOfStringKeySetValue(Map<String, Set<String>> mapOfStringKeySetValue) {
+        if (mapOfStringKeySetValue != null) {
+            mapOfStringKeySetValue = mapOfStringKeySetValue.entrySet().stream()
+                    .filter(entry -> CommonUtils.isNotNullEmptyOrWhitespace(entry.getKey())).map(entry -> {
+                        Set<String> value = entry.getValue();
+                        if (value != null) {
+                            Set<String> filteredValue = value.stream()
+                                    .filter(valueItem -> CommonUtils.isNotNullEmptyOrWhitespace(valueItem))
+                                    .map(valueItem -> valueItem.trim()).collect(Collectors.toSet());
+                            entry.setValue(filteredValue);
+                        }
+
+                        return entry;
+                    }).filter(entry -> entry.getValue() != null && !entry.getValue().isEmpty())
+                    .collect(Collectors.toMap(entry -> entry.getKey().trim(), entry -> entry.getValue()));
+        }
+        return mapOfStringKeySetValue;
+    }
+
+    public static <T, R> void trimStringFields(T obj, List<R> listOfStrFields) {
+        listOfStrFields.forEach(strField -> {
+            if (obj instanceof Component) {
+                Component._Fields compField = (Component._Fields) strField;
+                Component comp = (Component) obj;
+                Object fieldValueObj = comp.getFieldValue(compField);
+                if (fieldValueObj instanceof String) {
+                    comp.setFieldValue(compField, fieldValueObj.toString().trim());
+                }
+            } else if (obj instanceof Release) {
+                Release._Fields releaseField = (Release._Fields) strField;
+                Release release = (Release) obj;
+                Object fieldValueObj = release.getFieldValue(releaseField);
+                if (fieldValueObj instanceof String) {
+                    release.setFieldValue(releaseField, fieldValueObj.toString().trim());
+                }
+            } else if (obj instanceof Project) {
+                Project._Fields projField = (Project._Fields) strField;
+                Project proj = (Project) obj;
+                Object fieldValueObj = proj.getFieldValue(projField);
+                if (fieldValueObj instanceof String) {
+                    proj.setFieldValue(projField, fieldValueObj.toString().trim());
+                }
+            } else if (obj instanceof ClearingInformation) {
+                ClearingInformation._Fields clearingInformationField = (ClearingInformation._Fields) strField;
+                ClearingInformation clearingInformation = (ClearingInformation) obj;
+                Object fieldValueObj = clearingInformation.getFieldValue(clearingInformationField);
+                if (fieldValueObj instanceof String) {
+                    clearingInformation.setFieldValue(clearingInformationField, fieldValueObj.toString().trim());
+                }
+            } else if (obj instanceof COTSDetails) {
+                COTSDetails._Fields cotsDetailsField = (COTSDetails._Fields) strField;
+                COTSDetails cotsDetails = (COTSDetails) obj;
+                Object fieldValueObj = cotsDetails.getFieldValue(cotsDetailsField);
+                if (fieldValueObj instanceof String) {
+                    cotsDetails.setFieldValue(cotsDetailsField, fieldValueObj.toString().trim());
+                }
+            } else if (obj instanceof EccInformation) {
+                EccInformation._Fields eccInformationField = (EccInformation._Fields) strField;
+                EccInformation eccInformation = (EccInformation) obj;
+                Object fieldValueObj = eccInformation.getFieldValue(eccInformationField);
+                if (fieldValueObj instanceof String) {
+                    eccInformation.setFieldValue(eccInformationField, fieldValueObj.toString().trim());
+                }
+            }
+        });
+    }
 }

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/ComponentHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/ComponentHandlerTest.java
@@ -54,6 +54,7 @@ public class ComponentHandlerTest {
     public void testGetByUploadId() throws Exception {
 
         Component originalComponent = new Component("name").setDescription("a desc").setComponentType(ComponentType.OSS);
+        originalComponent.addToCategories("Library");
         String componentId = componentHandler.addComponent(originalComponent, adminUser).getId();
 
         Release release = new Release("name", "version", componentId);

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -58,6 +58,8 @@ public class ComponentDatabaseHandlerTest {
     private static final String email1 = "cedric.bodet@tngtech.com";
     private static final String email2 = "johannes.najjar@tngtech.com";
 
+    private static final String category = "Mobile";
+
     private static final User user1 = new User().setEmail(email1).setDepartment("AB CD EF").setId("481489458");
     private static final User user2 = new User().setEmail(email2).setDepartment("AB CD EF").setId("4786487647680");
 
@@ -94,15 +96,18 @@ public class ComponentDatabaseHandlerTest {
         Component component1 = new Component().setId("C1").setName("component1").setDescription("d1").setCreatedBy(email1).setMainLicenseIds(new HashSet<>(Arrays.asList("lic1"))).setCreatedOn("2017-07-20");
         component1.addToReleaseIds("R1A");
         component1.addToReleaseIds("R1B");
+        component1.addToCategories(category);
         components.add(component1);
         Component component2 = new Component().setId("C2").setName("component2").setDescription("d2").setCreatedBy(email2).setMainLicenseIds(new HashSet<>(Arrays.asList("lic2"))).setCreatedOn("2017-07-21");
         component2.addToReleaseIds("R2A");
         component2.addToReleaseIds("R2B");
         component2.addToReleaseIds("R2C");
+        component2.addToCategories(category);
         components.add(component2);
         Component component3 = new Component().setId("C3").setName("component3").setDescription("d3").setCreatedBy(email1).setMainLicenseIds(new HashSet<>(Arrays.asList("lic3"))).setCreatedOn("2017-07-22");
         component3.addToSubscribers(email1);
         component3.addToLanguages("E");
+        component3.addToCategories(category);
         components.add(component3);
 
         releases = new ArrayList<>();
@@ -150,7 +155,7 @@ public class ComponentDatabaseHandlerTest {
     @Test
     public void testGetComponentByReleaseId() throws Exception {
         Component component = new Component().setId("Linking").setName("Linking").setDescription("d1").setCreatedBy(email1);
-
+        component.addToCategories(category);
         final HashMap<String, ReleaseRelationship> releaseLink = new HashMap<>();
 
         releaseLink.put("R1A", ReleaseRelationship.CONTAINED);
@@ -171,7 +176,7 @@ public class ComponentDatabaseHandlerTest {
     @Test
     public void testGetComponentByReleaseIds() throws Exception {
         Component component = new Component().setId("Linking").setName("Linking").setDescription("d1").setCreatedBy(email1);
-
+        component.addToCategories(category);
         final HashMap<String, ReleaseRelationship> releaseLink = new HashMap<>();
 
         releaseLink.put("R1A", ReleaseRelationship.CONTAINED);
@@ -480,6 +485,7 @@ public class ComponentDatabaseHandlerTest {
     @Test
     public void testDontDeleteComponentWithReleaseContained() throws Exception {
         Component component = new Component().setId("Del").setName("delete").setDescription("d1").setCreatedBy(email1);
+        component.addToCategories(category);
         Release release = new Release().setId("DelR").setComponentId("Del").setName("delete Release").setVersion("1.0").setCreatedBy(email1).setVendorId("V1").setClearingState(ClearingState.NEW_CLEARING);
 
         handler.addComponent(component, email1);
@@ -571,6 +577,7 @@ public class ComponentDatabaseHandlerTest {
     @Test
     public void testAddComponent() throws Exception {
         Component expected = new Component().setName("NEW_CLEARING");
+        expected.addToCategories(category);
         Release release = new Release().setName("REL").setVersion("VER");
         expected.addToReleases(release);
 
@@ -610,6 +617,7 @@ public class ComponentDatabaseHandlerTest {
 
         {
             Component component = new Component().setId(componentId).setName("component4").setDescription("d4").setCreatedBy(email1);
+            component.addToCategories(category);
             handler.addComponent(component, email1);
         }
 
@@ -658,6 +666,7 @@ public class ComponentDatabaseHandlerTest {
 
         {
             Component component = new Component().setId(componentId).setName("component4").setDescription("d4").setCreatedBy(email1);
+            component.addToCategories(category);
             handler.addComponent(component, email1);
         }
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
@@ -18,12 +18,14 @@ public class ErrorMessages {
 
     public static final String PROJECT_NOT_ADDED = "Project could not be added.";
     public static final String PROJECT_DUPLICATE = "A project with the same name and version already exists.";
+    public static final String PROJECT_NAMING_ERROR = "Name of project cannot contain only space characters.";
     public static final String CLOSED_UPDATE_NOT_ALLOWED = "User cannot edit a closed project";
     public static final String COMPONENT_NOT_ADDED = "Component could not be added.";
     public static final String COMPONENT_DUPLICATE = "A component with the same name already exists.";
-    public static final String COMPONENT_NAMING_ERROR = "Name of component cannot contain only space characters.";
+    public static final String COMPONENT_NAMING_ERROR = "Name and Categories of component cannot contain only space characters.";
     public static final String RELEASE_NOT_ADDED = "Release could not be added.";
     public static final String RELEASE_DUPLICATE = "A release with the same name and version already exists.";
+    public static final String RELEASE_NAME_VERSION_ERROR = "Name and version of release cannot contain only space characters.";
     public static final String DUPLICATE_ATTACHMENT = "Multiple attachments with same name or content cannot be present in attachment list.";
     public static final String ERROR_GETTING_PROJECT = "Error fetching project from backend.";
     public static final String ERROR_GETTING_COMPONENT = "Error fetching component from backend.";
@@ -57,12 +59,14 @@ public class ErrorMessages {
     public static final ImmutableList<String> allErrorMessages = ImmutableList.<String>builder()
             .add(PROJECT_NOT_ADDED)
             .add(PROJECT_DUPLICATE)
+            .add(PROJECT_NAMING_ERROR)
             .add(CLOSED_UPDATE_NOT_ALLOWED)
             .add(COMPONENT_NOT_ADDED)
             .add(COMPONENT_DUPLICATE)
             .add(COMPONENT_NAMING_ERROR)
             .add(RELEASE_NOT_ADDED)
             .add(RELEASE_DUPLICATE)
+            .add(RELEASE_NAME_VERSION_ERROR)
             .add(DUPLICATE_ATTACHMENT)
             .add(LICENSE_USED_BY_RELEASE)
             .add(DOCUMENT_USED_BY_PROJECT_OR_RELEASE)

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
@@ -301,6 +301,7 @@ abstract public class Sw360Portlet extends MVCPortlet {
             break;
         case DUPLICATE:
         case DUPLICATE_ATTACHMENT:
+        case NAMINGERROR:
             // just break to not throw an exception, error message has to be set by caller
             // because of type specific error messages
             break;

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -1522,9 +1522,12 @@ public class ComponentPortlet extends FossologyAwarePortlet {
                 user.setCommentMadeDuringModerationRequest(ModerationRequestCommentMsg);
                 RequestStatus requestStatus = client.updateComponent(component, user);
                 setSessionMessage(request, requestStatus, "Component", "update", component.getName());
-                if (RequestStatus.DUPLICATE.equals(requestStatus) || RequestStatus.DUPLICATE_ATTACHMENT.equals(requestStatus)) {
+                if (RequestStatus.DUPLICATE.equals(requestStatus) || RequestStatus.DUPLICATE_ATTACHMENT.equals(requestStatus) ||
+                        RequestStatus.NAMINGERROR.equals(requestStatus)) {
                     if(RequestStatus.DUPLICATE.equals(requestStatus))
                         setSW360SessionError(request, ErrorMessages.COMPONENT_DUPLICATE);
+                    else if (RequestStatus.NAMINGERROR.equals(requestStatus))
+                        setSW360SessionError(request, ErrorMessages.COMPONENT_NAMING_ERROR);
                     else
                         setSW360SessionError(request, ErrorMessages.DUPLICATE_ATTACHMENT);
                     response.setRenderParameter(PAGENAME, PAGENAME_EDIT);
@@ -1609,9 +1612,12 @@ public class ComponentPortlet extends FossologyAwarePortlet {
 
                     RequestStatus requestStatus = client.updateRelease(release, user);
                     setSessionMessage(request, requestStatus, "Release", "update", printName(release));
-                    if (RequestStatus.DUPLICATE.equals(requestStatus) || RequestStatus.DUPLICATE_ATTACHMENT.equals(requestStatus)) {
+                    if (RequestStatus.DUPLICATE.equals(requestStatus) || RequestStatus.DUPLICATE_ATTACHMENT.equals(requestStatus) ||
+                            RequestStatus.NAMINGERROR.equals(requestStatus)) {
                         if(RequestStatus.DUPLICATE.equals(requestStatus))
                             setSW360SessionError(request, ErrorMessages.RELEASE_DUPLICATE);
+                        else if (RequestStatus.NAMINGERROR.equals(requestStatus))
+                            setSW360SessionError(request, ErrorMessages.RELEASE_NAME_VERSION_ERROR);
                         else
                             setSW360SessionError(request, ErrorMessages.DUPLICATE_ATTACHMENT);
                         response.setRenderParameter(PAGENAME, PAGENAME_EDIT_RELEASE);
@@ -1665,6 +1671,11 @@ public class ComponentPortlet extends FossologyAwarePortlet {
                             break;
                         case DUPLICATE:
                             setSW360SessionError(request, ErrorMessages.RELEASE_DUPLICATE);
+                            response.setRenderParameter(PAGENAME, PAGENAME_EDIT_RELEASE);
+                            prepareRequestForReleaseEditAfterDuplicateError(request, release);
+                            break;
+                        case NAMINGERROR:
+                            setSW360SessionError(request, ErrorMessages.RELEASE_NAME_VERSION_ERROR);
                             response.setRenderParameter(PAGENAME, PAGENAME_EDIT_RELEASE);
                             prepareRequestForReleaseEditAfterDuplicateError(request, release);
                             break;

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -1549,9 +1549,12 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 if (RequestStatus.SUCCESS.equals(requestStatus) && CommonUtils.isNotNullEmptyOrWhitespace(request.getParameter(OBLIGATION_DATA))) {
                     updateLinkedObligations(request, project, user, client);
                 }
-                if (RequestStatus.DUPLICATE.equals(requestStatus) || RequestStatus.DUPLICATE_ATTACHMENT.equals(requestStatus)) {
+                if (RequestStatus.DUPLICATE.equals(requestStatus) || RequestStatus.DUPLICATE_ATTACHMENT.equals(requestStatus) ||
+                        RequestStatus.NAMINGERROR.equals(requestStatus)) {
                     if(RequestStatus.DUPLICATE.equals(requestStatus))
                         setSW360SessionError(request, ErrorMessages.PROJECT_DUPLICATE);
+                    else if (RequestStatus.NAMINGERROR.equals(requestStatus))
+                        setSW360SessionError(request, ErrorMessages.PROJECT_NAMING_ERROR);
                     else
                         setSW360SessionError(request, ErrorMessages.DUPLICATE_ATTACHMENT);
                     response.setRenderParameter(PAGENAME, PAGENAME_EDIT);
@@ -1567,7 +1570,6 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 // Add project
                 Project project = new Project();
                 ProjectPortletUtils.updateProjectFromRequest(request, project);
-
                 String cyclicLinkedProjectPath = client.getCyclicLinkedProjectPath(project, user);
                 if (!isNullEmptyOrWhitespace(cyclicLinkedProjectPath)) {
                     FossologyAwarePortlet.addCustomErrorMessage(CYCLIC_LINKED_PROJECT + cyclicLinkedProjectPath,
@@ -1605,6 +1607,11 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                         if (CommonUtils.isNotNullEmptyOrWhitespace(sourceProjectId)) {
                             request.setAttribute(SOURCE_PROJECT_ID, sourceProjectId);
                         }
+                        prepareRequestForEditAfterDuplicateError(request, project, user);
+                        break;
+                    case NAMINGERROR:
+                        setSW360SessionError(request, ErrorMessages.PROJECT_NAMING_ERROR);
+                        response.setRenderParameter(PAGENAME, PAGENAME_EDIT);
                         prepareRequestForEditAfterDuplicateError(request, project, user);
                         break;
                     default:

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/editBasicInfo.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/editBasicInfo.jspf
@@ -22,7 +22,7 @@
         <td>
             <div class="form-group">
                 <label class="mandatory" for="comp_name">Name</label>
-                <input id="comp_name" name="<portlet:namespace/><%=Component._Fields.NAME%>" type="text" placeholder="Enter Name" required class="form-control"
+                <input id="comp_name" name="<portlet:namespace/><%=Component._Fields.NAME%>" type="text" placeholder="Enter Name" required pattern=".*\S.*" class="form-control"
                     value="<sw360:out value="${component.name}"/>" />
                 <div class="invalid-feedback">
                     Please enter a component name!

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/editReleaseInformation.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/editReleaseInformation.jspf
@@ -39,7 +39,7 @@
             <div class="form-group">
                 <label class="mandatory" for="comp_version">Version</label>
                 <input id="comp_version" class="form-control" name="<portlet:namespace/><%=Release._Fields.VERSION%>" type="text"
-                    placeholder="Enter Version" required
+                    placeholder="Enter Version" required pattern=".*\S.*"
                     value="<sw360:out value="${release.version}"/>" />
             </div>
         </td>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/basicInfo.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/basicInfo.jspf
@@ -31,7 +31,7 @@
                 <label class="mandatory" for="proj_name">Name</label>
                 <input id="proj_name" name="<portlet:namespace/><%=Project._Fields.NAME%>" type="text"
                     placeholder="Enter Name" class="form-control" minlength="2"
-                    value="<sw360:out value="${project.name}"/>" required/>
+                    value="<sw360:out value="${project.name}"/>" required pattern=".*\S.*"/>
                  <div class="invalid-feedback">
                     Please enter a project name!
                 </div>

--- a/libraries/lib-datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/sw360.thrift
@@ -30,6 +30,7 @@ enum RequestStatus {
     CLOSED_UPDATE_NOT_ALLOWED = 8,
     INVALID_INPUT = 9,
     PROCESSING = 10,
+    NAMINGERROR = 11
 }
 
 enum RemoveModeratorRequestStatus {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -110,6 +110,8 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
             throw new DataIntegrityViolationException("sw360 component with name '" + component.getName() + "' already exists.");
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.INVALID_INPUT) {
             throw new HttpMessageNotReadableException("Dependent document Id/ids not valid.");
+        } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.NAMINGERROR) {
+            throw new HttpMessageNotReadableException("Component name and categories field cannot be empty or contain only whitespace character");
         }
         return null;
     }
@@ -119,6 +121,8 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
         RequestStatus requestStatus = sw360ComponentClient.updateComponent(component, sw360User);
         if (requestStatus == RequestStatus.INVALID_INPUT) {
             throw new HttpMessageNotReadableException("Dependent document Id/ids not valid.");
+        } else if (requestStatus == RequestStatus.NAMINGERROR) {
+            throw new HttpMessageNotReadableException("Component name and categories field cannot be empty or contain only whitespace character");
         } else if (requestStatus != RequestStatus.SUCCESS) {
             throw new RuntimeException("sw360 component with name '" + component.getName() + " cannot be updated.");
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -134,6 +134,8 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             throw new DataIntegrityViolationException("sw360 project with name '" + project.getName() + "' already exists.");
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.INVALID_INPUT) {
             throw new HttpMessageNotReadableException("Dependent document Id/ids not valid.");
+        } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.NAMINGERROR) {
+            throw new HttpMessageNotReadableException("Project name field cannot be empty or contain only whitespace character");
         }
         return null;
     }
@@ -153,6 +155,10 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         }
 
         RequestStatus requestStatus = sw360ProjectClient.updateProject(project, sw360User);
+        if (requestStatus == RequestStatus.NAMINGERROR) {
+            throw new HttpMessageNotReadableException("Project name field cannot be empty or contain only whitespace character");
+        }
+
         if (requestStatus == RequestStatus.CLOSED_UPDATE_NOT_ALLOWED) {
             throw new RuntimeException("User cannot modify a closed project");
         } if (requestStatus == RequestStatus.INVALID_INPUT) {
@@ -265,5 +271,4 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
                 .flattenProjectLinkTree(SW360Utils.getLinkedProjects(project, deep, new ThriftClients(), log, user));
         return linkedProjects.stream().map(projectLinkMapper).collect(Collectors.toList());
     }
-
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -131,6 +131,10 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.INVALID_INPUT) {
             throw new HttpMessageNotReadableException("Dependent document Id/ids not valid.");
         }
+        else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.NAMINGERROR) {
+            throw new HttpMessageNotReadableException(
+                    "Release name and version field cannot be empty or contain only whitespace character");
+        }
         return null;
     }
 
@@ -140,6 +144,9 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         RequestStatus requestStatus = sw360ComponentClient.updateRelease(release, sw360User);
         if (requestStatus == RequestStatus.INVALID_INPUT) {
             throw new HttpMessageNotReadableException("Dependent document Id/ids not valid.");
+        } else if (requestStatus == RequestStatus.NAMINGERROR) {
+            throw new HttpMessageNotReadableException(
+                    "Release name and version field cannot be empty or contain only whitespace character");
         } else if (requestStatus != RequestStatus.SUCCESS) {
             throw new RuntimeException("sw360 release with name '" + release.getName() + " cannot be updated.");
         }


### PR DESCRIPTION
Remove Trailing and leading whitespace for all fields in component ,release and project during add or update through UI or REST

Validation for fields which should not contain only white space while creating or updating through UI or REST
- Name field for Project
- Name and Category field for Component
- Name and Version field for Release

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>