### PR TITLE
fix(REST): Added default value(NEW_CLEARING) for Clearing status while create and update Release

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -392,6 +392,9 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
         // check for MainlineState change
         setMainlineState(release, user, null);
+        if (release.getClearingState() == null) {
+            release.setClearingState(ClearingState.NEW_CLEARING);
+        }
         // Add release to database
         releaseRepository.add(release);
         final String id = release.getId();
@@ -842,6 +845,9 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 deleteAttachmentUsagesOfUnlinkedReleases(release, actual);
                 // check for MainlineState change
                 setMainlineState(release, user, actual);
+                if (release.getClearingState() == null) {
+                    release.setClearingState(ClearingState.NEW_CLEARING);
+                }
                 releaseRepository.update(release);
                 updateReleaseDependentFieldsForComponentId(release.getComponentId());
                 // clean up attachments in database

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -374,7 +374,8 @@ public class ComponentDatabaseHandlerTest {
 
         ReleaseLink releaseLinkR1A = createReleaseLinkTo(r1A)
                 .setReleaseRelationship(ReleaseRelationship.REFERRED)
-                .setNodeId("R1A");
+                .setNodeId("R1A")
+                .setClearingState(ClearingState.NEW_CLEARING);
 
         stripRandomPartsOfNodeIds(linkedReleases);
 
@@ -427,7 +428,8 @@ public class ComponentDatabaseHandlerTest {
 
         ReleaseLink releaseLinkR1A = createReleaseLinkTo(r1A)
                 .setReleaseRelationship(ReleaseRelationship.REFERRED)
-                .setNodeId("R1A");
+                .setNodeId("R1A")
+                .setClearingState(ClearingState.NEW_CLEARING);
 
         stripRandomPartsOfNodeIds(linkedReleases);
         assertThat(linkedReleases, contains(releaseLinkR1A));


### PR DESCRIPTION
> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*#844*)
> * Did you add or update any new dependencies that are required for your change? - No

### How To Test?
> Create or Update Release without providing clearing state info in request body. Default value should be saved instead of null
> No additional tests were implemented

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>