### PR TITLE
fix(ReleaseUI): fixed reload report in FOSSology Process

### DIFF
--- a/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
+++ b/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
@@ -496,6 +496,7 @@ public class FossologyHandler implements FossologyService.Iface {
                 return RequestStatus.FAILURE;
             }
             handleReportStep(componentClient, release, user, extToolProcess);
+            updateFossologyProcessInRelease(extToolProcess, release, user, componentClient);
             return RequestStatus.SUCCESS;
         }
         return RequestStatus.SUCCESS;


### PR DESCRIPTION
- Issue Fixed: Reload Report(FOSSology) from UI generates new report but tries to attach old report to Release.

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>