### PR TITLE
feat(fossology-pull-report): Pull already generated report from the fossology

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -426,6 +426,8 @@ public class PortalConstants {
     public static final String FOSSOLOGY_ACTION_STATUS = FOSSOLOGY_PREFIX + "status";
     public static final String FOSSOLOGY_ACTION_PROCESS = FOSSOLOGY_PREFIX + "process";
     public static final String FOSSOLOGY_ACTION_OUTDATED = FOSSOLOGY_PREFIX + "outdated";
+    public static final String FOSSOLOGY_ACTION_RELOAD_REPORT = FOSSOLOGY_PREFIX + "reload_report";
+    public static final String FOSSOLOGY_JOB_VIEW_LINK = "fossologyJobViewLink";
 
     public static final String RELEASES_AND_PROJECTS = "releasesAndProjects";
 

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/fossologyClearing.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/fossologyClearing.jspf
@@ -21,6 +21,9 @@
 <portlet:resourceURL var="outdatedURL">
     <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.FOSSOLOGY_ACTION_OUTDATED%>'/>
 </portlet:resourceURL>
+<portlet:resourceURL var="triggerReportGenURL">
+    <portlet:param name="<%=PortalConstants.ACTION%>" value='<%=PortalConstants.FOSSOLOGY_ACTION_RELOAD_REPORT%>'/>
+</portlet:resourceURL>
 
 
 <div class="dialogs">
@@ -29,6 +32,7 @@
         data-fossology-status-url="<%=statusURL%>"
         data-fossology-process-url="<%=processURL%>"
         data-fossology-outdated-url="<%=outdatedURL%>"
+        data-fossology-generate-report-url="<%=triggerReportGenURL%>"
         data-step-name-upload="<%=FossologyUtils.FOSSOLOGY_STEP_NAME_UPLOAD %>"
         data-step-name-scan="<%=FossologyUtils.FOSSOLOGY_STEP_NAME_SCAN %>"
         data-step-name-report="<%=FossologyUtils.FOSSOLOGY_STEP_NAME_REPORT %>"
@@ -76,16 +80,24 @@
                         </div>
                     </div>
                     <div class="row mt-4">
-                        <div class="col">
-                            <div class="auto-refresh text-right">
+                        <div class="col-md-12">
+                            <div class="auto-refresh">
                                 Auto-refresh in <span id="auto-refresh-seconds" class="ml-2">5</span>
                             </div>
                         </div>
+                        <core_rt:if test="${not empty fossologyJobViewLink}">
+                            <div class="col-md-12">
+                                <div class="fossology-link">
+                                    <a target="_blank" href="${fossologyJobViewLink}">Job view of FOSSology</a>
+                                </div>
+                            </div>
+                        </core_rt:if>
                     </div>
 				</div>
 
                 <div class="modal-footer">
                     <button type="button" class="btn btn-light" data-submit="outdated">Set Outdated</button>
+                    <button type="button" class="btn btn-light" data-submit="reload_report">Reload Report</button>
                     <button type="button" class="btn btn-light" data-dismiss="modal">Close</button>
                 </div>
 			</div>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/utils/includes/fossologyClearing.js
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/utils/includes/fossologyClearing.js
@@ -39,6 +39,9 @@ define('utils/includes/fossologyClearing', [
                 if (submit == 'outdated') {
                     setOutdated(releaseId);
                     callback(false);
+                } else if (submit == 'reload_report') {
+                    generateReport(releaseId);
+                    callback(false);
                 }
             },
             // beforeShow:
@@ -49,6 +52,19 @@ define('utils/includes/fossologyClearing', [
         $dialog.$.on('hidden.bs.modal', function() {
             clearTimeout(timeoutId);
             dialogOpen = false;
+        });
+    }
+
+    function generateReport(releaseId){
+        dialogOpen = true;
+        $('.auto-refresh').show();
+        fossologyRequest(config.fossologyGenerateReportUrl, releaseId)
+        .then(function(data) {
+            handleSuccessResult($dialog, releaseId, data);
+        })
+        .catch(function(message) {
+            $dialog.closeMessage();
+            $dialog.alert(message, false);
         });
     }
 

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
@@ -556,7 +557,7 @@ public class SW360Utils {
      */
     public static ExternalToolProcessStep getExternalToolProcessStepOfFirstProcessForTool(Release release,
             ExternalTool et, String stepName) {
-        if (release == null || et == null || StringUtils.isEmpty(stepName)) {
+        if (release == null || et == null || CommonUtils.isNullEmptyOrWhitespace(stepName)) {
             return null;
         }
 
@@ -564,7 +565,7 @@ public class SW360Utils {
                 .stream() //
                 .findFirst() //
                 .map(ExternalToolProcess::getProcessSteps) //
-                .get() //
+                .orElseGet(Lists::newArrayList)//
                 .stream() //
                 .filter(etps -> stepName.equals(etps.getStepName())) //
                 .findFirst() //

--- a/libraries/lib-datahandler/src/main/thrift/fossology.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/fossology.thrift
@@ -54,4 +54,9 @@ service FossologyService {
      **/
     RequestStatus markFossologyProcessOutdated(1: string releaseId, 2: User user);
 
+    /**
+     * only trigger the report generation for already scanned documents.
+     **/
+    RequestStatus triggerReportGenerationFossology(1: string releaseId, 2: User user);
+
 }


### PR DESCRIPTION
* Added an extra button to pull the report from from fossology, in case uploading and scanning of the report already done to prevent redundant upload and scanning.
* Moved the `auto-refresh` section to the left and added hyperlink to view fossology job for the respective source file.

Signed-off-by: Smruti Sahoo <smruti.sahoo@siemens.com>