### PR TITLE
fix(UI): Clearing Request and Obligations fixes

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/AbstractCLIParser.java
@@ -89,7 +89,7 @@ public abstract class AbstractCLIParser extends LicenseInfoParser {
 
     protected Optional<Node> findNamedSubelement(Node node, String name) {
         NodeList childNodes = node.getChildNodes();
-        return streamFromNodeList(childNodes).filter(n -> n.getNodeName().equals(name)).findFirst();
+        return streamFromNodeList(childNodes).filter(n -> n.getNodeName().equalsIgnoreCase(name)).findFirst();
     }
 
     private Stream<Node> streamFromNodeList(NodeList nodes) {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
@@ -411,6 +411,7 @@ public class ModerationPortlet extends FossologyAwarePortlet {
 
         request.setAttribute(CLEARING_REQUESTS, CommonUtils.nullToEmptyList(openClearingRequests));
         request.setAttribute(CLOSED_CLEARING_REQUESTS, CommonUtils.nullToEmptyList(closedClearingRequests));
+        request.setAttribute(IS_CLEARING_EXPERT, PermissionUtils.isUserAtLeast(UserGroup.CLEARING_EXPERT, user));
         super.doView(request, response);
     }
 

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/clearing/clearingRequest.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/clearing/clearingRequest.jsp
@@ -56,7 +56,7 @@
 <core_rt:set var="user" value="<%=themeDisplay.getUser()%>"/>
 <core_rt:set var="isProjectPresent" value='${not empty project}'/>
 <core_rt:set var="isRequestingUser" value='${clearingRequest.requestingUser eq user.emailAddress}'/>
-<core_rt:set var="isClearingTeam" value='${clearingRequest.clearingTeam eq user.emailAddress or isClearingExpert}'/>
+<core_rt:set var="isClearingTeam" value='${clearingRequest.clearingTeam eq user.emailAddress or (isClearingExpert and writeAccessUser)}'/>
 <core_rt:set var="isClosedOrRejected" value="${clearingRequest.clearingState eq 'CLOSED' or clearingRequest.clearingState eq 'REJECTED' or empty project}"/>
 <core_rt:set var="isEditableForClearingTeam" value="${isClearingTeam and not isClosedOrRejected and pageName eq 'editClearingRequest'}"/>
 
@@ -69,7 +69,7 @@
                     <button type="button" class="btn btn-primary" onclick="window.location.href='<%=editlURL%>' + window.location.hash"><liferay-ui:message key="edit.request" /></button>
                 </div>
             </core_rt:if>
-            <core_rt:if test="${isProjectPresent and isClosedOrRejected and writeAccessUser}">
+            <core_rt:if test="${isProjectPresent and isClosedOrRejected and isClearingTeam}">
                 <div class="btn-group" role="group">
                     <button type="button" id="reOpenRequest" class="btn btn-primary"><liferay-ui:message key="reopen.request" /></button>
                 </div>
@@ -277,7 +277,7 @@
                                         </core_rt:forEach>
                                         <tr>
                                             <td>
-                                                <core_rt:if test="${isProjectPresent and (isClearingTeam or writeAccessUser)}">
+                                                <core_rt:if test="${isProjectPresent and isClearingTeam}">
 	                                                <textarea id="clearingRequestComment" placeholder="<liferay-ui:message key='enter.comment' />..." class="h-25 form-control"></textarea>
 	                                                <div class="my-2 btn-group" role="group">
 	                                                    <button id="addComment" type="button" class="btn btn-success"><liferay-ui:message key='add.comment' /></button>
@@ -355,8 +355,8 @@ require(['jquery', 'modules/dialog', 'modules/validation', 'bridges/jquery-ui' ]
                                     +'<div class="col-0 user-icon user-icon-info text-uppercase"><span>'+iconText+'</span></div>'
                                     +'<div class="col-11">'
                                     +'<div class="comment-text">' + comment +'<footer class="blockquote-footer">'
-                                    +'<liferay-ui:message key="by" /> <cite><b>' + by + '</b></cite>'
-                                    +'<liferay-ui:message key="on" /> <cite><b>' + on + '</b></cite></footer></div>'
+                                    +' <liferay-ui:message key="by" /> <cite><b>' + by + '</b></cite>'
+                                    +' <liferay-ui:message key="on" /> <cite><b>' + on + '</b></cite></footer></div>'
                                     +'</div></div>'
                                 +'</td></tr>');
                 }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/view.jsp
@@ -37,6 +37,7 @@
              scope="request"/>
 <jsp:useBean id="closedClearingRequests" type="java.util.List<org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest>"
              scope="request"/>
+<jsp:useBean id="isClearingExpert" type="java.lang.Boolean" scope="request"/>
 <core_rt:set var="user" value="<%=themeDisplay.getUser()%>"/>
 
 <div class="container" style="display: none;">
@@ -156,6 +157,18 @@ AUI().use('liferay-portlet-url', function () {
                 e.preventDefault();
                 moderationsDataTable.buttons('.custom-print-button').trigger();
             }
+        });
+
+        $('.list-group-item').on('click', function(e) {
+                let ref = $(this).attr('href');
+                if (ref === '#tab-OpenCR' || ref === '#tab-ClosedCR') {
+                    let msg = '<liferay-ui:message key="clearing" /> (${clearingRequests.size()}/${closedClearingRequests.size()})';
+                    $('.portlet-title').attr('title', msg);
+                    $('.portlet-title').html(msg);
+                } else {
+                    $('.portlet-title').attr('title', '<liferay-ui:message key="moderations" /> (${moderationRequests.size()}/${closedModerationRequests.size()})');
+                    $('.portlet-title').html('<liferay-ui:message key="moderations" /> (${moderationRequests.size()}/<span id="requestCounter">${closedModerationRequests.size()}</span>)');
+                }
         });
 
         function prepareModerationsData() {
@@ -282,7 +295,7 @@ AUI().use('liferay-portlet-url', function () {
                     {title: "Actions", render: {display: renderClearingRequestAction}, className: 'one action'}
                 ],
                 language: {
-                    emptyTable: "No clearing requests are found."
+                    emptyTable: "<liferay-ui:message key='no.clearing.request.found'/>"
                 },
                 "order": [[2, 'asc']],
                 initComplete: datatables.showPageContainer
@@ -290,15 +303,15 @@ AUI().use('liferay-portlet-url', function () {
         }
 
         function renderClearingRequestAction(tableData, type, row) {
-            let status = $(row[3]).text();
-            if (status === 'Closed' || status === 'Rejected' || !row[10] || $(row[6]).attr('href').replace('mailto:', '') !== '${user.emailAddress}') {
+            if (row[10] && ($(row[6]).attr('href').replace('mailto:', '') === '${user.emailAddress}' || ${isClearingExpert})) {
+                return render.linkTo(
+                        makeClearingRequestUrl(row.DT_RowId, '<%=PortalConstants.PAGENAME_EDIT_CLEARING_REQUEST%>'),
+                        "",
+                        '<div class="actions"><svg class="edit lexicon-icon"><title>Edit</title><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#pencil"/></svg></div>'
+                        );
+            } else {
                 return '';
             }
-            return render.linkTo(
-                    makeClearingRequestUrl(row.DT_RowId, '<%=PortalConstants.PAGENAME_EDIT_CLEARING_REQUEST%>'),
-                    "",
-                    '<div class="actions"><svg class="edit lexicon-icon"><title>Edit</title><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#pencil"/></svg></div>'
-                    );
         }
 
         // helper functions

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentUsages.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentUsages.jspf
@@ -114,7 +114,7 @@
                 alert.success($form, '<liferay-ui:message key="saved.attachment.usages" />', 4);
                 button.finish('#saveAttachmentUsagesButton');
             }).fail(function(xhr, status, error){
-                alert.danger($form, '<liferay-ui:message key="couldnt.save.attachment.usages" />' + xhr.responseText, 6);
+                alert.danger($form, "<liferay-ui:message key="couldnt.save.attachment.usages" />" + xhr.responseText, 6);
                 button.finish('#saveAttachmentUsagesButton');
             });
         }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligations.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligations.jspf
@@ -76,7 +76,6 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
         </core_rt:if>
 
         obligationJSON.push({
-            "DT_RowId": "${entry.key}",
             "obligation": '${entry.key}',
             "lIds": licenseIds.join(', <br>'),
             "rIds": releaseIds,
@@ -129,6 +128,12 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
                     } else if (status === 'To be fulfilled by parent project') {
                         $(td).addClass('text-info');
                     }
+                }
+            },
+            {
+                "targets": 5,
+                "createdCell": function (td, cellData, rowData, row, col) {
+                    $(td).css('max-width', '15rem');
                 }
             }
         ],
@@ -195,15 +200,5 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
         render.toggleAllChildRows($(this), table);
     });
 
-    /*
-     * Define function for child row creation, which will contain additional data for a clicked table row
-     */
-    function createChildRow(rowData) {
-        var childHtmlString = '' +
-            '<div>' +
-            '<span>' + rowData.text + '</span>' +
-            '</div>';
-        return childHtmlString;
-    }
 });
 </script>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligationsEdit.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligationsEdit.jspf
@@ -130,6 +130,7 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
                 "createdCell": function (td, cellData, rowData, row, col) {
                     $.fn.dataTable.render.inputText.updateTitle(td);
                     $.fn.dataTable.render.inputText.useInputDialog(td, "<liferay-ui:message key="enter.obligation.comment" />");
+                    $(td).css('max-width', '15rem');
                 }
             }
         ],
@@ -290,17 +291,6 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
     $('#editObligationsTable thead').on('click', 'th.more-info', function() {
         render.toggleAllChildRows($(this), table);
     });
-
-    /*
-     * Define function for child row creation, which will contain obligation text for a clicked table row
-     */
-    function createChildRow(rowData) {
-        let childHtmlString = '' +
-            '<div>' +
-            '<span>' + rowData.text + '</span>' +
-            '</div>';
-        return childHtmlString;
-    }
 
     /* collect all the obligation status */
     function updateObligations(event, data, node, config) {

--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -705,6 +705,7 @@ no=No
 no.attachments.yet=No attachments yet.
 no.changes.in.attachments=No changes in attachments
 no.changes.in.basic.fields=No changes in basic fields.
+no.clearing.request.found=No clearing request found.
 no.data.available.in.table=No data available in table
 no.duplicate.identifiers.were.found=No duplicate identifiers were found.
 no.license.details.found.in.the.database.for.given.license.id=No license details found in the database for given license id.
@@ -729,6 +730,7 @@ no.releases.linked.to.this.project.or.its.linked.projects=No releases linked to 
 no.report=no report
 no.results.found.please.refine.your.search=No results found please refine your search
 no.subscriptions.available=No subscriptions available.
+not.applicable=Not Applicable
 not.available=not available
 not.checked=Not Checked
 not.decided.so.far=Not decided so far
@@ -745,7 +747,7 @@ obligations=Obligations
 obligations.are.not.present.in.accepted.cli.xml.file=Obligations are not present in Accepted CLI xml file.
 obligation.status.is.saved.successfully.refresh.the.page.to.see.the.updated.status=Obligation status is saved successfully, Refresh the page to see the updated status
 obligations.view=Obligations View
-on=On
+on=on
 only.administrators.can.edit.a.closed.project=Only administrators can edit a closed project.
 only.admin.users.can.delete.todos=Only admin users can delete Todos!
 only.approved.cli.files.obligations.will.be.shown.here=Only <b>Approved</b> CLI files Obligations will be shown here.
@@ -1106,6 +1108,7 @@ this.project.x.contains=This project <b data-name="name"></b> contains:
 this.release.x.contains=This release <b data-name="name"></b> contains:
 this.release.x.contains.1=This release <span data-name="name"></span> contains
 title=Title
+to.be.fulfilled.by.parent.project=To be fulfilled by parent project
 to.be.replaced=To be replaced
 todo=Todo
 todo.details=Todo Details

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -705,6 +705,7 @@ no=Không
 no.attachments.yet=Không có tệp đính kèm nào.
 no.changes.in.attachments=Không có thay đổi trong tệp đính kèm
 no.changes.in.basic.fields=Không có thay đổi trong các lĩnh vực cơ bản.
+no.clearing.request.found=No clearing request found.
 no.data.available.in.table=Không có dữ liệu trong bảng
 no.duplicate.identifiers.were.found=Không tìm thấy định danh trùng lặp.
 no.license.details.found.in.the.database.for.given.license.id=Không có chi tiết giấy phép được tìm thấy trong cơ sở dữ liệu cho id giấy phép nhất định.
@@ -729,6 +730,7 @@ no.releases.linked.to.this.project.or.its.linked.projects=Không có bản phát
 no.report=không có báo cáo
 no.results.found.please.refine.your.search=Không tìm thấy kết quả, vui lòng điều chỉnh tìm kiếm của bạn
 no.subscriptions.available=Không có đăng ký có sẵn.
+not.applicable=Not Applicable
 not.available=Không có sẵn
 not.checked=Chưa được kiểm tra
 not.decided.so.far=Không quyết định cho đến nay
@@ -745,7 +747,7 @@ obligations=Nghĩa vụ
 obligations.are.not.present.in.accepted.cli.xml.file=Nghĩa vụ không có trong tệp xml CLI được chấp nhận.
 obligation.status.is.saved.successfully.refresh.the.page.to.see.the.updated.status=Trạng thái nghĩa vụ được lưu thành công, Làm mới trang để xem trạng thái cập nhật
 obligations.view=Xem nghĩa vụ
-on=On
+on=on
 only.administrators.can.edit.a.closed.project=Chỉ quản trị viên có thể dự án đã đóng
 only.admin.users.can.delete.todos=Chỉ người dùng quản trị mới có thể xóa Việc cần làm!
 only.approved.cli.files.obligations.will.be.shown.here=Chỉ <b>Được phê duyệt</b> Các tệp CLI Nghĩa vụ sẽ được hiển thị tại đây.
@@ -1106,6 +1108,7 @@ this.project.x.contains=Dự án này <b data-name="name"></b> chứa:
 this.release.x.contains=Bản phát hành <b data-name="name"></b> này chứa:
 this.release.x.contains.1=Bản phát hành <span data-name="name"></span> chứa
 title=Tiêu đề
+to.be.fulfilled.by.parent.project=To be fulfilled by parent project
 to.be.replaced=Sẽ được thay thế
 todo=Việc cần làm
 todo.details=Chi tiết việc cần làm


### PR DESCRIPTION

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Summary of changes:
 * `Edit` icon will be showed for all the users with role `Clearing Expert` and above in `Open / Closed` Clearing Request tab. 
 * Text truncate (`ellipsis`) is now working for `comment` row in `Project Obligation` table.
 * Fixed `Expand` icon not visible for component name under `Obligations` tab in `Release view`.
 * Fixed `js` error on `attachmentUsage.jspf` page.

Issue: #853 

### How To Test?
* Login with user role `Clearing expert` or above and you should be able to see edit icons for clearing request in `Open / Closed` Clearing Request tab. 
* In project `edit` mode, enter a long text in `comment` input of `Project Obligation` table, Once saved, the `comment` text should be truncated.
* No syntax error in browser console upon loading of `view project` page.
* Have you implemented any additional tests? - No

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: Abdul Kapti <abdul.mannankapti@siemens.com>