### PR TITLE
fix(ui): Added missing tooltip

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/todos/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/todos/view.jsp
@@ -127,11 +127,10 @@
                     }),
                     $deleteAction = $('<svg>', {
                         'class': 'delete lexicon-icon',
-                        title: 'Delete',
                         'data-id': value,
                         'data-title': row.title
                     });
-                $deleteAction.append($('<use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#trash"/>'));
+                $deleteAction.append($('<title>Delete</title><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#trash"/>'));
 
                 $actions.append($deleteAction);
                 return $actions[0].outerHTML;

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/view.jsp
@@ -305,18 +305,17 @@
                     $editAction = render.linkTo(
                         makeComponentUrl(id, '<%=PortalConstants.PAGENAME_EDIT%>'),
                         "",
-                        '<svg class="lexicon-icon" title="Edit"><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#pencil"/></svg>'
+                        '<svg class="lexicon-icon"><title>Edit</title><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#pencil"/></svg>'
                     ),
                     $deleteAction = $('<svg>', {
                         'class': 'delete lexicon-icon',
-                        title: 'Delete',
                         'data-component-id': id,
                         'data-component-name': row.name,
                         'data-component-release-count': row.lRelsSize,
                         'data-component-attachment-count': row.attsSize,
                     });
             
-                $deleteAction.append($('<use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#trash"/>'));
+                $deleteAction.append($('<title>Delete</title><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#trash"/>'));
 
                 $actions.append($editAction, $deleteAction);
                 return $actions[0].outerHTML;

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/ajax/linkedProjectsAjax.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/ajax/linkedProjectsAjax.jsp
@@ -45,7 +45,8 @@
             </div>
         </td>
         <td class="content-middle">
-            <svg title="Delete" class="action lexicon-icon" data-row-id="projectLinkRow${uuid}">
+            <svg class="action lexicon-icon" data-row-id="projectLinkRow${uuid}">
+                <title>Delete</title>
                 <use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#trash"/>
             </svg>
         </td>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/clearingStatus.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/clearingStatus.jspf
@@ -74,7 +74,7 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
                 $editAction = render.linkTo(
                     makeReleaseUrl(row[6]),
                     "",
-                    '<svg class="lexicon-icon" title="Edit"><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#pencil"/></svg>'
+                    '<svg class="lexicon-icon"><title>Edit</title><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#pencil"/></svg>'
                 );
 
             $actions.append($editAction);

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/view.jsp
@@ -294,11 +294,10 @@
                     $copyAction = render.linkTo(
                         makeProjectUrl(id, '<%=PortalConstants.PAGENAME_DUPLICATE%>'),
                         "",
-                        '<svg class="lexicon-icon" title="Duplicate"><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#paste"/></svg>'
+                        '<svg class="lexicon-icon"><title>Duplicate</title><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#paste"/></svg>'
                     ),
                     $deleteAction = $('<svg>', {
                         'class': 'delete lexicon-icon',
-                        title: 'Delete',
                         'data-project-id': id,
                         'data-project-name': row.name,
                         'data-linked-projects-count': row.lProjSize,
@@ -306,7 +305,7 @@
                         'data-project-attachment-count': row.attsSize,
                     });
 
-                $deleteAction.append($('<use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#trash"/>'));
+                $deleteAction.append($('<title>Delete</title><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#trash"/>'));
 
                 if(row.cState == 'CLOSED' && ${isUserAdmin != 'Yes'}) {
                     $editAction = $('<svg class="lexicon-icon disabled"><title>Only administrators can edit a closed project.</title><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#pencil"/></svg>');
@@ -335,10 +334,10 @@
                 });
                 var $psBox = $('<div>', {
                     'class': 'stateBox capsuleLeft ' + projectStateBackgroundColour
-                }).text('PS');
+                }).text('PS').attr("title", "Project state: "+ row.state);
                 var $csBox = $('<div>', {
                     'class': 'stateBox capsuleRight ' + clearingStateBackgroundColour
-                }).text('CS');
+                }).text('CS').attr("title", "Project clearing state: " + row.cState);
 
                 $state.append($psBox, $csBox);
                 return $state[0].outerHTML;

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/ajax/linkedReleasesAjax.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/ajax/linkedReleasesAjax.jsp
@@ -68,7 +68,8 @@
             </div>
         </td>
         <td class="content-middle">
-            <svg title="Delete" class="action lexicon-icon" data-row-id="releaseLinkRow${uuid}" data-release-name="<sw360:out value='${releaseLink.longName}' jsQuoting="true"/>">
+            <svg class="action lexicon-icon" data-row-id="releaseLinkRow${uuid}" data-release-name="<sw360:out value='${releaseLink.longName}' jsQuoting="true"/>">
+                <title>Delete</title>
                 <use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#trash"/>
             </svg>
         </td>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/editAdditionalData.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/editAdditionalData.jsp
@@ -83,7 +83,8 @@
                 '<input class="form-control" id="<%=PortalConstants.ADDITIONAL_DATA_VALUE%>' + rowId + '" name="<portlet:namespace/><%=PortalConstants.ADDITIONAL_DATA_VALUE%>' + rowId + '" required="" minlength="1" placeholder="Enter additional data value" title="additional data value" value="' + value + '"/>' +
                 '</td>' +
                 '<td class="content-middle">' +
-                '<svg title="Delete" class="action lexicon-icon" data-row-id="' + rowId + '">' +
+                '<svg class="action lexicon-icon" data-row-id="' + rowId + '">' +
+                '<title>Delete</title>' +
                 '<use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#trash"/>' +
                 '</svg>' +
                 '</td>' +

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/editExternalIds.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/editExternalIds.jsp
@@ -82,7 +82,8 @@
                 '<input class="form-control" id="<%=PortalConstants.EXTERNAL_ID_VALUE%>' + rowId + '" name="<portlet:namespace/><%=PortalConstants.EXTERNAL_ID_VALUE%>' + rowId + '" required="" minlength="1" placeholder="Enter external id value" title="external id value" value="' + value + '"/>' +
                 '</td>' +
                 '<td class="content-middle">' +
-                '<svg title="Delete" class="action lexicon-icon" data-row-id="' + rowId + '">' +
+                '<svg class="action lexicon-icon" data-row-id="' + rowId + '">' +
+                '<title>Delete</title>' +
                 '<use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#trash"/>' +
                 '</svg>' +
                 '</td>' +

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/mapEdit.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/mapEdit.jspf
@@ -35,7 +35,8 @@
                     </td>
 
                     <td class="content-middle">
-                        <svg class="action lexicon-icon" title="Delete" data-row-id="mapEditTableRow${loop1.count}_${loop2.count}">
+                        <svg class="action lexicon-icon" data-row-id="mapEditTableRow${loop1.count}_${loop2.count}">
+                            <title>Delete</title>
                             <use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#trash"/>
                         </svg>
                     </td>
@@ -92,7 +93,8 @@
                 '<input id="<%=PortalConstants.CUSTOM_MAP_VALUE%>'+randomRowId+'" name="<portlet:namespace/><%=PortalConstants.CUSTOM_MAP_VALUE%>'+randomRowId+'" type="email" class="form-control" placeholder="${inputSubtitle}" title="${inputSubtitle}" />'+
                 '</td>'+
                 '<td class="content-middle">'+
-                '<svg title="Delete" class="action lexicon-icon" data-row-id="' + randomRowId + '">' +
+                '<svg class="action lexicon-icon" data-row-id="' + randomRowId + '">' +
+                '<title>Delete</title>' +
                 '<use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#trash"/>' +
                 '</svg>' +
                 '</td>'+


### PR DESCRIPTION
* Fixed the tool tip by converting the title attribute to title tag and added the missing tool tip for clearing state and project active state in the project listing page.

Signed-off-by: Smruti Sahoo <smruti.sahoo@siemens.com>