### PR TITLE
feat(WelcomePageUI): display configurable content for guidelines on welcome page

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -41,6 +41,7 @@ public class PortalConstants {
     public static final Boolean IS_CLEARING_TEAM_UNKNOWN_ENABLED;
     public static final Set<String> PROJECT_OBLIGATIONS_ACTION_SET;
     public static final Boolean IS_PROJECT_OBLIGATIONS_ENABLED;
+    public static final Boolean CUSTOM_WELCOME_PAGE_GUIDELINE;
 
     // DO NOT CHANGE THIS UNLESS YOU KNOW WHAT YOU ARE DOING !!!
     // - friendly url mapping files must be changed
@@ -541,6 +542,7 @@ public class PortalConstants {
         IS_CLEARING_TEAM_UNKNOWN_ENABLED = Boolean.parseBoolean(props.getProperty("clearing.team.unknown.enabled", "true"));
         PROJECT_OBLIGATIONS_ACTION_SET = CommonUtils.splitToSet(props.getProperty("project.obligation.actions", "Action 1,Action 2,Action 3"));
         IS_PROJECT_OBLIGATIONS_ENABLED = Boolean.parseBoolean(props.getProperty("project.obligations.enabled", "true"));
+        CUSTOM_WELCOME_PAGE_GUIDELINE = Boolean.parseBoolean(props.getProperty("custom.welcome.page.guideline", "false"));
 
         // SW360 REST API Constants
         API_TOKEN_ENABLE_GENERATOR = Boolean.parseBoolean(props.getProperty("rest.apitoken.generator.enable", "false"));

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
@@ -40,6 +40,7 @@ import org.eclipse.sw360.portal.users.UserCacheHolder;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.ResourceRequest;
+import javax.portlet.RenderRequest;
 
 import java.util.*;
 import java.util.function.Function;
@@ -61,6 +62,7 @@ import static org.eclipse.sw360.datahandler.common.CommonUtils.*;
 public class PortletUtils {
 
     private static final Logger LOGGER = Logger.getLogger(PortletUtils.class);
+    private static final String TEMPLATE_FILE = "/welcomePageGuideline.html";
 
     private PortletUtils() {
         // Utility class with only static functions
@@ -406,5 +408,14 @@ public class PortletUtils {
     public static Comparator<Project> compareByDescription(boolean isAscending) {
         Comparator<Project> comparator = Comparator.comparing(p -> nullToEmptyString(p.getDescription()));
         return isAscending ? comparator : comparator.reversed();
+    }
+
+    public static void setWelcomePageGuideLine(RenderRequest request) {
+        String welcomePageGuideLine = null;
+        if (PortalConstants.CUSTOM_WELCOME_PAGE_GUIDELINE) {
+            welcomePageGuideLine = new String(
+                    CommonUtils.loadResource(PortletUtils.class, TEMPLATE_FILE).orElse(new byte[0]));
+        }
+        request.setAttribute("welcomePageGuideLine", welcomePageGuideLine);
     }
 }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/signup/SignupPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/signup/SignupPortlet.java
@@ -22,6 +22,7 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.portal.common.ErrorMessages;
 import org.eclipse.sw360.portal.common.PortalConstants;
+import org.eclipse.sw360.portal.common.PortletUtils;
 import org.eclipse.sw360.portal.common.UsedAsLiferayAction;
 import org.eclipse.sw360.portal.portlets.Sw360Portlet;
 import org.eclipse.sw360.portal.users.UserUtils;
@@ -64,6 +65,7 @@ public class SignupPortlet extends Sw360Portlet {
     @Override
     public void doView(RenderRequest request, RenderResponse response) throws IOException, PortletException {
         String pageName = request.getParameter(PortalConstants.PAGENAME);
+        PortletUtils.setWelcomePageGuideLine(request);
         if (PortalConstants.PAGENAME_SUCCESS.equals(pageName)) {
             include("/html/homepage/signup/success.jsp", request, response);
         } else {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/welcome/WelcomePortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/welcome/WelcomePortlet.java
@@ -12,11 +12,17 @@ package org.eclipse.sw360.portal.portlets.homepage.welcome;
 
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 
+import org.eclipse.sw360.portal.common.PortletUtils;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import javax.portlet.Portlet;
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
 
 import static org.eclipse.sw360.portal.common.PortalConstants.WELCOME_PORTLET_NAME;
+
+import java.io.IOException;
 
 @org.osgi.service.component.annotations.Component(
     immediate = true,
@@ -37,4 +43,9 @@ import static org.eclipse.sw360.portal.common.PortalConstants.WELCOME_PORTLET_NA
     configurationPolicy = ConfigurationPolicy.REQUIRE
 )
 public class WelcomePortlet extends MVCPortlet {
+    @Override
+    public void doView(RenderRequest request, RenderResponse response) throws IOException, PortletException {
+        PortletUtils.setWelcomePageGuideLine(request);
+        super.doView(request, response);
+    }
 }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/homepage/signup/success.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/homepage/signup/success.jsp
@@ -15,12 +15,17 @@
 
 
 <div class="jumbotron">
-	<h1 class="display-4">Welcome to SW360!</h1>
-	<p class="lead">
+    <core_rt:if test="${not empty welcomePageGuideLine}">
+        ${welcomePageGuideLine}
+    </core_rt:if>
+    <core_rt:if test="${empty welcomePageGuideLine}">
+        <h1 class="display-4">Welcome to SW360!</h1>
+        <p class="lead">
 		SW360 is an open source software project that provides both a web application and a repository to collect,
 		organize and make available information about software components. It establishes a central hub for software
 		components in an organization.
-	</p>
+        </p>
+    </core_rt:if>
 	<hr class="my-4">
 	<div class="alert alert-success" role="alert">
 		Your account has been created, but it is still inactive. An administrator will review it and activate it.

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/homepage/signup/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/homepage/signup/view.jsp
@@ -30,12 +30,17 @@
 </portlet:actionURL>
 
 <div class="jumbotron">
-	<h1 class="display-4">Welcome to SW360!</h1>
-	<p class="lead">
+    <core_rt:if test="${not empty welcomePageGuideLine}">
+        ${welcomePageGuideLine}
+    </core_rt:if>
+    <core_rt:if test="${empty welcomePageGuideLine}">
+        <h1 class="display-4">Welcome to SW360!</h1>
+        <p class="lead">
 		SW360 is an open source software project that provides both a web application and a repository to collect,
 		organize and make available information about software components. It establishes a central hub for software
 		components in an organization.
-	</p>
+        </p>
+    </core_rt:if>
 	<hr class="my-4">
 	<core_rt:if test="${themeDisplay.signedIn}">
 		<h3>You are signed in, please go ahead using SW360!</h3>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/homepage/welcome/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/homepage/welcome/view.jsp
@@ -14,12 +14,17 @@
 <liferay-theme:defineObjects/>
 
 <div class="jumbotron">
-	<h1 class="display-4">Welcome to SW360!</h1>
-	<p class="lead">
+    <core_rt:if test="${not empty welcomePageGuideLine}">
+        ${welcomePageGuideLine}
+    </core_rt:if>
+    <core_rt:if test="${empty welcomePageGuideLine}">
+	    <h1 class="display-4">Welcome to SW360!</h1>
+	    <p class="lead">
 		SW360 is an open source software project that provides both a web application and a repository to collect,
 		organize and make available information about software components. It establishes a central hub for software
 		components in an organization.
-	</p>
+	    </p>
+    </core_rt:if>
 	<hr class="my-4">
 	<core_rt:if test="${themeDisplay.signedIn}">
 		<h3>You are signed in, please go ahead using SW360!</h3>

--- a/frontend/sw360-portlet/src/main/resources/welcomePageGuideline.html
+++ b/frontend/sw360-portlet/src/main/resources/welcomePageGuideline.html
@@ -1,0 +1,7 @@
+<h1 class="display-4">Welcome to SW360!</h1>
+<p class="lead">SW360 is an open source software project that
+    provides both a web application and a repository to collect,
+    organize and make available information about software components.
+    It establishes a central hub for software components in an
+    organization.
+</p>


### PR DESCRIPTION
Description: Display configurable content for guidelines on welcome page

To configure guidelines on welcome page, 

- set `custom.welcome.page.guideline = true` in `sw360.properties`

- put the content for guidelines in `welcomePageGuideline.html` 

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>