### PR TITLE
fix(ProjectUI): Obligation view for changes in linked release attachment

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -21,10 +21,12 @@ import com.google.common.collect.Sets;
 
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.common.WrappedException.WrappedTException;
 import org.eclipse.sw360.datahandler.db.AttachmentDatabaseHandler;
 import org.eclipse.sw360.datahandler.db.ComponentDatabaseHandler;
+import org.eclipse.sw360.datahandler.db.ProjectDatabaseHandler;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.components.*;
@@ -64,28 +66,26 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
     private static final String DEFAULT_OBLIGATIONS_FILE = "/DefaultObligations.txt";
     private static final String DEFAULT_OBLIGATIONS_TEXT = dropCommentedLine(DEFAULT_OBLIGATIONS_FILE);
     private static final String MSG_NO_RELEASE_GIVEN = "No release given";
-    private static final String LICENSE_TYPE_GLOBAL = "Global";
-    private static final String LICENSE_TYPE_OTHERS = "Others";
-    private static final String SPDX_IDENTIFIER_NA = "n/a";
-    private static final String SPDX_IDENTIFIER_UNKNOWN = "SPDX identifier unknown";
-    private static final String OBLIGATION_TOPIC_UNKNOWN = "Obligation topic unknown";
 
     protected List<LicenseInfoParser> parsers;
     protected List<OutputGenerator<?>> outputGenerators;
     protected ComponentDatabaseHandler componentDatabaseHandler;
+    protected ProjectDatabaseHandler projectDatabaseHandler;
     protected Cache<String, List<LicenseInfoParsingResult>> licenseInfoCache;
     protected Cache<String, List<ObligationParsingResult>> obligationCache;
     protected Cache<String, LicenseInfoParsingResult> licenseObligationMappingCache;
 
     public LicenseInfoHandler() throws MalformedURLException {
         this(new AttachmentDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE, DatabaseSettings.COUCH_DB_ATTACHMENTS),
-                new ComponentDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE, DatabaseSettings.COUCH_DB_ATTACHMENTS));
+                new ComponentDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE, DatabaseSettings.COUCH_DB_ATTACHMENTS),
+                new ProjectDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE, DatabaseSettings.COUCH_DB_ATTACHMENTS));
     }
 
     @VisibleForTesting
     protected LicenseInfoHandler(AttachmentDatabaseHandler attachmentDatabaseHandler,
-                              ComponentDatabaseHandler componentDatabaseHandler) throws MalformedURLException {
+                              ComponentDatabaseHandler componentDatabaseHandler, ProjectDatabaseHandler projectDatabaseHandler) throws MalformedURLException {
         this.componentDatabaseHandler = componentDatabaseHandler;
+        this.projectDatabaseHandler = projectDatabaseHandler;
         this.licenseInfoCache = CacheBuilder.newBuilder().expireAfterWrite(CACHE_TIMEOUT_MINUTES, TimeUnit.MINUTES)
                 .maximumSize(CACHE_MAX_ITEMS).build();
         this.obligationCache = CacheBuilder.newBuilder().expireAfterWrite(CACHE_TIMEOUT_MINUTES, TimeUnit.MINUTES)
@@ -125,11 +125,6 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
         Collection<LicenseInfoParsingResult> projectLicenseInfoResults = getAllReleaseLicenseInfos(releaseToAttachmentId, user,
                 excludedLicensesPerAttachment);
         Collection<ObligationParsingResult> obligationsResults = getAllReleaseObligations(releaseToAttachmentId, user);
-
-        if (project.getReleaseIdToUsageSize() > 0) {
-            project.setLinkedObligations(createLicenseToObligationMappingForReport(project,
-                    new ArrayList<LicenseInfoParsingResult>(projectLicenseInfoResults), new ArrayList<ObligationParsingResult>(obligationsResults), releaseToAttachmentId));
-        }
 
         String[] outputGeneratorClassnameAndVariant = outputGenerator.split("::");
         if (outputGeneratorClassnameAndVariant.length != 2) {
@@ -235,9 +230,9 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
     }
 
     @Override
-    public Map<Project, List<LicenseInfoParsingResult>> setProjectObligationStatus(Project project, List<LicenseInfoParsingResult> licenseResults) {
+    public Map<Project, List<LicenseInfoParsingResult>> setProjectObligationStatus(Project project, List<LicenseInfoParsingResult> licenseResults, Map<String, String> excludedReleaseIdToAcceptedCLI) {
 
-        Map<String, ObligationStatusInfo> obligationStatusMap = project.isSetLinkedObligations() ? project.getLinkedObligations() : Maps.newHashMap();
+        Map<String, ObligationStatusInfo> obligationStatusMap = project.isSetLinkedObligations() ? removeUnwantedObligations(project, excludedReleaseIdToAcceptedCLI) : Maps.newHashMap();
         Map<Project, List<LicenseInfoParsingResult>> projectObligationMap = Maps.newHashMap();
 
         // mapping obligations and it's status
@@ -245,19 +240,21 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
             Release release = result.getRelease();
             LicenseInfo licenseInfo = result.getLicenseInfo();
             licenseInfo.setLicenseNamesWithTexts(filterLicense(licenseInfo));
-
             for (LicenseNameWithText license : licenseInfo.getLicenseNamesWithTexts()) {
-                String licenseSpdxId = license.getLicenseSpdxId();
+                String licenseName = license.getLicenseName();
                 license.getObligations().stream().forEach(obl -> {
                     ObligationStatusInfo posi = obligationStatusMap.get(obl.getTopic());
+                    release.setAttachments(release.getAttachments().stream()
+                            .filter(a -> a.getAttachmentContentId().equals(result.getAttachmentContentId()))
+                            .collect(Collectors.toSet()));
                     if (Objects.nonNull(posi)) {
                         posi.setText(obl.getText());
-                        posi.addToLicenseIds(licenseSpdxId);
+                        posi.addToLicenseIds(licenseName);
                         posi.addToReleases(release);
                         obl.setObligationStatusInfo(posi);
                     } else {
                         ObligationStatusInfo osi = new ObligationStatusInfo().setText(obl.getText())
-                                .setReleases(Sets.newHashSet(release)).setLicenseIds(Sets.newHashSet(licenseSpdxId));
+                                .setReleases(Sets.newHashSet(release)).setLicenseIds(Sets.newHashSet(licenseName));
                         obligationStatusMap.put(obl.getTopic(), osi);
                     }
                 });
@@ -268,18 +265,41 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
         return projectObligationMap;
     }
 
+    private Map<String, ObligationStatusInfo> removeUnwantedObligations(Project project, Map<String, String> excludedReleaseIdToAcceptedCLI) {
+        if (!excludedReleaseIdToAcceptedCLI.isEmpty()) {
+            Map<String, ObligationStatusInfo> obligationStatusMap = project.getLinkedObligations().entrySet().stream().filter(entry -> {
+                ObligationStatusInfo osi = entry.getValue();
+                Map<String, String> currentReleaseIdToAcceptedCLI = osi.getReleaseIdToAcceptedCLI();
+                if (excludedReleaseIdToAcceptedCLI.equals(currentReleaseIdToAcceptedCLI)) {
+                    return false;
+                }
+                if (osi.isSetReleaseIdToAcceptedCLI()) {
+                    currentReleaseIdToAcceptedCLI.keySet().removeAll(excludedReleaseIdToAcceptedCLI.keySet());
+                    if (currentReleaseIdToAcceptedCLI.isEmpty()) {
+                        return false;
+                    }
+                }
+                return true;
+            }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            projectDatabaseHandler.updateProjectForObligations(project.getId(), obligationStatusMap);
+            return obligationStatusMap;
+        }
+        return project.getLinkedObligations();
+    }
+
     private Set<LicenseNameWithText> filterLicense(LicenseInfo licenseInfo) {
-        // filtering all license without obligations and license with Unknown or n/a Spdx id
+        // filtering all license without obligations and license name unknown or n/a
         Predicate<LicenseNameWithText> filterLicense = license -> (license.isSetObligations()
-                && !(SPDX_IDENTIFIER_UNKNOWN.equals(license.getLicenseSpdxId())
-                        && SPDX_IDENTIFIER_NA.equalsIgnoreCase(license.getLicenseSpdxId())));
+                && !(SW360Constants.LICENSE_NAME_UNKNOWN.equals(license.getLicenseName())
+                        && SW360Constants.NA.equalsIgnoreCase(license.getLicenseName())));
 
         return licenseInfo.getLicenseNamesWithTexts().stream().filter(filterLicense).map(license -> {
             // changing non-global license type as Others an global to Global
-            if (LICENSE_TYPE_GLOBAL.equalsIgnoreCase(license.getType())) {
-                license.setType(LICENSE_TYPE_GLOBAL);
+            if (SW360Constants.LICENSE_TYPE_GLOBAL.equalsIgnoreCase(license.getType())) {
+                license.setType(SW360Constants.LICENSE_TYPE_GLOBAL);
             } else {
-                license.setType(LICENSE_TYPE_OTHERS);
+                license.setType(SW360Constants.LICENSE_TYPE_OTHERS);
             }
             return license;
         }).collect(Collectors.toSet());
@@ -295,7 +315,7 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
 
         Map<String, Set<Obligation>> licenseIdToObligations = obligationResult.getObligations().stream()
                 // filtering obligations with unknown topic
-                .filter(obligation -> !(OBLIGATION_TOPIC_UNKNOWN.equals(obligation.getTopic())))
+                .filter(obligation -> !(SW360Constants.OBLIGATION_TOPIC_UNKNOWN.equals(obligation.getTopic())))
                 // sort the obligations by topic in ascending order
                 .sorted(Comparator.comparing(Obligation::getTopic, String.CASE_INSENSITIVE_ORDER))
                 .collect(Collectors.toList()).stream()
@@ -307,14 +327,32 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
 
         LicenseInfo licenseInfo = licenseResult.getLicenseInfo();
         licenseInfo.getLicenseNamesWithTexts()
-                .forEach(license -> license.setObligations(licenseIdToObligations.get(license.getLicenseSpdxId())));
+                .forEach(license -> license.setObligations(licenseIdToObligations.get(license.getLicenseName())));
         licenseInfo.setTotalObligations(obligationResult.getObligationsSize());
         licenseObligationMappingCache.put(licenseResult.getAttachmentContentId(), licenseResult);
         return licenseResult;
     }
 
+    /* TODO: This method will used once project obligations approach is fixed */
     private Map<String, ObligationStatusInfo> createLicenseToObligationMappingForReport(Project project, List<LicenseInfoParsingResult> licenseResults,
             List<ObligationParsingResult> obligationResults, Map<Release, Set<String>> releaseToSelectedAttachmentIds) {
+
+        Set<String> linkedReleaseIds = project.getReleaseIdToUsage().keySet();
+        Map<String, String> releaseIdToAcceptedCLI = Maps.newHashMap();
+
+        if (project.getLinkedObligationsSize() > 0) {
+            releaseIdToAcceptedCLI
+                    .putAll(SW360Utils.getReleaseIdtoAcceptedCLIMappings(project.getLinkedObligations()));
+        }
+
+        Map<Release, Set<String>> filteredRelToSelAttIds = releaseToSelectedAttachmentIds.entrySet().stream()
+                .filter(e -> linkedReleaseIds.contains(e.getKey().getId()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        if (filteredRelToSelAttIds.isEmpty()) {
+            LOGGER.info("Attachment from linked releases is not selected while downloading the report.");
+            return null;
+        }
 
         Map<String, LicenseInfoParsingResult> attachmentToLicenseMap = licenseResults.stream()
                 .filter(LicenseInfoParsingResult::isSetAttachmentContentId)
@@ -326,28 +364,35 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
                 .collect(Collectors.toList()).stream()
                 .collect(Collectors.toMap(ObligationParsingResult::getAttachmentContentId, Function.identity()));
 
-        Set<Release> releases = releaseToSelectedAttachmentIds.keySet().stream().filter(rel -> rel.getAttachmentsSize() > 0).collect(Collectors.toSet());
-        if (releases.isEmpty()) {
-            return null;
-        }
-        releaseToSelectedAttachmentIds.keySet().retainAll(releases);
-
         List<LicenseInfoParsingResult> licenseParsingResults = new ArrayList<LicenseInfoParsingResult>();
-        for (Entry<Release, Set<String>> entry : releaseToSelectedAttachmentIds.entrySet()) {
-            Attachment attachment = SW360Utils.getApprovedClxAttachmentForRelease(entry.getKey());
-            for (String attachmentContentId : entry.getValue()) {
-                LicenseInfoParsingResult licenseResult = attachmentToLicenseMap.get(attachmentContentId);
-                ObligationParsingResult obligationResult = attachmentToObligationMap.get(attachmentContentId);
-                if (attachmentContentId != null && attachmentContentId.equals(attachment.getAttachmentContentId())
-                        && null != obligationResult && null != licenseResult) {
-                    licenseParsingResults.add(createLicenseToObligationMapping(licenseResult, obligationResult));
+
+
+        for (Entry<Release, Set<String>> entry : filteredRelToSelAttIds.entrySet()) {
+            List<Attachment> filteredAttachments = SW360Utils.getApprovedClxAttachmentForRelease(entry.getKey());
+
+            if (filteredAttachments.size() == 1) {
+                final String approvedAttContentId = filteredAttachments.get(0).getAttachmentContentId();
+                final String releaseId = entry.getKey().getId();
+
+                if (releaseIdToAcceptedCLI.containsKey(releaseId)
+                        && releaseIdToAcceptedCLI.get(releaseId).equals(approvedAttContentId)) {
+                    releaseIdToAcceptedCLI.remove(releaseId);
+                }
+
+                for (String attachmentContentId : entry.getValue()) {
+                    LicenseInfoParsingResult licenseResult = attachmentToLicenseMap.get(attachmentContentId);
+                    ObligationParsingResult obligationResult = attachmentToObligationMap.get(attachmentContentId);
+                    if (attachmentContentId.equals(approvedAttContentId)
+                            && null != obligationResult && null != licenseResult) {
+                        licenseParsingResults.add(createLicenseToObligationMapping(licenseResult, obligationResult));
+                    }
                 }
             }
         }
         if (licenseParsingResults.isEmpty()) {
             return null;
         }
-        return setProjectObligationStatus(project, licenseParsingResults).keySet().iterator().next().getLinkedObligations();
+        return setProjectObligationStatus(project, licenseParsingResults, releaseIdToAcceptedCLI).keySet().iterator().next().getLinkedObligations();
     }
 
     @Override

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
@@ -257,7 +257,6 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
 
             fillCommonRulesTable(document, project);
 
-            fillLinkedObligations(document, Maps.newHashMap(), project);
             // because of the impossible API component subsections must be the last thing in the docx file
             // the rest of the sections must be generated after this
             writeComponentSubsections(document, projectLicenseInfoResults, obligationResults);
@@ -701,7 +700,7 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
         setTableBorders(table);
     }
 
-
+    /* TODO: This method will used once project obligations approach is fixed */
     private void fillLinkedObligations(XWPFDocument document, Map<String, String> externalIdMap, Project project) {
         XWPFTable table = document.getTables().get(OBLIGATION_STATUS_TABLE_INDEX);
         final int[] currentRow = new int[] { 0 };

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
@@ -42,6 +42,8 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static org.eclipse.sw360.datahandler.common.CommonUtils.closeQuietly;
+import static org.eclipse.sw360.datahandler.common.SW360Constants.LICENSE_NAME_UNKNOWN;
+import static org.eclipse.sw360.datahandler.common.SW360Constants.OBLIGATION_TOPIC_UNKNOWN;
 
 /**
  * Abstract class with common helper methods for CLIParser and CombinedCLIParser
@@ -55,12 +57,10 @@ public abstract class AbstractCLIParser extends LicenseInfoParser {
     private static final String LICENSENAME_ATTRIBUTE_NAME = "name";
     private static final String SPDX_IDENTIFIER_ATTRIBUTE_NAME = "spdxidentifier";
     private static final String TYPE_ATTRIBUTE_NAME = "type";
-    private static final String LICENSE_NAME_UNKNOWN = "License name unknown";
     private static final String TYPE_UNKNOWN = "Type unknown";
     private static final String OBLIGATION_TEXT_UNKNOWN = "Obligation text unknown";
     private static final Logger log = Logger.getLogger(CLIParser.class);
     private static final String SPDX_IDENTIFIER_UNKNOWN = "SPDX identifier unknown";
-    private static final String OBLIGATION_TOPIC_UNKNOWN = "Obligation topic unknown";
 
     private static final String OBLIGATION_TOPIC_ELEMENT_NAME = "Topic";
     private static final String OBLIGATION_TEXT_ELEMENT_NAME = "Text";

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandlerTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandlerTest.java
@@ -54,7 +54,7 @@ public class LicenseInfoHandlerTest {
     @Before
     public void setUp() throws Exception {
         when(attachmentDatabaseHandler.getAttachmentConnector()).thenReturn(connector);
-        handler = new LicenseInfoHandler(attachmentDatabaseHandler, null);
+        handler = new LicenseInfoHandler(attachmentDatabaseHandler, null, null);
     }
 
     @Test(expected = IllegalStateException.class)

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -40,6 +40,7 @@ public class PortalConstants {
     public static final Boolean MAINLINE_STATE_ENABLED_FOR_USER;
     public static final Boolean IS_CLEARING_TEAM_UNKNOWN_ENABLED;
     public static final Set<String> PROJECT_OBLIGATIONS_ACTION_SET;
+    public static final Boolean IS_PROJECT_OBLIGATIONS_ENABLED;
 
     // DO NOT CHANGE THIS UNLESS YOU KNOW WHAT YOU ARE DOING !!!
     // - friendly url mapping files must be changed
@@ -177,8 +178,6 @@ public class PortalConstants {
     public static final String ATTACHMENT_USAGES = "attachmentUsages";
     public static final String ATTACHMENT_USAGES_RESTRICTED_COUNTS = "attachmentUsagesRestrictedCounts";
     public static final String SPDX_LICENSE_INFO = "spdxLicenseInfo";
-    public static final String SPDX_IDENTIFIER_UNKNOWN = "SPDX identifier unknown";
-    public static final String SPDX_IDENTIFIER_NA = "n/a";
 
     //! Specialized keys for projects
     public static final String PROJECT_PORTLET_NAME = PORTLET_NAME_PREFIX + "projects";
@@ -221,6 +220,7 @@ public class PortalConstants {
     public static final String SOURCE_PROJECT_ID = "sourceProjectId";
     public static final String PROJECT_RELEASE_LICENSE_INFO = "projectReleaseLicenseInfo";
     public static final String APPROVED_OBLIGATIONS_COUNT = "approvedObligationsCount";
+    public static final String EXCLUDED_RELEASES = "excludedReleases";
 
 
     public static final String FOSSOLOGY_PORTLET_NAME = PORTLET_NAME_PREFIX + "fossology";
@@ -531,6 +531,7 @@ public class PortalConstants {
         MAINLINE_STATE_ENABLED_FOR_USER = Boolean.parseBoolean(props.getProperty("mainline.state.enabled.for.user", "false"));
         IS_CLEARING_TEAM_UNKNOWN_ENABLED = Boolean.parseBoolean(props.getProperty("clearing.team.unknown.enabled", "true"));
         PROJECT_OBLIGATIONS_ACTION_SET = CommonUtils.splitToSet(props.getProperty("project.obligation.actions", "Action 1,Action 2,Action 3"));
+        IS_PROJECT_OBLIGATIONS_ENABLED = Boolean.parseBoolean(props.getProperty("project.obligations.enabled", "false"));
 
         // SW360 REST API Constants
         API_TOKEN_ENABLE_GENERATOR = Boolean.parseBoolean(props.getProperty("rest.apitoken.generator.enable", "false"));

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -546,8 +546,8 @@ public class ComponentPortlet extends FossologyAwarePortlet {
                 licenseWithText = licenseInfoResult.stream()
                         .flatMap(result -> result.getLicenseInfo().getLicenseNamesWithTexts().stream())
                         .filter(license -> license.getType().equals(LICENSE_TYPE_GLOBAL)
-                                && !license.getLicenseSpdxId().equals(SPDX_IDENTIFIER_UNKNOWN)
-                                && !license.getLicenseSpdxId().equals(SPDX_IDENTIFIER_NA)) // exclude unknown and n/a
+                                && !license.getLicenseName().equals(SW360Constants.LICENSE_NAME_UNKNOWN)
+                                && !license.getLicenseName().equals(SW360Constants.NA)) // exclude unknown and n/a
                         .findFirst().orElse(null);
             }
 

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/detail.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/detail.jsp
@@ -30,6 +30,7 @@
     <jsp:useBean id="licInfoAttUsages" type="java.util.Map<java.lang.String, org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage>" scope="request"/>
     <jsp:useBean id="sourceAttUsages" type="java.util.Map<java.lang.String, org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage>" scope="request"/>
     <jsp:useBean id="manualAttUsages" type="java.util.Map<java.lang.String, org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage>" scope="request"/>
+    <core_rt:set var="isProjectObligationsEnabled" value='<%=PortalConstants.IS_PROJECT_OBLIGATIONS_ENABLED%>'/>
 </c:catch>
 
 <%@include file="/html/utils/includes/logError.jspf" %>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/edit.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/edit.jsp
@@ -60,6 +60,7 @@
 
     <core_rt:set  var="addMode"  value="${empty project.id}" />
     <core_rt:set  var="pageName"  value="<%= request.getParameter("pagename") %>" />
+    <core_rt:set var="isProjectObligationsEnabled" value='<%=PortalConstants.IS_PROJECT_OBLIGATIONS_ENABLED%>'/>
 </c:catch>
 
 <%--These variables are used as a trick to allow referencing enum values in EL expressions below--%>
@@ -69,11 +70,11 @@
 
 <core_rt:if test="${empty attributeNotFoundException}">
 
-<core_rt:set var="isObligationEnabled"  value="${hasWritePermissions and isUserAtLeastClearingAdmin}" />
+<core_rt:set var="isObligationEnabled"  value="${isProjectObligationsEnabled and hasWritePermissions and isUserAtLeastClearingAdmin}" />
 <core_rt:if test="${isObligationEnabled}">
     <core_rt:set var="isObligationPresent"  value="${not empty project.linkedObligations}" />
     <core_rt:if test="${isObligationPresent}">
-        <jsp:useBean id="projectReleaseLicenseInfo" type="java.util.List<org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult>" scope="request" />
+    <jsp:useBean id="projectReleaseLicenseInfo" type="java.util.List<org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult>" scope="request" />
     <jsp:useBean id="approvedObligationsCount" type="java.lang.Integer" scope="request"/>
     </core_rt:if>
 </core_rt:if>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/detailOverview.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/detailOverview.jspf
@@ -26,6 +26,7 @@
 				<a class="list-group-item list-group-item-action <core_rt:if test="${selectedTab == 'tab-attachmentUsages'}">active</core_rt:if>" href="#tab-attachmentUsages" data-toggle="list" role="tab">Attachment Usages</a>
 			</core_rt:if>
 			<a class="list-group-item list-group-item-action <core_rt:if test="${selectedTab == 'tab-ClearingStatus'}">active</core_rt:if>" href="#tab-ClearingStatus" data-toggle="list" role="tab">Clearing Status</a>
+			<core_rt:if test="${isProjectObligationsEnabled}">
 			<a class="list-group-item list-group-item-action <core_rt:if test="${selectedTab == 'tab-Obligations'}">active</core_rt:if>" href="#tab-Obligations" data-toggle="list" role="tab">Obligations
 				<core_rt:if test="${isObligationPresent}">
 					<span id="obligtionsCount"
@@ -45,6 +46,7 @@
 					</span>
 				</core_rt:if>
 			</a>
+			</core_rt:if>
 			<a class="list-group-item list-group-item-action <core_rt:if test="${selectedTab == 'tab-ECCStatus'}">active</core_rt:if>" href="#tab-ECCStatus" data-toggle="list" role="tab">ECC Status</a>
 			<a class="list-group-item list-group-item-action <core_rt:if test="${selectedTab == 'tab-Attachments'}">active</core_rt:if>" href="#tab-Attachments" data-toggle="list" role="tab">Attachments</a>
 			<core_rt:if test="${inProjectDetailsContext}">

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/editObligations.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/editObligations.jspf
@@ -28,11 +28,11 @@
     <table id="editObligationTable" class="table table-bordered" >
         <colgroup>
             <col />
+            <col style="width: 25%;" />
             <col style="width: 20%;" />
-            <col style="width: 15%;" />
-            <col style="width: 20%;" />
+            <col style="width: 25%;" />
             <col style="width: 12%;" />
-            <col style="width: 15%;" />
+            <!-- <col style="width: 15%;" /> -->
             <col style="width: 18%;" />
             <col />
         </colgroup>
@@ -45,7 +45,8 @@
                 <th>Licenses</th>
                 <th>Releases</th>
                 <th>Status</th>
-                <th>Action</th>
+                <!-- Commented code for obligation action, until action select options are provided -->
+                <!-- <th>Action</th> -->
                 <th>Comment</th>
             </tr>
         </thead>
@@ -79,7 +80,8 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button'], func
             var fullName = '${release.name} (${release.version})';
             releaseLinks.push({
                 id: "${release.id}",
-                name: fullName
+                name: fullName,
+                attachmentId: "${release.attachments.iterator().next().attachmentContentId}"
 	        });
         </core_rt:forEach>
 
@@ -88,7 +90,7 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button'], func
             "licenseLinks": licenseLinks,
             "releaseLinks": releaseLinks,
             "status": '<sw360:DisplayEnumOptions type="<%=ProjectObligationStatus.class%>" selected="${projectObligations.status}" />',
-            "action": "${projectObligations.action}",
+            /* "action": "${projectObligations.action}", */
             "comment": "${projectObligations.comment}",
             "text": '<sw360:out value="${projectObligations.text}" maxChar="200" />',
             "modifiedBy": "${projectObligations.modifiedBy}",
@@ -110,7 +112,7 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button'], func
             { "data": "licenseLinks", "render": { display: renderLicenseLink } },
             { "data": "releaseLinks", "render": { display: renderReleaseLink } },
             { "data": "status", "render": { display: renderStatus } },
-            { "data": "action", render: $.fn.dataTable.render.inputSelect(actionOptions, '', 'obl_action toplabelledInput', 'textlabel stackedLabel') },
+            /* { "data": "action", render: $.fn.dataTable.render.inputSelect(actionOptions, '', 'obl_action toplabelledInput', 'textlabel stackedLabel') }, */
             { "data": "comment", defaultContent: "", render: $.fn.dataTable.render.inputText('comment', 'obl_comment toplabelledInput', 'Enter comments') },
         ],
         "columnDefs": [
@@ -121,7 +123,7 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button'], func
                 }
             },
             {
-                "targets": 6,
+                "targets": 5,
                 "createdCell": function (td, cellData, rowData, row, col) {
                     $.fn.dataTable.render.inputText.updateTitle(td);
                     $.fn.dataTable.render.inputText.useInputDialog(td, "Enter obligation comment");
@@ -148,7 +150,7 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button'], func
             }
         ],
         "initComplete": datatables.showPageContainer
-    }, undefined, [0, 2, 3, 4, 5, 6]);
+    }, undefined, [0, 4, 5]);
 
     function renderStatus(status, type, row) {
         return '<select class="obl_status toplabelledInput form-control">' + status + '</select>';
@@ -187,9 +189,9 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button'], func
         storeData($(this));
     });
 
-    $("#editObligationTable tbody").on("change", 'td select.obl_action',function () {
+    /* $("#editObligationTable tbody").on("change", 'td select.obl_action',function () {
         storeData($(this));
-    });
+    }); */
 
     $("#editObligationTable tbody").on("change", 'td input.obl_comment',function () {
         if ($(this).closest('tr').find("input.obl_comment").val()) {
@@ -257,18 +259,19 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button'], func
         table.rows().every(function (rowIdx, tableLoop, rowLoop) {
             var rowData = this.data(),
                 mapKey = rowData.obligation,
+                releaseToAcceptedCLIMap = new Map(),
                 ids = [];
             for (release of rowData.releaseLinks) {
-                ids.push(release.id);
+                releaseToAcceptedCLIMap[release.id] = release.attachmentId;
             }
             var mapValue = {
                 licenseIds: rowData.licenseLinks,
-                releaseIds: ids
+                releaseIdToAcceptedCLI: releaseToAcceptedCLIMap
             };
             if (dataMap.has(mapKey)) {
                 $node = $(this.node()),
                 mapValue.status = $node.find('select.obl_status option:selected').val();
-                mapValue.action = $node.find("select.obl_action option:selected").val();
+                /* mapValue.action = $node.find("select.obl_action option:selected").val(); */
                 mapValue.comment = $node.find("input.obl_comment").val();
                 mapValue.modifiedOn = date;
             }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/linkedObligations.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/linkedObligations.jspf
@@ -29,15 +29,16 @@
         </core_rt:when>
         <core_rt:otherwise>
             The possible reasons for not loading linked obligations:
-            <li>No <b>Accepted</b> CLI file in linked release. (Obligations from accepted CLI file will be loaded here)</li>
-            <li>More than <b>ONE</b> Accepted CLI file in linked release. (Each release should have only one accepted CLI file)</li>
-            <li>No obligations are present in CLI file.</li>
+            <li>No <b>accepted</b> CLI xml file in linked release. (Obligations from accepted CLI file will be loaded here)</li>
+            <li>More than <b>one</b> Accepted CLI xml file in linked release. (Each release should have only one accepted CLI file)</li>
+            <li>Obligations are <b>not</b> present in Accepted CLI xml file.</li>
         </core_rt:otherwise>
     </core_rt:choose>
     </div>
 </core_rt:if>
 
 <core_rt:if test="${isObligationPresent}">
+    <jsp:useBean id="excludedReleases" type="java.util.Set<org.eclipse.sw360.datahandler.thrift.components.Release>" scope="request" />
 
 <liferay-portlet:renderURL var="friendlyReleaseURL" portletName="sw360_portlet_components">
     <portlet:param name="<%=PortalConstants.PAGENAME%>" value="<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_PAGENAME%>"/>
@@ -49,6 +50,18 @@
     <portlet:param name="<%=PortalConstants.PAGENAME%>" value="<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_PAGENAME%>"/>
     <portlet:param name="<%=PortalConstants.LICENSE_ID%>" value="<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_ID%>"/>
 </liferay-portlet:renderURL>
+
+    <core_rt:if test="${not empty excludedReleases}">
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            Obligation status associated with the following release(s) are removed/updated due to changes in associated CLI.xml file
+            <core_rt:forEach items="${excludedReleases}" var="exRelease" varStatus="loop">
+            <li><sw360:DisplayReleaseLink release="${exRelease}" showFullname="true"/></li>
+            </core_rt:forEach>
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                <span aria-hidden="true"><svg class="lexicon-icon"><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#times"/></svg></span>
+            </button>
+        </div>
+    </core_rt:if>
 
 <div class="tab-content" id="pills-tabContent">
     <div class="tab-pane show active" id="pills-obligationsView" role="tabpanel" aria-labelledby="pills-obligations-tab">

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligationsByReleases.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligationsByReleases.jspf
@@ -27,13 +27,14 @@
     <table class="table info_table" id="poInfoTableByRelease" style="table-layout: auto">
         <thead>
             <tr>
-                <th colspan="5" class="headlabel">Project Obligation Status</th>
+                <th colspan="4" class="headlabel">Project Obligation Status</th>
             </tr>
             <tr>
                 <th width="35%">Release &#8883; Attachment &#8883;
                     License Type &#8883; License &#8883; Obligation</th>
                 <th width="25%">Text</th>
-                <th width="10">Action taken</th>
+                <!-- Commented code for obligation action, until action select options are provided -->
+                <!-- <th width="10">Action taken</th> -->
                 <th width="10%">Status</th>
                 <th width="20%">Comment</th>
             </tr>
@@ -47,7 +48,7 @@
                 <core_rt:set var="bckgrndClass" value="text-success" />
 
                 <tr id="releaseRow_${loop.count}" data-tt-id="${release.id}" data-row-type="release">
-                    <td colspan="5">
+                    <td colspan="4">
                         <sw360:DisplayReleaseLink release="${release}" showName="true"/>
                         <span class="badge badge-light text-dark">
                             <sw360:out value=" (${totalObligations})" />
@@ -62,7 +63,7 @@
                             data-tt-id="${release.id}_${licenseType}"
                             data-tt-parent-id="${release.id}" data-row-type="licenseType"
                             class="highlightSuccess">
-                            <td colspan="5"><sw360:out value="${licenseType}" /></td>
+                            <td colspan="4"><sw360:out value="${licenseType}" /></td>
                         </tr>
                     </core_rt:if>
 
@@ -71,7 +72,7 @@
                         data-tt-parent-id="${release.id}_${licenseType}"
                         data-row-type="licenseId"
                         <core_rt:if test="${obligationSize gt 0}">class="highlightWarning"</core_rt:if>>
-                        <td colspan="5">
+                        <td colspan="4">
                             <sw360:out value="${license.licenseSpdxId}" />
                         </td>
                     </tr>
@@ -94,9 +95,9 @@
                                 <td>
                                     <sw360:out value="${obligation.text}" maxChar="40" />
                                 </td>
-                                <td>
+                                <%-- <td>
                                     <sw360:out value="${osi.action}" />
-                                </td>
+                                </td> --%>
                                 <td>
                                     <sw360:DisplayEnum value="${osi.status}" />
                                 </td>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/viewByObligations.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/viewByObligations.jspf
@@ -26,10 +26,10 @@
         <colgroup>
             <col />
             <col style="width: 25%;" />
-            <col style="width: 15%;" />
+            <col style="width: 20%;" />
             <col style="width: 25%;" />
-            <col style="width: 7%;" />
-            <col style="width: 8%;" />
+            <col style="width: 10%;" />
+            <!-- <col style="width: 8%;" /> -->
             <col style="width: 20%;" />
             <col />
         </colgroup>
@@ -42,7 +42,8 @@
                 <th>Licenses</th>
                 <th>Releases</th>
                 <th>Status</th>
-                <th>Action</th>
+                <!-- Commented code for obligation action, until action select options are provided -->
+                <!-- <th>Action</th> -->
                 <th>Comment</th>
             </tr>
         </thead>
@@ -79,7 +80,7 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
             "rIds": releaseIds,
             "rNames": releaseNames.join(', <br>'),
             "status": "<sw360:DisplayEnum value='${projectObligations.status}'/>",
-            "action": '${projectObligations.action}',
+            /* "action": '${projectObligations.action}', */
             "comment": '${projectObligations.comment}',
             "text": '<sw360:out value="${projectObligations.text}" maxChar="200" />',
             "modifiedBy": '${projectObligations.modifiedBy}',
@@ -101,7 +102,7 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
             { "data": "lIds", "render": { display: renderLicenseLink } },
             { "data": "rNames", "render": { display: renderReleaseLink } },
             { "data": "status", className: 'text-center' },
-            { "data": "action" },
+           /*  { "data": "action" }, */
             { "data": "comment", render: $.fn.dataTable.render.ellipsis },
         ],
         "columnDefs": [
@@ -126,7 +127,7 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
         },
         "order": [[1, 'asc']],
         "initComplete": datatables.showPageContainer
-    }, [1, 2, 3, 4, 5, 6], [0, 5, 6]);
+    }, [1, 2, 3, 4, 5], [0, 5]);
 
     function renderReleaseLink(rNames, type, row) {
         var releaseLinks = [],

--- a/frontend/sw360-portlet/src/main/resources/sw360.properties
+++ b/frontend/sw360-portlet/src/main/resources/sw360.properties
@@ -66,6 +66,8 @@
 
 #clearing.team.unknown.enabled=true
 
+#project.obligations.enabled=false
+
 ## used in the projectimport-portlet UI, comma separated list of hosts
 ## 	Example: https://some.host.domain,https://some.other.host.domain
 #projectimport.hosts=

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -40,6 +40,11 @@ public class SW360Constants {
     public static final String KEY_REV = "_rev";
 
     public static final String PROJECT_VULNERABILITY_RATING_ID_PREFIX = "pvrating_";
+    public static final String LICENSE_TYPE_GLOBAL = "Global";
+    public static final String LICENSE_TYPE_OTHERS = "Others";
+    public static final String NA = "n/a";
+    public static final String LICENSE_NAME_UNKNOWN = "License name unknown";
+    public static final String OBLIGATION_TOPIC_UNKNOWN = "Obligation topic unknown";
     // Proper values of the "type" member to deserialize to CouchDB
     public static final String TYPE_OBLIGATION = "obligation";
     public static final String TYPE_TODO = "todo";

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -232,20 +232,16 @@ public class SW360Utils {
         return getVersionedName(release.getName(), release.getVersion());
     }
 
-    public static Attachment getApprovedClxAttachmentForRelease(Release release) {
+    public static List<Attachment> getApprovedClxAttachmentForRelease(Release release) {
         Predicate<Attachment> isApprovedCLI = attachment -> attachment.getCheckStatus().equals(CheckStatus.ACCEPTED)
                 && AttachmentType.COMPONENT_LICENSE_INFO_XML.equals(attachment.getAttachmentType());
 
-        List<Attachment> attachmentList = release.getAttachments().stream().filter(isApprovedCLI).collect(Collectors.toList());
+        return release.getAttachments().stream().filter(isApprovedCLI).collect(Collectors.toList());
+    }
 
-        if (CommonUtils.isNotEmpty(attachmentList)) {
-            if (attachmentList.size() == 1) {
-                return attachmentList.get(0);
-            } else {
-                log.warn("More then 1 Accepted CLI file for Release: " + release.getId() + " - " + printName(release));
-            }
-        }
-        return new Attachment();
+    public static Map<String, String> getReleaseIdtoAcceptedCLIMappings(Map<String, ObligationStatusInfo> obligationStatusMap) {
+        return obligationStatusMap.values().stream().flatMap(e -> e.getReleaseIdToAcceptedCLI().entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (oldValue, newValue) -> oldValue));
     }
 
     public static String printFullname(Release release) {

--- a/libraries/lib-datahandler/src/main/thrift/licenseinfo.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/licenseinfo.thrift
@@ -117,9 +117,10 @@ service LicenseInfoService {
     list<ObligationParsingResult> getObligationsForAttachment(1: Release release, 2: string attachmentContentId, 3: User user);
 
     /**
-     * populates the linked obligation status.
+     * remove the obligation associated with excluded release,
+     * and set the linked obligation status in project.
      */
-    map<Project, list<LicenseInfoParsingResult>> setProjectObligationStatus(1: Project project, 2: list<LicenseInfoParsingResult> licenseInfoResults);
+    map<Project, list<LicenseInfoParsingResult>> setProjectObligationStatus(1: Project project, 2: list<LicenseInfoParsingResult> licenseInfoResults, 3: map<string, string> excludedReleaseIdToAcceptedCLI);
 
     /**
      * create the mapping between license and obligations

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -186,7 +186,7 @@ struct ObligationStatusInfo {
     6: optional string modifiedOn,
     7: optional set<Release> releases, // used to display in UI, no need to save this in database
     8: required set<string> licenseIds,
-    9: optional set<string> releaseIds,
+    9: optional map<string, string> releaseIdToAcceptedCLI,
 }
 
 service ProjectService {


### PR DESCRIPTION
Changes included:

- Added config key `project.obligations.enabled` to _enable/disable_ the project obligations feature in sw360.properties. By default the feature is **disabled**.
- Delete the project obligations associated with individual `linked release`, if:
    1. Previously accepted CLI.xml file is **rejected** _or_ **deleted**.
    2. Accepted more than **ONE**  CLI.xml file at later point of time.
- To display the message if there is any changes in previously accepted CLI.xml file of `linked release`.
- Commented the code for `Action` field of obligation (to hide it in UI), until action select options are provided.


closes #726 

Signed-off-by: akapti <abdul.mannankapti@siemens.com>