### PR TITLE
CR-UI(CR Table and Details page): fixed various bugs

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/clearing/clearingRequest.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/clearing/clearingRequest.jsp
@@ -195,7 +195,7 @@
                                                 </core_rt:choose>
                                                 </td>
                                             </tr>
-                                            <core_rt:if test="${clearingRequest.isSetTimestampOfDecision()}">
+                                            <core_rt:if test="${clearingRequest.isSetTimestampOfDecision() and clearingRequest.timestampOfDecision gt 0}">
                                                 <tr>
                                                     <td><label class="form-group"><liferay-ui:message key="request.closed.on" />:</label></td>
                                                     <td>
@@ -277,7 +277,7 @@
                                         </core_rt:forEach>
                                         <tr>
                                             <td>
-                                                <core_rt:if test="${isProjectPresent and isClearingTeam}">
+                                                <core_rt:if test="${isProjectPresent and (isClearingTeam or isRequestingUser)}">
 	                                                <textarea id="clearingRequestComment" placeholder="<liferay-ui:message key='enter.comment' />..." class="h-25 form-control"></textarea>
 	                                                <div class="my-2 btn-group" role="group">
 	                                                    <button id="addComment" type="button" class="btn btn-success"><liferay-ui:message key='add.comment' /></button>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/view.jsp
@@ -144,6 +144,8 @@ AUI().use('liferay-portlet-url', function () {
 
         quickfilter.addTable(moderationsDataTable);
         quickfilter.addTable(closedModerationsDataTable);
+        quickfilter.addTable(clearingRequestsDataTable);
+        quickfilter.addTable(closedClearingRequestsDataTable);
 
         $('.TogglerModeratorsList').on('click', toggleModeratorsList );
         $('#closedModerationsTable').on('click', 'svg.delete', function(event) {
@@ -297,6 +299,12 @@ AUI().use('liferay-portlet-url', function () {
                 language: {
                     emptyTable: "<liferay-ui:message key='no.clearing.request.found'/>"
                 },
+                columnDefs: [
+                    {
+                        targets: [2],
+                        type: 'natural'
+                    },
+                ],
                 "order": [[2, 'asc']],
                 initComplete: datatables.showPageContainer
             }, [1,2,3,4,5,6,7], [0,8]);


### PR DESCRIPTION
Signed-off-by: Abdul Kapti <abdul.mannankapti@siemens.com>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
- [x] Clearing Request: `Requesting User` cannot add `comment` in a CR in `Clearing Request Details` page.
* Fixed 
- [x] The `Quick Filter` is not working for any columns on the `Clearing Request` table.
* Fixed 
- [x] The sorting of values in the `Request ID `field is not correct in the `Clearing Request` table.
* Fixed 
<br>
Issue: #893 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
* login using `USER` role credentials.
* create a clearing request 
* requesting user should be able to add the comment in clearing request.
* quick filter should be working on clearing request table page.
* sorting error for `Request ID ` should be fixed now.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
