### PR TITLE
feat(rest): Attachement sha1 improvement

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/attachments.adoc
+++ b/rest/resource-server/src/docs/asciidoc/attachments.adoc
@@ -30,3 +30,20 @@ include::{snippets}/should_document_get_attachment/http-response.adoc[]
 
 ===== Links
 include::{snippets}/should_document_get_attachment/links.adoc[]
+
+[[should_document_get_attachments_by_sha1]]
+==== Get attachment info by SHA1
+
+A `GET` request will get attachment information with the given sha1 and the resources having it. Please set the request parameter `&sha1=<SHA1>`.
+
+===== Response structure
+include::{snippets}/should_document_get_attachments_by_sha1/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_attachments_by_sha1/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_attachments_by_sha1/http-response.adoc[]
+
+===== Links
+include::{snippets}/should_document_get_attachments_by_sha1/links.adoc[]

--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -85,6 +85,24 @@ include::{snippets}/should_document_get_releases_by_external-ids/curl-request.ad
 ===== Example response
 include::{snippets}/should_document_get_releases_by_external-ids/http-response.adoc[]
 
+[[should_document_get_releases_by_sha1]]
+==== Listing by attachments with SHA1
+
+A `GET` request will get a collection of releases that have attachments with the given sha1. Please set the request parameter `&sha1=<SHA1>`.
+
+===== Response structure
+include::{snippets}/should_document_get_releases_by_sha1/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_releases_by_sha1/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_releases_by_sha1/http-response.adoc[]
+
+===== Links
+include::{snippets}/should_document_get_releases_by_sha1/links.adoc[]
+
+
 
 [[resources-release-attachment-info-get]]
 ==== Listing attachment info

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/TestHelper.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/TestHelper.java
@@ -14,6 +14,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
+import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.MainlineState;
+import org.eclipse.sw360.datahandler.thrift.Source;
+import org.eclipse.sw360.rest.resourceserver.attachment.AttachmentInfo;
 import org.eclipse.sw360.rest.resourceserver.core.MultiStatus;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -22,6 +29,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.Base64Utils;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.io.IOException;
@@ -34,6 +42,10 @@ import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 public class TestHelper {
+
+    public static String release1Id = "121831bjh1v2j";
+    public static String releaseId2 = "3451831bjh1v2jxxz";
+    public static String attachmentShaUsedMultipleTimes = "12345";
 
     static public void checkResponse(String responseBody, String linkRelation, int embeddedArraySize) throws IOException {
         TestHelper.checkResponse(responseBody, linkRelation, embeddedArraySize, null);
@@ -108,6 +120,66 @@ public class TestHelper {
         }
     }
 
+    public static List<Release> getDummyReleaseListForTest() {
+        List<Release> releases = new ArrayList<>();
+
+        Release release1 = new Release();
+        release1.setName("Release 1");
+        release1.setId(release1Id);
+        release1.setComponentId("component123");
+        release1.setVersion("1.0.4");
+        release1.setCpeid("cpe:id-1231");
+        release1.setMainlineState(MainlineState.MAINLINE);
+        release1.setClearingState(ClearingState.APPROVED);
+        releases.add(release1);
+
+        Release release2 = new Release();
+        release2.setName("Release 2");
+        release2.setId(releaseId2);
+        release2.setComponentId("component456");
+        release2.setVersion("2.0.0");
+        release2.setCpeid("cpe:id-4567");
+        release2.setMainlineState(MainlineState.OPEN);
+        release2.setClearingState(ClearingState.NEW_CLEARING);
+        releases.add(release2);
+
+        return releases;
+    }
+
+    public static List<Attachment> getDummyAttachmentsListForTest() {
+        List<Attachment> attachments = new ArrayList<>();
+        Attachment attachment1 = new Attachment();
+        attachment1.setAttachmentContentId("a1");
+        attachment1.setSha1(attachmentShaUsedMultipleTimes);
+        attachment1.setFilename("Attachment 1");
+        attachment1.setAttachmentType(AttachmentType.BINARY);
+        attachments.add(attachment1);
+
+        Attachment attachment2 = new Attachment();
+        attachment2.setAttachmentContentId("a2");
+        attachment2.setSha1(attachmentShaUsedMultipleTimes);
+        attachment2.setFilename("Attachment 2");
+        attachment2.setAttachmentType(AttachmentType.SOURCE);
+        attachments.add(attachment2);
+
+        return attachments;
+    }
+
+    public static List<AttachmentInfo> getDummyAttachmentInfoListForTest() {
+        Source source1 = new Source(Source._Fields.RELEASE_ID, release1Id);
+        Source source2 = new Source(Source._Fields.RELEASE_ID, releaseId2);
+
+        List<AttachmentInfo> attachmentInfos = new ArrayList<>();
+        AttachmentInfo attachmentInfo1 = new AttachmentInfo(getDummyAttachmentsListForTest().get(0));
+        attachmentInfo1.setOwner(source1);
+        attachmentInfos.add(attachmentInfo1);
+
+        AttachmentInfo attachmentInfo2 = new AttachmentInfo(getDummyAttachmentsListForTest().get(1));
+        attachmentInfo2.setOwner(source2);
+        attachmentInfos.add(attachmentInfo2);
+
+        return attachmentInfos;
+    }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private static class OAuthToken {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/AttachmentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/AttachmentTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Siemens AG, 2017,2019. Part of the SW360 Portal Project.
+ *
+  * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.sw360.rest.resourceserver.integration;
+
+import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.Source;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.eclipse.sw360.rest.resourceserver.TestHelper;
+import org.eclipse.sw360.rest.resourceserver.attachment.AttachmentInfo;
+import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
+import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
+import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.eq;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class AttachmentTest extends TestIntegrationBase {
+
+    @Value("${local.server.port}")
+    private int port;
+
+    @MockBean
+    private Sw360UserService userServiceMock;
+
+    @MockBean
+    private Sw360AttachmentService attachmentServiceMock;
+
+    @MockBean
+    private Sw360ReleaseService releaseServiceMock;
+
+    private final String shaInvalid = "56789";
+
+    @Before
+    public void before() throws TException {
+
+        given(this.attachmentServiceMock.getAttachmentsBySha1(eq(TestHelper.attachmentShaUsedMultipleTimes))).willReturn(TestHelper.getDummyAttachmentInfoListForTest());
+        given(this.attachmentServiceMock.getAttachmentsBySha1(eq(shaInvalid))).willReturn(new ArrayList<>());
+
+        User user = new User();
+        user.setId("123456789");
+        user.setEmail("admin@sw360.org");
+        user.setFullname("John Doe");
+
+        given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(user);
+
+        given(this.releaseServiceMock.getReleaseForUserById(eq(TestHelper.release1Id), eq(user))).willReturn(TestHelper.getDummyReleaseListForTest().get(0));
+        given(this.releaseServiceMock.getReleaseForUserById(eq(TestHelper.releaseId2), eq(user))).willReturn(TestHelper.getDummyReleaseListForTest().get(1));
+    }
+
+    @Test
+    public void should_get_multiple_attachments_by_sha1() throws IOException {
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/attachments?sha1=" + TestHelper.attachmentShaUsedMultipleTimes,
+                        HttpMethod.GET,
+                        new HttpEntity<>(null, headers),
+                        String.class);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        TestHelper.checkResponse(response.getBody(), "attachments", 2);
+    }
+
+    @Test
+    public void should_get_empty_attachment_collection_by_sha1() throws IOException {
+        HttpHeaders headers = getHeaders(port);
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/attachments?sha1=" + shaInvalid,
+                        HttpMethod.GET,
+                        new HttpEntity<>(null, headers),
+                        String.class);
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+    }
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -10,6 +10,10 @@
 package org.eclipse.sw360.rest.resourceserver.restdocs;
 
 import org.apache.thrift.TException;
+import org.eclipse.sw360.datahandler.thrift.Source;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
+import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
+import org.eclipse.sw360.rest.resourceserver.attachment.AttachmentInfo;
 import org.eclipse.sw360.datahandler.thrift.MainlineState;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
@@ -36,7 +40,6 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultHandler;
 
 import com.google.common.collect.ImmutableSet;
@@ -82,18 +85,40 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
     Component component;
     private Project project;
 
-    private String releaseId = "3765276512";
+    private final String releaseId = "3765276512";
+    private final String attachmentSha1 = "da373e491d3863477568896089ee9457bc316783";
 
     @Before
     public void before() throws TException, IOException {
-        Set<Attachment> attachmentList = new HashSet<>();
+        Set<Attachment> attachments = new HashSet<>();
         Set<Component> usedByComponent = new HashSet<>();
         List<Resource<Attachment>> attachmentResources = new ArrayList<>();
         attachment = new Attachment("1231231254", "spring-core-4.3.4.RELEASE.jar");
-        attachment.setSha1("da373e491d3863477568896089ee9457bc316783");
-        attachmentList.add(attachment);
+        attachment.setSha1(attachmentSha1);
+        attachments.add(attachment);
         attachmentResources.add(new Resource<>(attachment));
 
+        attachment.setSha1(attachmentSha1);
+        attachment.setAttachmentType(AttachmentType.BINARY_SELF);
+        attachment.setCreatedTeam("Clearing Team 1");
+        attachment.setCreatedComment("please check asap");
+        attachment.setCreatedOn("2016-12-18");
+        attachment.setCreatedBy("admin@sw360.org");
+        attachment.setCheckedTeam("Clearing Team 2");
+        attachment.setCheckedComment("everything looks good");
+        attachment.setCheckedOn("2016-12-18");
+        attachment.setCheckStatus(CheckStatus.ACCEPTED);
+        attachments.add(attachment);
+        AttachmentInfo attachmentInfo = new AttachmentInfo(attachment);
+        List<AttachmentInfo> attachmentInfos = new ArrayList<>();
+        attachmentInfos.add(attachmentInfo);
+
+        Source owner = new Source();
+        attachmentInfo.setOwner(owner);
+
+        given(this.attachmentServiceMock.getAttachmentById(eq(attachment.getAttachmentContentId())))
+                .willReturn(attachmentInfo);
+        given(this.attachmentServiceMock.getAttachmentsBySha1(eq(attachment.getSha1()))).willReturn(attachmentInfos);
         given(this.attachmentServiceMock.getAttachmentContent(anyObject())).willReturn(new AttachmentContent().setId("1231231254").setFilename("spring-core-4.3.4.RELEASE.jar").setContentType("binary"));
         given(this.attachmentServiceMock.getResourcesFromList(anyObject())).willReturn(new Resources<>(attachmentResources));
         given(this.attachmentServiceMock.uploadAttachment(anyObject(), anyObject(), anyObject())).willReturn(attachment);
@@ -115,20 +140,22 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         List<Release> releaseList = new ArrayList<>();
         release = new Release();
         release.setId(releaseId);
-        release.setName("Angular");
-        release.setCpeid("cpe:/a:Google:Angular:2.3.0:");
+        owner.setReleaseId(release.getId());
+        release.setName("Spring Core 4.3.4");
+        release.setCpeid("cpe:/a:pivotal:spring-core:4.3.4:");
         release.setReleaseDate("2016-12-07");
-        release.setVersion("2.3.0");
+        release.setVersion("4.3.4");
         release.setCreatedOn("2016-12-18");
         release.setCreatedBy("admin@sw360.org");
-        release.setDownloadurl("http://www.google.com");
         release.setModerators(new HashSet<>(Arrays.asList("admin@sw360.org", "jane@sw360.org")));
+        release.setCreatedBy("admin@sw360.org");
+        release.setDownloadurl("http://www.google.com");
         release.setComponentId(component.getId());
         release.setClearingState(ClearingState.APPROVED);
-        release.setMainlineState(MainlineState.OPEN);
+        release.setMainlineState(MainlineState.SPECIFIC);
         release.setExternalIds(Collections.singletonMap("mainline-id-component", "1432"));
         release.setAdditionalData(Collections.singletonMap("Key", "Value"));
-        release.setAttachments(attachmentList);
+        release.setAttachments(attachments);
         release.setLanguages(new HashSet<>(Arrays.asList("C++", "Java")));
         release.setMainLicenseIds(new HashSet<>(Arrays.asList("GPL-2.0-or-later", "Apache-2.0")));
         release.setOperatingSystems(ImmutableSet.of("Windows", "Linux"));
@@ -443,5 +470,21 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
     @Test
     public void should_document_upload_attachment_to_release() throws Exception {
         testAttachmentUpload("/api/releases/", releaseId);
+    }
+
+    @Test
+    public void should_document_get_releases_by_sha1() throws Exception {
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(get("/api/releases?sha1=" + attachmentSha1)
+                        .header("Authorization", "Bearer " + accessToken).accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andDo(this.documentationHandler.document(
+                        links(linkWithRel("curies").description("Curies are used for online documentation")),
+                        responseFields(
+                                fieldWithPath("_links")
+                                        .description("<<resources-index-links,Links>> to other resources"),
+                                fieldWithPath("_embedded.sw360:releases").description(
+                                        "The collection of <<resources-releases,Releases resources>>. In most cases the result should contain either one element or an empty response. If the same binary file is uploaded and attached to multiple sw360 resources, the collection will contain all the releases that have attachments with matching sha1 hash."))))
+                .andReturn();
     }
 }


### PR DESCRIPTION
  * Get attachments by sha1 via `/attachments?sha1=XXXX`
  * Listing releases by attachment sha1 via `/releases?sha1=XXXX`

Signed-off-by: Smruti Sahoo <smruti.sahoo@siemens.com>