### PR TITLE
feat(REST): Patch Releases to Project

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -248,7 +248,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         Release release = releaseRepository.get(id);
 
         if (release == null) {
-            throw fail("Could not fetch release from database! id=" + id);
+            throw fail(404, "Could not fetch release from database! id=" + id);
         }
 
         vendorRepository.fillVendor(release);

--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -161,7 +161,7 @@ public class ComponentHandler implements ComponentService.Iface {
     }
 
     @Override
-    public Release getReleaseById(String id, User user) throws TException {
+    public Release getReleaseById(String id, User user) throws SW360Exception {
         assertId(id);
         assertUser(user);
 

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -24,6 +24,7 @@ typedef sw360.DocumentState DocumentState
 typedef sw360.ReleaseRelationship ReleaseRelationship
 typedef sw360.MainlineState MainlineState
 typedef sw360.ProjectReleaseRelationship ProjectReleaseRelationship
+typedef sw360.SW360Exception SW360Exception
 typedef attachments.Attachment Attachment
 typedef attachments.FilledAttachment FilledAttachment
 typedef users.User User
@@ -487,7 +488,7 @@ service ComponentService {
     /**
       * get release from database filled with vendor and permissions for user
       **/
-    Release getReleaseById(1: string id, 2: User user);
+    Release getReleaseById(1: string id, 2: User user) throws (1: SW360Exception exp);
 
      /**
        * get release from database filled with vendor and permissions for user

--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -304,6 +304,17 @@ include::{snippets}/should_document_link_releases/curl-request.adoc[]
 ===== Example response
 include::{snippets}/should_document_link_releases/http-response.adoc[]
 
+[[resources-project-patch-releases]]
+==== Patch Releases to the project
+
+A `PATCH` request to append new releases to existing releases in a project
+
+===== Example request
+include::{snippets}/should_document_patch_releases/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_patch_releases/http-response.adoc[]
+
 [[resources-project-get-download-licenseinfo]]
 ==== Download License Info
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -24,6 +24,7 @@ import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
@@ -35,6 +36,7 @@ import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.stereotype.Service;
 
@@ -65,7 +67,18 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
 
     public Release getReleaseForUserById(String releaseId, User sw360User) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-        return sw360ComponentClient.getReleaseById(releaseId, sw360User);
+        Release releaseById = null;
+        try {
+            releaseById = sw360ComponentClient.getReleaseById(releaseId, sw360User);
+        } catch (SW360Exception sw360Exp) {
+            if (sw360Exp.getErrorCode() == 404) {
+                throw new ResourceNotFoundException("Release does not exists! id=" + releaseId);
+            } else {
+                throw sw360Exp;
+            }
+        }
+
+        return releaseById;
     }
 
     @Override

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -47,7 +47,9 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.Sets;
 
 import java.io.IOException;
@@ -769,12 +771,14 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
 
     @Test
     public void should_document_link_releases() throws Exception {
-        List<String> releaseIds = Arrays.asList("3765276512", "5578999", "3765276513");
+        MockHttpServletRequestBuilder requestBuilder = post("/api/projects/" + project.getId() + "/releases");
+        add_patch_releases(requestBuilder);
+    }
 
-        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
-        this.mockMvc.perform(post("/api/projects/" + project.getId() + "/releases").contentType(MediaTypes.HAL_JSON)
-                .content(this.objectMapper.writeValueAsString(releaseIds))
-                .header("Authorization", "Bearer " + accessToken)).andExpect(status().isCreated());
+    @Test
+    public void should_document_patch_releases() throws Exception {
+        MockHttpServletRequestBuilder requestBuilder = patch("/api/projects/" + project.getId() + "/releases");
+        add_patch_releases(requestBuilder);
     }
 
     @Test
@@ -792,5 +796,14 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 parameterWithName("variant").description("All the possible values for variants are "
                                         + Arrays.asList(OutputFormatVariant.values())),
                                 parameterWithName("externalIds").description("The external Ids of the project"))));
+    }
+
+    private void add_patch_releases(MockHttpServletRequestBuilder requestBuilder) throws Exception {
+        List<String> releaseIds = Arrays.asList("3765276512", "5578999", "3765276513");
+
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        this.mockMvc.perform(requestBuilder.contentType(MediaTypes.HAL_JSON)
+                .content(this.objectMapper.writeValueAsString(releaseIds))
+                .header("Authorization", "Bearer " + accessToken)).andExpect(status().isCreated());
     }
 }


### PR DESCRIPTION
Added a new request parameter `&patch=<true|false>` in-order to patch releases to existing releases in a Project.

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>