### PR TITLE
feat(ProjectMigration): script to migrate a project field to new value

### DIFF
--- a/scripts/utilities/001_update_project_field_value.py
+++ b/scripts/utilities/001_update_project_field_value.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+# -----------------------------------------------------------------------------
+# Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+#
+# All rights reserved.   This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# This is a manual database migration script. It is assumed that a
+# dedicated framework for automatic migration will be written in the
+# future. When that happens, this script should be refactored to conform
+# to the framework's prerequisites to be run by the framework. For
+# example, server address and db name should be parameterized, the code
+# reorganized into a single class or function, etc.
+# -----------------------------------------------------------------------------
+
+import time
+import couchdb
+import json
+from webbrowser import get
+
+# ---------------------------------------
+# constants
+# ---------------------------------------
+
+DRY_RUN = True
+
+COUCHSERVER = "http://localhost:5984/"
+DBNAME = 'sw360db'
+
+couch = couchdb.Server(COUCHSERVER)
+db = couch[DBNAME]
+
+# set values for field to be updated, OldValue and NewValue
+fieldName = "field_to_be_migrated"
+oldValue = "old_value"
+newValue = "new_value"
+
+# ----------------------------------------
+# queries
+# ----------------------------------------
+
+# get all the projects with oldValue
+projects_all_query = '''function(doc){
+    if (doc.type == "project" && doc.''' + fieldName + ''' == "''' + oldValue + '''"){
+        emit(doc._id, doc)
+    }
+}'''
+
+# ---------------------------------------
+# functions
+# ---------------------------------------
+
+def run():
+    log = {}
+    log['updatedProjects'] = []
+    print 'Getting all projects with ' + fieldName + ' as ' + oldValue
+    projects_all = db.query(projects_all_query)
+    print 'Received ' + str(len(projects_all)) + ' projects'
+    log['totalCount'] = len(projects_all)
+
+    for projectRow in projects_all:
+        project = projectRow.value
+        project[fieldName] = newValue
+        print '\tUpdating project ID -> ' + project.get('_id') + ', Project Name -> ' + project.get('name')
+        updatedProject = {}
+        updatedProject['id'] = project.get('_id')
+        updatedProject['name'] = project.get('name')
+        log['updatedProjects'].append(updatedProject)
+        if not DRY_RUN:
+            db.save(project)
+    resultFile = open('015_migration.log', 'w')
+    json.dump(log, resultFile, indent = 4, sort_keys = True)
+    resultFile.close()
+
+    print '\n'
+    print '------------------------------------------'
+    print 'Total Projects with ' + fieldName + ' as ' + oldValue + ': ' + str(len(projects_all))
+    print '------------------------------------------'
+    print 'Please check log file "015_migration.log" in this directory for details'
+    print '------------------------------------------'
+
+# --------------------------------
+
+startTime = time.time()
+run()
+print '\nTime of migration: ' + "{0:.2f}".format(time.time() - startTime) + 's'

--- a/scripts/utilities/README.md
+++ b/scripts/utilities/README.md
@@ -1,0 +1,24 @@
+# Utilities
+
+This folder contains utility scripts which implement the database schema changes.
+
+The scripts are written in `python2` and depend on `python2-couchdb`. The couchdb has to run and be accessible on `localhost:5984`.
+
+To execute it is recommended to do this in the following order:
+1. ensure that couchdb is accessible (try to open `http://localhost:5984/_utils/`)
+2. run the utility scripts (i.e. for each script call `python2 /PATH/TO/00?_some_utility_script.py`)
+    * be aware that some scripts are using an internal dry-run switch which you have to change manually in the script's code
+
+## List and Description of script
+- `001_update_project_field_value.py`
+    - Script to update a field*(String)* in project document to a new value.
+      Following variables needs to be updated based on the requirement
+      1. `fieldName` = *"field_to_be_migrated"*
+      2. `oldValue` = *"old_value"*
+      3. `newValue` = *"new_value"*
+
+## Run the scripts for a database not running on localhost
+tbd.
+
+## Run the scripts within docker
+You can use the bash script `./dockerized-migration-runner.sh` to run the scripts wrapped within a docker container.


### PR DESCRIPTION
Migration script to migrate a project field to new value.
Following variables needs to be updated based on requirement
`fieldName` = "field_to_be_migrated"
`oldValue` = "old_value"
`newValue` = "new_value"

For updating ClearingTeam Field in Project - `clearing.teams` property in `sw360.properties` file should be updated accordingly

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>