### PR TITLE
chore(dependencies): updating main dependencies

### DIFF
--- a/frontend/sw360-portlet/pom.xml
+++ b/frontend/sw360-portlet/pom.xml
@@ -214,7 +214,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
-            <version>4.2.3.RELEASE</version>
+            <version>4.2.15.RELEASE</version>
             <scope>compile</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,20 +49,20 @@
         <!-- note that 6.1.0-SNAPSHOT relates to 6.0.${patchlevel} -->
         <!-- pls see also the profile cli -->
         <revision>8.${patchlevel}</revision>
-        <patchlevel>2.0-SNAPSHOT</patchlevel>        
+        <patchlevel>2.0-SNAPSHOT</patchlevel>
         <java.version>1.8</java.version>
         <ektorp.version>1.5.0</ektorp.version>
-        <thrift.version>0.11.0</thrift.version>
+        <thrift.version>0.13.0</thrift.version>
         <guava.version>21.0</guava.version>
-        <spring.version>4.3.12.RELEASE</spring.version>
-        <spring-boot.version>1.5.8.RELEASE</spring-boot.version>
-        <spring-restdocs.version>1.1.3.RELEASE</spring-restdocs.version>
+        <spring.version>4.3.26.RELEASE</spring.version>
+        <spring-boot.version>1.5.22.RELEASE</spring-boot.version>
+        <spring-restdocs.version>1.2.6.RELEASE</spring-restdocs.version>
 
-        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j.version>1.7.30</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <log4j.version>1.2.17</log4j.version>
-        <junit-dataprovider.version>1.12.0</junit-dataprovider.version>
 
+        <junit-dataprovider.version>1.12.0</junit-dataprovider.version>
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>1.10.19</mockito.version>

--- a/scripts/install-thrift.sh
+++ b/scripts/install-thrift.sh
@@ -19,7 +19,7 @@
 
 set -e
 
-VERSION=0.11.0
+VERSION=0.13.0
 
 BASEDIR="/tmp"
 BUILDDIR="${BASEDIR}/thrift-$VERSION"


### PR DESCRIPTION
just updating some of the main dependecies:

* ektorp: was already latest: 1.5.0
* thrift: from 0.11 to 0.13
* google guava from 21.0 to 28.1, planned but not working, stick to 21.0
* spring from 4.3.12 to 4.3.26.RELEASE
* spring-boot from 1.5.8 to 1.5.22.RELEASE
* spring-restdocs from 1.1.3 to  1.2.6.RELEASE
* slf4j from 1.7.25 to 1.7.30
* logback is already latest: 1.2.3
* log4j is already at 1.2.17

not covered here:
* no test dependencies
* no infrastructure
* no dependencies in special projects