### PR TITLE
fix(ClearingStatus): Tree View Release name getting truncated, Sort for Project mainline state and Clearing State in List View fixed , added search filter

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/clearingStatus.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/clearingStatus.jspf
@@ -96,20 +96,31 @@ AUI().use('liferay-portlet-url', function () {
                     {title: "<liferay-ui:message key="release.path" />", data : "releaseOrigin", "defaultContent": ""},
                     {title: "<liferay-ui:message key="relation" />", data : "relation", "defaultContent": ""},
                     {title: "<liferay-ui:message key="main.licenses" />", data : "mainLicenses", "defaultContent": "", render: {display: mainLicenseUrl}},
-                    {title: "<liferay-ui:message key="state" />", data: "isRelease", render: {display: renderState}, "defaultContent": ""},
+                    {title: "<liferay-ui:message key="state" />", "data": function(row) {
+                        let ps=row.projectState;
+                        let cs=row.clearingState;
+                        if(ps === null || ps === undefined) ps="0";
+                        if(cs === null || cs === undefined) cs="0";
+                        return ps + priorityOfClearingState(cs) + cs;
+                    }, render: {display: renderState}, "defaultContent": ""},
                     {title: "<liferay-ui:message key="release.mainline.state" />", data : "releaseMainlineState", "defaultContent": ""},
                     {title: "<liferay-ui:message key="project.mainline.state" />", data : "projectMainlineState", "defaultContent": ""},
                     {title: "<liferay-ui:message key="actions" />",  data: "id", "orderable": false, "defaultContent": "", render: {display: renderActions}, className: "two actions" }
                 ],
                 "order": [[ 0, "asc" ]],
                 fnDrawCallback: datatables.showPageContainer,
-
             language: {
                 url: "<liferay-ui:message key="datatables.lang" />",
                 loadingRecords: "<liferay-ui:message key="loading" />"
-            }}, [0, 1, 2, 3, 4,5,6,7,8], 8);
+            }}, [0, 1, 2, 3, 4, 5, 6, 7, 8], undefined, true);
             return clearingStatusTable;
         }
+
+        $("#clearingStatusTable").on('init.dt', function() {
+            $('#pills-listView input').on('keyup change clear', function () {
+                $("#clearingStatusTable").DataTable().search($(this).val(), false, true).draw();
+            });
+        });
 
         var homeUrl = themeDisplay.getURLHome().replace(/\/web\//, '/group/');
 
@@ -122,7 +133,7 @@ AUI().use('liferay-portlet-url', function () {
             else {
                 url = makeProjectViewUrl(row.id);
             }
-            let viewUrl = $("<a></a>").attr("href",url).html(name);
+            let viewUrl = $("<a></a>").attr("href",url).css("word-break","break-word").html(name);
             return viewUrl[0].outerHTML;
         }
 
@@ -167,8 +178,8 @@ AUI().use('liferay-portlet-url', function () {
             return $actions[0].outerHTML;
         }
 
-        function renderState(isRelease, type, row) {
-            if(isRelease==="true") {
+        function renderState(data, type, row) {
+            if(row.isRelease==="true") {
                 return renderClearingStateBox(row.clearingState);
             }
             return renderProjectStateBox(row.projectState,row.clearingState)
@@ -227,6 +238,25 @@ AUI().use('liferay-portlet-url', function () {
                         return 'bg-primary';
                 }
             return '<%=PortalConstants.CLEARING_STATE_UNKNOWN__CSS%>';
+        }
+
+        function priorityOfClearingState(cState) {
+            switch (cState) {
+                case 'Report approved':
+                case 'Closed':
+                    return '1';
+                case 'Report available':
+                    return '2';
+                case 'In Progress':
+                case 'Under clearing':
+                    return '3';
+                case 'Sent to clearing tool':
+                    return '4';
+                case 'Open':
+                case 'New':
+                    return '5';
+            }
+            return '6';
         }
 
         function makeReleaseUrl(releaseId) {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/ajax/linkedProjectsRows.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/ajax/linkedProjectsRows.jspf
@@ -34,7 +34,7 @@
         >
             <td style="white-space: nowrap">
                 <a href="<sw360:DisplayProjectLink projectId="${projectLink.id}" bare="true" scopeGroupId="${concludedScopeGroupId}"/>"><sw360:out
-                        value="${projectLink.name} ${projectLink.version}" maxChar="20"
+                        value="${projectLink.name} ${projectLink.version}" maxChar="60"
                 /></a>
             </td>
             <td>
@@ -66,7 +66,7 @@
         >
             <td style="white-space: nowrap">
                 <a href="<sw360:DisplayReleaseLink releaseId="${releaseLink.id}" bare="true" scopeGroupId="${concludedScopeGroupId}" />">
-                    <sw360:out value="${releaseLink.name} ${releaseLink.version}" maxChar="20"/>
+                    <sw360:out value="${releaseLink.name} ${releaseLink.version}" maxChar="60"/>
                 </a>
             </td>
             <td>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/ajax/linkedReleasesClearingStatusRows.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/ajax/linkedReleasesClearingStatusRows.jsp
@@ -29,7 +29,7 @@
         <core_rt:if test="${empty parent_branch_id and not empty releaseLink.parentNodeId}">data-tt-parent-id="${releaseLink.parentNodeId}"</core_rt:if>>
         <td style="white-space: nowrap">
             <a href="<sw360:DisplayReleaseLink releaseId="${releaseLink.id}" bare="true" scopeGroupId="${concludedScopeGroupId}" />">
-                <sw360:out value="${releaseLink.name} ${releaseLink.version}" maxChar="20" />
+                <sw360:out value="${releaseLink.name} ${releaseLink.version}" maxChar="60" />
             </a>
         </td>
         <td>


### PR DESCRIPTION


> Tree View Release name getting truncated, Sort for Project mainline state and Clearing State in List View fixed , added search filter
>  * Revert truncate length of Release and Project name from 20 to 60 old value, truncated names will show complete name in tooltip.
>  * Fixed sorting for clearing state ,Project mailine state in List View
> * Added Search filter with AND logic for text separated by space


> * Which issue is this pull request belonging to and how is it solving it? (*#869*)
> * Did you add or update any new dependencies that are required for your change? - No

### How To Test?
>   - Sort by State and Project mailine state column in list View, 
>   - Search with multiple filters separated by space
>   - Release/Project name in Tree view should show upto 60 char , beyond that truncated by ... and complete name in tooltip

> Have you implemented any additional tests? - No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>