### PR TITLE
feat(UI): Reorder attachment types dropdown

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/editAttachments.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/editAttachments.jspf
@@ -126,6 +126,15 @@
             columnDefs: [{
                   targets: 1,
                   createdCell: function(td, cellData, rowData, row, col) {
+                      var options = $(td).find('.attachmentType option');
+                      $(options[1]).insertBefore($(options[0]));
+                      $(options[4]).insertBefore($(options[0]));
+                      $(options[5]).insertBefore($(options[0]));
+                      $(options[6]).insertBefore($(options[0]));
+                      if (!rowData.attachmentType && !rowData.sha1) {
+                          $(options[0]).removeAttr('selected');
+                          $(options[1]).attr('selected', '');
+                      }
                       $.fn.dataTable.render.inputSelect.updateTitle(td);
                   }
             }, {


### PR DESCRIPTION

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * #805, fixed it using **jQuery** to change the order of `select options` as mentioned in issue.
> * No changes in dependencies.

Issue: #805 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> * Check the order is as mentioned in issue, and newly added attachments are being saved as **type** `source`.
> * No additional tests implemented.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: akapti <abdul.mannankapti@siemens.com>