### PR TITLE
Compile against Java 11

### DIFF
--- a/libraries/lib-datahandler/pom.xml
+++ b/libraries/lib-datahandler/pom.xml
@@ -152,6 +152,18 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${annotation-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>apache.thrift</groupId>
+            <artifactId>thrift</artifactId>
+            <version>1.13</version>
+            <scope>system</scope>
+            <systemPath>/usr/share/java/libthrift.jar</systemPath>
+        </dependency>
+        <dependency>
             <groupId>com.github.stephenc.findbugs</groupId>
             <artifactId>findbugs-annotations</artifactId>
             <version>1.3.9-1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,13 @@
         <!-- note that 6.1.0-SNAPSHOT relates to 6.0.${patchlevel} -->
         <!-- pls see also the profile cli -->
         <revision>8.${patchlevel}</revision>
-        <patchlevel>1.0-SNAPSHOT</patchlevel>        
+        <patchlevel>1.0-SNAPSHOT</patchlevel>
         <java.version>1.8</java.version>
         <ektorp.version>1.5.0</ektorp.version>
         <thrift.version>0.11.0</thrift.version>
         <guava.version>21.0</guava.version>
+        <annotation-api.version>1.3.2</annotation-api.version>
+
         <spring.version>4.3.12.RELEASE</spring.version>
         <spring-boot.version>1.5.8.RELEASE</spring-boot.version>
         <spring-restdocs.version>1.1.3.RELEASE</spring-restdocs.version>
@@ -66,7 +68,7 @@
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>1.10.19</mockito.version>
-        <project-lombok.version>1.16.12</project-lombok.version>
+        <project-lombok.version>1.18.12</project-lombok.version>
         <maven-source-plugin.version>2.4</maven-source-plugin.version>
         <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
 
@@ -175,6 +177,11 @@
                 <artifactId>com.liferay.petra.lang</artifactId>
                 <version>3.0.0</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>${annotation-api.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Signed-off-by: Helio Chissini de Castro <helio.chissini-de-castro@bmw.de>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

* Add javax.annotation-api dependency, as deprecation of original javax.annotation
* Update lombok version for 1.18.12

Issue: 
Current code not compiles against Java 11