### PR TITLE
feat(PreferenceUI): Enabled Email notification for Requesting User in CR

### DIFF
--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -11,13 +11,13 @@
 package org.eclipse.sw360.moderation.db;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.common.ThriftEnumUtils;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
-import org.eclipse.sw360.datahandler.db.ChangeLogsRepository;
 import org.eclipse.sw360.datahandler.db.ComponentDatabaseHandler;
 import org.eclipse.sw360.datahandler.db.DatabaseHandlerUtil;
 import org.eclipse.sw360.datahandler.db.ProjectDatabaseHandler;
@@ -602,10 +602,12 @@ public class ModerationDatabaseHandler {
 
     private void sendMailForNewCommentInCR(ClearingRequest cr, Comment comment, User user) throws SW360Exception {
         Project project = projectDatabaseHandler.getProjectById(cr.getProjectId(), user);
-        Set<String> recipients = Sets.newHashSet(cr.getRequestingUser(), cr.getClearingTeam());
-        mailUtil.sendClearingMail(ClearingRequestEmailTemplate.NEW_COMMENT, recipients, MailConstants.SUBJECT_FOR_CLEARING_REQUEST_COMMENT,
-                new StringBuilder(CommonUtils.nullToEmptyString(user.getUserGroup())).append(MailConstants.DASH).append(SW360Utils.printFullname(user)).toString(),
-                CommonUtils.nullToEmptyString(cr.getId()), SW360Utils.printName(project), CommonUtils.nullToEmptyString(comment.getText()));
+        Map<String, String> recipients = Maps.newHashMap();
+        recipients.put(ClearingRequest._Fields.REQUESTING_USER.toString(), cr.getRequestingUser());
+        recipients.put(ClearingRequest._Fields.CLEARING_TEAM.toString(), cr.getClearingTeam());
+        String userDetails = new StringBuilder(CommonUtils.nullToEmptyString(user.getUserGroup())).append(MailConstants.DASH).append(SW360Utils.printFullname(user)).toString();
+        mailUtil.sendClearingMail(ClearingRequestEmailTemplate.NEW_COMMENT, MailConstants.SUBJECT_FOR_CLEARING_REQUEST_COMMENT, "", recipients,
+            userDetails, CommonUtils.nullToEmptyString(cr.getId()), SW360Utils.printName(project), CommonUtils.nullToEmptyString(comment.getText()));
     }
 
     private void sendMailNotificationsForNewRequest(ModerationRequest request, String userEmail){

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -17,7 +17,9 @@ import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
+import org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 
 import java.util.*;
 import java.util.function.Function;
@@ -83,6 +85,7 @@ public class SW360Constants {
 
     public static final String NOTIFICATION_CLASS_RELEASE = "release";
     public static final String NOTIFICATION_CLASS_MODERATION_REQUEST = "moderation";
+    public static final String NOTIFICATION_CLASS_CLEARING_REQUEST = "clearing";
     public static final String NOTIFICATION_CLASS_COMPONENT = "component";
     public static final String NOTIFICATION_CLASS_PROJECT = "project";
     public static final Map<String, List<Map.Entry<String, String>>> NOTIFIABLE_ROLES_BY_OBJECT_TYPE = ImmutableMap.<String, List<Map.Entry<String, String>>>builder()
@@ -112,6 +115,9 @@ public class SW360Constants {
             .put(NOTIFICATION_CLASS_MODERATION_REQUEST, ImmutableList.<Map.Entry<String, String>>builder()
                     .add(pair(ModerationRequest._Fields.REQUESTING_USER, "Requesting User"),
                             pair(ModerationRequest._Fields.MODERATORS, "Moderator"))
+                    .build())
+            .put(NOTIFICATION_CLASS_CLEARING_REQUEST, ImmutableList.<Map.Entry<String, String>>builder()
+                    .add(pair(ClearingRequest._Fields.REQUESTING_USER, "Requesting User"))
                     .build())
             .build();
     public static final List<String> NOTIFICATION_EVENTS_KEYS = NOTIFIABLE_ROLES_BY_OBJECT_TYPE.entrySet()


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
 * Enabled `Email Notification preference` for `Requesting User` in `Clearing request`.
 * Email notifications for `Clearing Team` will always get triggered.

Issue: #866

### Suggest Reviewer


### How To Test?
* Requesting User should receive an email, if email subscription is enabled under Clearing tab.
* Email will get triggered upon: Creation of CR, updating a CR, adding comment in CR, changes in Linked release for a project linked with CR.


### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: Abdul Kapti <abdul.mannankapti@siemens.com>

