### PR TITLE
fix(ProjectUI): Show proper error msg ,when loading of project fails due to access or dependency not found.

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -153,7 +153,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         assertNotNull(project);
 
         if(!makePermission(project, user).isActionAllowed(RequestedAction.READ)) {
-            throw fail("User " + user + " is not allowed to view the requested project " + project + "!");
+            throw fail(403, "User: %s is not allowed to view the requested project: %s", user.getEmail(), project.getId());
         }
 
         return project;

--- a/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -18,6 +18,7 @@ import org.eclipse.sw360.datahandler.db.ProjectDatabaseHandler;
 import org.eclipse.sw360.datahandler.db.ProjectSearchHandler;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.components.ReleaseClearingStatusData;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
@@ -123,7 +124,7 @@ public class ProjectHandler implements ProjectService.Iface {
     ////////////////////////////
 
     @Override
-    public Project getProjectById(String id, User user) throws TException {
+    public Project getProjectById(String id, User user) throws SW360Exception {
         assertUser(user);
         assertId(id);
 
@@ -257,7 +258,7 @@ public class ProjectHandler implements ProjectService.Iface {
     }
 
     @Override
-    public List<ReleaseClearingStatusData> getReleaseClearingStatuses(String projectId, User user) throws TException {
+    public List<ReleaseClearingStatusData> getReleaseClearingStatuses(String projectId, User user) throws SW360Exception {
         return handler.getReleaseClearingStatuses(projectId, user);
     }
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
@@ -50,6 +50,8 @@ public class ErrorMessages {
     public static final String REST_API_TOKEN_ERROR = "Token could not generated/deleted. Please verify if the service is available.";
     public static final String REST_API_TOKEN_NAME_DUPLICATE = "Token name already exists.";
     public static final String REST_API_EXPIRE_DATE_NOT_VALID = "Your selected token expiration date is not valid.";
+    public static final String ERROR_PROJECT_OR_DEPENDENCIES_NOT_FOUND = "Error fetching project. Project or its dependencies are not found.";
+    public static final String ERROR_PROJECT_OR_LINKEDPROJECT_NOT_ACCESSIBLE = "Error fetching project. Project or its Linked Projects are not accessible.";
 
     //this map is used in errorKeyToMessage.jspf to generate key-value pairs for the liferay-ui error tag
     public static final ImmutableList<String> allErrorMessages = ImmutableList.<String>builder()
@@ -86,6 +88,8 @@ public class ErrorMessages {
             .add(REST_API_TOKEN_ERROR)
             .add(REST_API_TOKEN_NAME_DUPLICATE)
             .add(REST_API_EXPIRE_DATE_NOT_VALID)
+            .add(ERROR_PROJECT_OR_DEPENDENCIES_NOT_FOUND)
+            .add(ERROR_PROJECT_OR_LINKEDPROJECT_NOT_ACCESSIBLE)
             .build();
 
     private ErrorMessages() {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
@@ -326,6 +326,16 @@ abstract public class Sw360Portlet extends MVCPortlet {
         setSessionMessage(request, requestStatus, type, verb, null);
     }
 
+    public void setSessionErrorBasedOnErrorCode(RenderRequest request, int errorCode) {
+        if (errorCode == 404) {
+            setSW360SessionError(request, ErrorMessages.ERROR_PROJECT_OR_DEPENDENCIES_NOT_FOUND);
+        } else if (errorCode == 403) {
+            setSW360SessionError(request, ErrorMessages.ERROR_PROJECT_OR_LINKEDPROJECT_NOT_ACCESSIBLE);
+        } else {
+            setSW360SessionError(request, ErrorMessages.ERROR_GETTING_PROJECT);
+        }
+    }
+
     protected void addEditDocumentMessage(RenderRequest request, Map<RequestedAction, Boolean> permissions, DocumentState documentState) {
 
         List<String> msgs = new ArrayList<>();

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -1001,6 +1001,8 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 if (PortalConstants.IS_PROJECT_OBLIGATIONS_ENABLED && project.getReleaseIdToUsageSize() > 0) {
                     request.setAttribute(OBLIGATION_DATA, loadLinkedObligations(request, project));
                 }
+            } catch (SW360Exception sw360Exp) {
+                setSessionErrorBasedOnErrorCode(request, sw360Exp.getErrorCode());
             } catch (TException e) {
                 log.error("Error fetching project from backend!", e);
                 setSW360SessionError(request, ErrorMessages.ERROR_GETTING_PROJECT);
@@ -1308,6 +1310,9 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 project = client.getProjectByIdForEdit(id, user);
                 usingProjects = client.searchLinkingProjects(id, user);
                 allUsingProjectCount = client.getCountByProjectId(id);
+            } catch (SW360Exception sw360Exp) {
+                setSessionErrorBasedOnErrorCode(request, sw360Exp.getErrorCode());
+                return;
             } catch (TException e) {
                 log.error("Something went wrong with fetching the project", e);
                 setSW360SessionError(request, ErrorMessages.ERROR_GETTING_PROJECT);

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Assert.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Assert.java
@@ -40,7 +40,7 @@ public class SW360Assert {
 
     public static <T> T assertNotNull(T object, String messageFormat, Object... args) throws SW360Exception {
         if (object == null) {
-            throw fail(messageFormat, args);
+            throw fail(404, messageFormat, args);
         }
         return object;
     }
@@ -128,6 +128,13 @@ public class SW360Assert {
     public static SW360Exception fail(String messageFormat, Object... args) throws SW360Exception {
         SW360Exception sw360Exception = new SW360Exception();
         throw fail(sw360Exception, messageFormat, args);
+    }
+
+    public static SW360Exception fail(int errorCode, String messageFormat, Object... args) throws SW360Exception {
+        String message = String.format(messageFormat, args);
+        SW360Exception exp = new SW360Exception(message).setErrorCode(errorCode);
+        log.error(message, exp);
+        throw exp;
     }
 
     public static SW360Exception fail(Throwable t, String messageFormat, Object... args) throws SW360Exception {

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -27,6 +27,7 @@ typedef sw360.ReleaseRelationship ReleaseRelationship
 typedef sw360.MainlineState MainlineState
 typedef sw360.ProjectReleaseRelationship ProjectReleaseRelationship
 typedef sw360.ObligationStatus ObligationStatus
+typedef sw360.SW360Exception SW360Exception
 typedef components.Release Release
 typedef components.ReleaseClearingStateSummary ReleaseClearingStateSummary
 typedef users.User User
@@ -262,7 +263,7 @@ service ProjectService {
      * get a project by id, if it is visible for the user
      * (part of project CRUD support)
      */
-    Project getProjectById(1: string id, 2: User user);
+    Project getProjectById(1: string id, 2: User user) throws (1: SW360Exception exp);
 
     /**
      * get multiple projects by id, if they are visible to the user
@@ -350,7 +351,7 @@ service ProjectService {
     /**
      * get clearing status data for all releases linked by the given project and its subprojects
      */
-    list<ReleaseClearingStatusData> getReleaseClearingStatuses(1: string projectId, 2: User user);
+    list<ReleaseClearingStatusData> getReleaseClearingStatuses(1: string projectId, 2: User user) throws (1: SW360Exception exp);
 
     /**
      * get the count value of projects which have `id` in releaseIdToUsage

--- a/libraries/lib-datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/sw360.thrift
@@ -46,6 +46,7 @@ enum AddDocumentRequestStatus {
 
 exception SW360Exception {
     1: required string why,
+    2: optional i32 errorCode,
 }
 
 enum ModerationState {


### PR DESCRIPTION
If user doesn't have access to a Project or its LinkedProject or some of project dependencies are missing . It gives generic Error.
Show proper error message ,when loading of project fails due to access denied or dependencies not found.

closes: #746 , #240 

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>