### PR TITLE
fix(spreadsheet-export): Project spreadsheet export returns blank spreadsheet

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/view.jsp
@@ -648,7 +648,7 @@
                 portletURL.setParameter('<%=Project._Fields.TYPE%>', $('#project_type').val());
                 portletURL.setParameter('<%=Project._Fields.PROJECT_RESPONSIBLE%>', $('#project_responsible').val());
                 portletURL.setParameter('<%=Project._Fields.BUSINESS_UNIT%>', $('#group').val());
-                portletURL.setParameter('<%=Project._Fields.STATE%>', $('#state').val());
+                portletURL.setParameter('<%=Project._Fields.STATE%>', $('#project_state').val());
                 portletURL.setParameter('<%=Project._Fields.TAG%>', $('#tag').val());
                 portletURL.setParameter('<%=PortalConstants.EXTENDED_EXCEL_EXPORT%>', type === 'projectWithReleases' ? 'true' : 'false');
 


### PR DESCRIPTION
   * Fixed the incorrect element id in the jsp page.

Signed-off-by: Smruti Sahoo <smruti.sahoo@siemens.com>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*#https://github.com/eclipse/sw360/issues/841*)
> * Did you add or update any new dependencies that are required for your change? - No

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
Go to projects listing page -> click on "Export Spreadsheet" -> Verify both for "Projects only" and "Projects with linked releases"

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
