### PR TITLE
Support custom fields in additional data

### DIFF
--- a/build-configuration/resources/couchdb.properties
+++ b/build-configuration/resources/couchdb.properties
@@ -10,9 +10,9 @@
 
 # N.B this is the default build property file, defined in module build-configuration
 
-couchdb.url = http://localhost:5984
-couchdb.user =
-couchdb.password =
+couchdb.url = https://couchdb-dev-0.gtlc.only.sap/
+couchdb.user = sw360
+couchdb.password = sw360
 couchdb.database = sw360db
 couchdb.usersdb = sw360users
 couchdb.attachments = sw360attachments

--- a/build-configuration/test-resources/couchdb.properties
+++ b/build-configuration/test-resources/couchdb.properties
@@ -10,7 +10,9 @@
 
 # N.B this is the build property file, copied from module build-configuration
 
-couchdb.url = http://localhost:5984
+couchdb.url = https://couchdb-dev-0.gtlc.only.sap/
+couchdb.user =
+couchdb.password = 
 couchdb.database = sw360_test_db
 couchdb.usersdb = sw360_test_users
 couchdb.attachments = sw360_test_attachments

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/CustomFieldHelper.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/CustomFieldHelper.java
@@ -121,9 +121,15 @@ public class CustomFieldHelper {
                 customFieldsMap.put(fieldProperties[2], customField);
                 UnicodeProperties unicodeProperties = exp.getAttributeProperties(key);
                 unicodeProperties.forEach((propertyKey, propertyValue) -> {
-                    if (propertyKey != null && propertyKey.equals(CustomFieldPropertyKey.DISPLAY_TYPE.getKey())) {
+
+                    if (propertyKey == null) {
+                        return;
+                    }
+
+                    if (propertyKey.equals(CustomFieldPropertyKey.DISPLAY_TYPE.getKey())) {
                         customField.setFieldType(CustomFieldType.getType(propertyValue));
 
+                        // Set options
                         if (CustomFieldType.isOptionRequiredType(customField.getFieldType())) {
                             Serializable defaultValue = exp.getAttributeDefault(key);
                             if (defaultValue == null) {
@@ -135,6 +141,14 @@ public class CustomFieldHelper {
                                 customField.addOption(option);
                             }
                         }
+
+                        if (CustomFieldType.getType(propertyValue) == CustomFieldType.TEXTFIELD) {
+                            customField.setFieldPattern(value.toString());
+                        }
+                    }
+
+                    if (propertyKey.equals(CustomFieldPropertyKey.HIDDEN.getKey())) {
+                        customField.setHidden(Boolean.parseBoolean(propertyValue));
                     }
                 });
             });

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/customfields/CustomField.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/customfields/CustomField.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.sw360.portal.common.customfields;
 
 import java.util.ArrayList;
@@ -9,8 +18,10 @@ public class CustomField{
     private String fieldLabel;
     private int fieldId;
     private CustomFieldType fieldType;
+    private String fieldPattern;
     private String value;
     private List<String> options;
+    private boolean isHidden;
 
     public String getFieldKey() {
         return fieldKey;
@@ -44,6 +55,14 @@ public class CustomField{
         this.fieldType = fieldType;
     }
 
+    public String getFieldPattern() {
+        return fieldPattern;
+    }
+
+    public void setFieldPattern(String fieldPattern) {
+        this.fieldPattern = fieldPattern;
+    }
+
     public String getValue() {
         return value;
     }
@@ -65,6 +84,14 @@ public class CustomField{
             this.options = new ArrayList<>();
         }
         this.options.add(option);
+    }
+
+    public boolean isHidden() {
+        return isHidden;
+    }
+
+    public void setHidden(boolean hidden) {
+        isHidden = hidden;
     }
 
     public static class Comparators {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/customfields/CustomField.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/customfields/CustomField.java
@@ -1,0 +1,73 @@
+package org.eclipse.sw360.portal.common.customfields;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class CustomField{
+    private String fieldKey;
+    private String fieldLabel;
+    private int fieldId;
+    private CustomFieldType fieldType;
+    private String value;
+    private List<String> options;
+
+    public String getFieldKey() {
+        return fieldKey;
+    }
+
+    public void setFieldKey(String fieldKey) {
+        this.fieldKey = fieldKey;
+    }
+
+    public String getFieldLabel() {
+        return fieldLabel;
+    }
+
+    public void setFieldLabel(String fieldLabel) {
+        this.fieldLabel = fieldLabel;
+    }
+
+    public int getFieldId() {
+        return fieldId;
+    }
+
+    public void setFieldId(int fieldId) {
+        this.fieldId = fieldId;
+    }
+
+    public CustomFieldType getFieldType() {
+        return fieldType;
+    }
+
+    public void setFieldType(CustomFieldType fieldType) {
+        this.fieldType = fieldType;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public List<String> getOptions() {
+        return options;
+    }
+
+    public void setOptions(List<String> options) {
+        this.options = options;
+    }
+
+    public void addOption(String option) {
+        if (this.options == null) {
+            this.options = new ArrayList<>();
+        }
+        this.options.add(option);
+    }
+
+    public static class Comparators {
+        public static Comparator<CustomField> FIELDID = Comparator.comparingInt(o -> o.fieldId);
+    }
+}

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/customfields/CustomFieldPageIdentifier.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/customfields/CustomFieldPageIdentifier.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.sw360.portal.common.customfields;
 
 public enum CustomFieldPageIdentifier {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/customfields/CustomFieldPageIdentifier.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/customfields/CustomFieldPageIdentifier.java
@@ -1,0 +1,19 @@
+package org.eclipse.sw360.portal.common.customfields;
+
+public enum CustomFieldPageIdentifier {
+    COMPONENT("component-"),
+    RELEASE("release-");
+    private String value;
+
+    CustomFieldPageIdentifier(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    public static boolean is(String key, CustomFieldPageIdentifier identifier) {
+        return (key != null && key.startsWith(identifier.getValue()));
+    }
+}

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/customfields/CustomFieldPropertyKey.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/customfields/CustomFieldPropertyKey.java
@@ -1,0 +1,14 @@
+package org.eclipse.sw360.portal.common.customfields;
+
+public enum CustomFieldPropertyKey {
+    DISPLAY_TYPE("display-type");
+
+    private String propertyKey;
+    CustomFieldPropertyKey(String propertyKey) {
+        this.propertyKey = propertyKey;
+    }
+
+    public String getKey() {
+        return this.propertyKey;
+    }
+}

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/customfields/CustomFieldPropertyKey.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/customfields/CustomFieldPropertyKey.java
@@ -1,7 +1,17 @@
+/*
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.sw360.portal.common.customfields;
 
 public enum CustomFieldPropertyKey {
-    DISPLAY_TYPE("display-type");
+    DISPLAY_TYPE("display-type"),
+    HIDDEN("hidden");
 
     private String propertyKey;
     CustomFieldPropertyKey(String propertyKey) {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/customfields/CustomFieldType.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/customfields/CustomFieldType.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright Siemens AG, 2013-2017. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.sw360.portal.common.customfields;
 
 import java.util.ArrayList;

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/customfields/CustomFieldType.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/customfields/CustomFieldType.java
@@ -1,0 +1,39 @@
+package org.eclipse.sw360.portal.common.customfields;
+
+import java.util.ArrayList;
+
+public enum CustomFieldType {
+    DROPDOWN("selection-list"),
+    CHECKBOX("checkbox"),
+    TEXTAREA("text-box"),
+    TEXTFIELD("input-field"),
+    DATE("date");
+
+    public static ArrayList<CustomFieldType> optionRequiredTypes = new ArrayList<>();
+    static {
+        optionRequiredTypes.add(DROPDOWN);
+        optionRequiredTypes.add(CHECKBOX);
+    }
+
+    private String liferayType;
+    CustomFieldType(String liferayType) {
+        this.liferayType = liferayType;
+    }
+
+    public String getLiferayType() {
+        return this.liferayType;
+    }
+
+    public static CustomFieldType getType(String liferayType) {
+        for (CustomFieldType customFieldType : CustomFieldType.values()) {
+            if (customFieldType.getLiferayType().equals(liferayType)) {
+                return customFieldType;
+            }
+        }
+        return null;
+    }
+
+    public static boolean isOptionRequiredType(CustomFieldType type) {
+        return optionRequiredTypes.contains(type);
+    }
+}

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/edit.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/edit.jsp
@@ -50,6 +50,7 @@
 
     <jsp:useBean id="usingProjects" type="java.util.Set<org.eclipse.sw360.datahandler.thrift.projects.Project>"
                  scope="request"/>
+    <jsp:useBean id="customFields" type="java.util.List<org.eclipse.sw360.portal.common.customfields.CustomField>" scope="request"/>
     <jsp:useBean id="allUsingProjectsCount" type="java.lang.Integer" scope="request"/>
     <jsp:useBean id="usingComponents" type="java.util.Set<org.eclipse.sw360.datahandler.thrift.components.Component>"
                  scope="request"/>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/editRelease.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/editRelease.jsp
@@ -50,6 +50,7 @@
                  scope="request"/>
     <jsp:useBean id="allUsingProjectsCount" type="java.lang.Integer" scope="request"/>
     <jsp:useBean id="usingComponents" type="java.util.Set<org.eclipse.sw360.datahandler.thrift.components.Component>" scope="request"/>
+    <jsp:useBean id="customFields" type="java.util.List<org.eclipse.sw360.portal.common.customfields.CustomField>" scope="request"/>
 
     <core_rt:set var="programmingLanguages" value='<%=PortalConstants.PROGRAMMING_LANGUAGES%>'/>
     <core_rt:set var="operatingSystemsAutoC" value='<%=PortalConstants.OPERATING_SYSTEMS%>'/>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/editAdditionalData.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/editAdditionalData.jsp
@@ -18,29 +18,31 @@
         </tr>
     </thead>
 	<c:forEach var="customField" items="${customFields}">
-		<tr>
+		<tr <c:if test="${customField.hidden}">style="display:none"</c:if> class="bodyRow">
 			<td>
-				<div class="form-group">
+				<div>
 					<input class="form-control" id="${customField.fieldKey}" name="<portlet:namespace/><%=PortalConstants.ADDITIONAL_DATA_KEY%>${customField.fieldKey}"
 						   type="text" value="<sw360:out value="${customField.fieldLabel}"/>" readonly/>
 				</div>
 			</td>
 			<td>
-				<div class="form-group">
-					<c:if test="${customField.fieldType == 'TEXTFIELD'}" >
+				<div>
+					<c:if test="${customField.fieldType == 'TEXTFIELD'}">
 						<input class="form-control" id="${customField.fieldLabel}" name="<portlet:namespace/><%=PortalConstants.ADDITIONAL_DATA_VALUE%>${customField.fieldKey}"
-							   type="text" placeholder="Enter ${customField.fieldLabel}" value="<sw360:out value="${customField.value}"/>" />
+							   type="text" placeholder="Enter ${customField.fieldLabel}"
+							   <c:if test="${not empty customField.fieldPattern}">pattern="${customField.fieldPattern}" title="${customField.fieldPattern}"</c:if>
+							   value="<sw360:out value="${customField.value}"/>"/>
 					</c:if>
-					<c:if test="${customField.fieldType == 'TEXTAREA'}" >
+					<c:if test="${customField.fieldType == 'TEXTAREA'}">
 						<textarea class="form-control" id="${customField.fieldLabel}" name="<portlet:namespace/><%=PortalConstants.ADDITIONAL_DATA_VALUE%>${customField.fieldKey}"
-								  rows="4" placeholder="Enter ${customField.fieldLabel}"><sw360:out value="${customField.value}"/></textarea>
+								  rows="4" placeholder="Enter ${customField.fieldLabel}">${customField.value}</textarea>
 					</c:if>
-					<c:if test="${customField.fieldType == 'DATE'}" >
+					<c:if test="${customField.fieldType == 'DATE'}">
 						<input id="${customField.fieldLabel}" class="datepicker form-control" name="<portlet:namespace/><%=PortalConstants.ADDITIONAL_DATA_VALUE%>${customField.fieldKey}" type="text"
 							   placeholder="Enter ${customField.fieldLabel}" pattern="\d{4}-\d{2}-\d{2}"
 							   value="<sw360:out value="${customField.value}"/>"/>
 					</c:if>
-					<c:if test="${customField.fieldType == 'DROPDOWN'}" >
+					<c:if test="${customField.fieldType == 'DROPDOWN'}">
 						<select class="form-control" id="${customField.fieldLabel}" name="<portlet:namespace/><%=PortalConstants.ADDITIONAL_DATA_VALUE%>${customField.fieldKey}">
 							<option value="">Select:</option>
 							<c:forEach var="option" items="${customField.options}">
@@ -48,7 +50,7 @@
 							</c:forEach>
 						</select>
 					</c:if>
-					<c:if test="${customField.fieldType == 'CHECKBOX'}" >
+					<c:if test="${customField.fieldType == 'CHECKBOX'}">
 						<input id="${customField.fieldLabel}" type="checkbox" class="form-check-input" name="<portlet:namespace/><%=PortalConstants.ADDITIONAL_DATA_VALUE%>${customField.fieldKey}"
 						value="${customField.options[0]}" <c:if test="${not empty customField.value}">checked</c:if>/>
 						<label class="form-check-label" for="${customField.fieldKey}">${customField.options[0]}</label>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/editAdditionalData.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/editAdditionalData.jsp
@@ -17,6 +17,47 @@
             <th colspan="3" class="headlabel">Additional Data</th>
         </tr>
     </thead>
+	<c:forEach var="customField" items="${customFields}">
+		<tr>
+			<td>
+				<div class="form-group">
+					<input class="form-control" id="${customField.fieldKey}" name="<portlet:namespace/><%=PortalConstants.ADDITIONAL_DATA_KEY%>${customField.fieldKey}"
+						   type="text" value="<sw360:out value="${customField.fieldLabel}"/>" readonly/>
+				</div>
+			</td>
+			<td>
+				<div class="form-group">
+					<c:if test="${customField.fieldType == 'TEXTFIELD'}" >
+						<input class="form-control" id="${customField.fieldLabel}" name="<portlet:namespace/><%=PortalConstants.ADDITIONAL_DATA_VALUE%>${customField.fieldKey}"
+							   type="text" placeholder="Enter ${customField.fieldLabel}" value="<sw360:out value="${customField.value}"/>" />
+					</c:if>
+					<c:if test="${customField.fieldType == 'TEXTAREA'}" >
+						<textarea class="form-control" id="${customField.fieldLabel}" name="<portlet:namespace/><%=PortalConstants.ADDITIONAL_DATA_VALUE%>${customField.fieldKey}"
+								  rows="4" placeholder="Enter ${customField.fieldLabel}"><sw360:out value="${customField.value}"/></textarea>
+					</c:if>
+					<c:if test="${customField.fieldType == 'DATE'}" >
+						<input id="${customField.fieldLabel}" class="datepicker form-control" name="<portlet:namespace/><%=PortalConstants.ADDITIONAL_DATA_VALUE%>${customField.fieldKey}" type="text"
+							   placeholder="Enter ${customField.fieldLabel}" pattern="\d{4}-\d{2}-\d{2}"
+							   value="<sw360:out value="${customField.value}"/>"/>
+					</c:if>
+					<c:if test="${customField.fieldType == 'DROPDOWN'}" >
+						<select class="form-control" id="${customField.fieldLabel}" name="<portlet:namespace/><%=PortalConstants.ADDITIONAL_DATA_VALUE%>${customField.fieldKey}">
+							<option value="">Select:</option>
+							<c:forEach var="option" items="${customField.options}">
+								<option value="${option}" <c:if test="${option eq customField.value}">selected</c:if>>${option}</option>
+							</c:forEach>
+						</select>
+					</c:if>
+					<c:if test="${customField.fieldType == 'CHECKBOX'}" >
+						<input id="${customField.fieldLabel}" type="checkbox" class="form-check-input" name="<portlet:namespace/><%=PortalConstants.ADDITIONAL_DATA_VALUE%>${customField.fieldKey}"
+						value="${customField.options[0]}" <c:if test="${not empty customField.value}">checked</c:if>/>
+						<label class="form-check-label" for="${customField.fieldKey}">${customField.options[0]}</label>
+					</c:if>
+
+				</div>
+			</td>
+		</tr>
+	</c:forEach>
 </table>
 
 <button type="button" class="btn btn-secondary" id="add-additional-data">Click to add row to Additional Data</button>
@@ -47,6 +88,9 @@
 </div>
 
 <script>
+	require(['jquery', /* jquery-plugins */ 'jquery-ui'], function($) {
+		$(".datepicker").datepicker({changeMonth:true,changeYear:true,dateFormat: "yy-mm-dd"});
+	});
     require(['jquery', 'modules/dialog'], function($, dialog) {
 
         createAdditionalDataTable();

--- a/pom.xml
+++ b/pom.xml
@@ -74,24 +74,24 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!--  User must provide below property configuration based on his/her liferay deployment environment -->
-        <base.deploy.dir />
+        <base.deploy.dir>C:\\tools\\SW360\\Liferay\\liferay-ce-portal-7.2.1-ga2</base.deploy.dir>
 
         <!--
             This is were the liferay OSGi modules go to on upload:
                 - frontend/*
                 - libraries/*
         -->
-        <liferay.deploy.dir>${base.deploy.dir}/liferay</liferay.deploy.dir>
+        <liferay.deploy.dir>${base.deploy.dir}/osgi/modules</liferay.deploy.dir>
         <!--
             This is were the backend services go to on upload:
                 - backend/svc/*
         -->
-        <backend.deploy.dir>${base.deploy.dir}/tomcat</backend.deploy.dir>
+        <backend.deploy.dir>${base.deploy.dir}/tomcat-9.0.17/webapps</backend.deploy.dir>
         <!--
             This is were the rest services go to on upload:
                 - rest/*
         -->
-        <rest.deploy.dir>${base.deploy.dir}/tomcat</rest.deploy.dir>
+        <rest.deploy.dir>${base.deploy.dir}/tomcat-9.0.17/webapps</rest.deploy.dir>
 
         <!-- some mem optimization here -->
         <argLine>-Dcatalina.home=${project.build.directory}/home -Xms64m -Xmx128m -XX:MaxPermSize=512m</argLine>
@@ -376,6 +376,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.21.0</version>
+                <configuration>
+                    <forkCount>0</forkCount>
+                    <argLine>-Xmx1024m</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -453,6 +462,7 @@
         <id>ci</id>
         <properties>
             <!-- second of two places for version setting: minor version -->
+            <!--suppress UnresolvedMavenProperty -->
             <patchlevel>0.${count}</patchlevel>
         </properties>
         </profile>


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> The idea is to create custom fields in Liferay(Control Panel->Configuration->Custom Fields) and then use Expando API to retrieve these fields in portlet and show these fields in the additional data group without changing the current data structure
> * Which issue is this pull request belonging to and how is it solving it? ([Enrich additional data feature on component and release page](https://github.com/eclipse/sw360/issues/809))
> * Did you add or update any new dependencies that are required for your change? No

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mcjaeger .

### How To Test?
> Details has been documented in the [issue](https://github.com/eclipse/sw360/issues/809)

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR
