### PR TITLE
Adding rolling versions based on commit count

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,16 +34,20 @@ before_install:
   - sudo apt-get install -y couchdb
   - sudo service couchdb restart
   - ./scripts/install-thrift.sh --no-cleanup
-install: mvn dependency:resolve || true
 
-env: MVN_ARGS="package"
-script: mvn --fail-at-end $MVN_ARGS
+env:
+  GIT_COMMIT_COUNT="$(git rev-list  `git rev-list --tags --no-walk --max-count=1`..HEAD --count)"
+  MVN_ARGS="package"
+install:
+  mvn dependency:resolve || true
+script:
+  mvn --fail-at-end $MVN_ARGS
 
 matrix:
   include:
-    - name: mvn package
+    - name: mvn package -Pci -Dcount=$GIT_COMMIT_COUNT
       env: MVN_ARGS="package"
-    - name: mvn validate
+    - name: mvn validate -Pci -Dcount=$GIT_COMMIT_COUNT
       env: MVN_ARGS="validate"
       before_install:
     - name: mvn dependency:analyze

--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,11 @@
     </modules>
 
     <properties>
-        <!-- This is the single place for changing the version of SW360 -->
-        <revision>7.1.0-SNAPSHOT</revision>
-
+        <!-- This is first of two places for changing the version of SW360 -->
+        <!-- note that 6.1.0-SNAPSHOT relates to 6.0.${patchlevel} -->
+        <!-- pls see also the profile cli -->
+        <revision>7.${patchlevel}</revision>
+        <patchlevel>1.0-SNAPSHOT</patchlevel>
         <java.version>1.8</java.version>
         <ektorp.version>1.5.0</ektorp.version>
         <thrift.version>0.11.0</thrift.version>
@@ -443,6 +445,16 @@
                         </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+        <activation>
+            <activeByDefault>false</activeByDefault>
+        </activation>
+        <id>ci</id>
+        <properties>
+            <!-- second of two places for version setting: minor version -->
+            <patchlevel>0.${count}</patchlevel>
+        </properties>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Using the command:

```
git rev-list  `git rev-list --tags --no-walk --max-count=1`..HEAD --count
```

which returns the number of commits since last tag on this branch, we would like to increase the patch level version which should be increased automatically.

Making it a PR beause we would like to see travis working on it.
