### PR TITLE
fix(components): components listing limited to 200 entries

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -1488,10 +1488,10 @@ public class ComponentPortlet extends FossologyAwarePortlet {
     private List<Component> getFilteredComponentList(PortletRequest request) {
         Map<String, Set<String>> filterMap = getComponentFilterMap(request);
         List<Component> componentList;
+        int limit = -1;
 
         try {
             final User user = UserCacheHolder.getUserFromRequest(request);
-            int limit = CustomFieldHelper.loadAndStoreStickyViewSize(request, user, CUSTOM_FIELD_COMPONENTS_VIEW_SIZE);
             ComponentService.Iface componentClient = thriftClients.makeComponentClient();
             if (filterMap.isEmpty()) {
                 componentList = componentClient.getRecentComponentsSummary(limit, user);


### PR DESCRIPTION
 * components listing limited to 200 entries both in UI and spreadsheet export.

closes #791 

Signed-off-by: Smruti Sahoo <smruti.sahoo@siemens.com>