### PR TITLE
Oheger bosch/feat/attachments delete

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/components.adoc
+++ b/rest/resource-server/src/docs/asciidoc/components.adoc
@@ -193,6 +193,28 @@ include::{snippets}/should_document_get_component_attachment/curl-request.adoc[]
 ===== Example response
 include::{snippets}/should_document_get_component_attachment/http-response.adoc[]
 
+[[resources-component-attachment-delete]]
+==== Delete attachments
+
+With a `DELETE` request one or multiple attachments can be deleted from a component.
+To delete multiple attachments at once, just specify a comma-separated list of
+attachment IDs.
+
+Note that attachments can only be deleted if they are not used by a project.
+Requests that cannot delete any of the attachments specified fail with response
+status 500.
+
+===== Example request
+include::{snippets}/should_document_delete_component_attachment/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_delete_component_attachment/http-response.adoc[]
+
+The response contains the updated component. Here the set of attachments is especially
+relevant. If multiple attachments were to be deleted, but the deletion failed for
+some of them, those can still be found in the set. So callers should inspect
+the set of attachments in the result to find out whether all delete operations
+have been successful.
 
 [[resources-components-create]]
 ==== Creating a component

--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -195,6 +195,29 @@ include::{snippets}/should_document_get_release_attachment/curl-request.adoc[]
 ===== Example response
 include::{snippets}/should_document_get_release_attachment/http-response.adoc[]
 
+[[resources-release-attachment-delete]]
+==== Delete attachments
+
+With a `DELETE` request one or multiple attachments can be deleted from a release.
+To delete multiple attachments at once, just specify a comma-separated list of
+attachment IDs.
+
+Note that attachments can only be deleted if they are not used by a project.
+Requests that cannot delete any of the attachments specified fail with response
+status 500.
+
+===== Example request
+include::{snippets}/should_document_delete_release_attachment/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_delete_release_attachment/http-response.adoc[]
+
+The response contains the updated release. Here the set of attachments is especially
+relevant. If multiple attachments were to be deleted, but the deletion failed for
+some of them, those can still be found in the set. So callers should inspect
+the set of attachments in the result to find out whether all delete operations
+have been successful.
+
 [[resources-trigger_fossology_process-get]]
 ==== Trigger FOSSology process
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentService.java
@@ -16,9 +16,6 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TException;
-import org.apache.thrift.protocol.TCompactProtocol;
-import org.apache.thrift.protocol.TProtocol;
-import org.apache.thrift.transport.THttpClient;
 import org.apache.thrift.transport.TTransportException;
 import org.eclipse.sw360.commonIO.AttachmentFrontendUtils;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
@@ -28,6 +25,7 @@ import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.attachments.*;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
+import org.eclipse.sw360.rest.resourceserver.core.ThriftServiceProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
@@ -61,6 +59,9 @@ public class Sw360AttachmentService {
 
     @NonNull
     private final RestControllerHelper restControllerHelper;
+
+    @NonNull
+    private final ThriftServiceProvider<AttachmentService.Iface> thriftAttachmentServiceProvider;
 
     private static final Logger log = Logger.getLogger(Sw360AttachmentService.class);
     private final Duration downloadTimeout = Duration.durationOf(30, TimeUnit.SECONDS);
@@ -191,9 +192,7 @@ public class Sw360AttachmentService {
     }
 
     private AttachmentService.Iface getThriftAttachmentClient() throws TTransportException {
-        THttpClient thriftClient = new THttpClient(thriftServerUrl + "/attachments/thrift");
-        TProtocol protocol = new TCompactProtocol(thriftClient);
-        return new AttachmentService.Client(protocol);
+        return thriftAttachmentServiceProvider.getService(thriftServerUrl);
     }
 
     public Resources<Resource<Attachment>> getResourcesFromList(Set<Attachment> attachmentList) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/ThriftAttachmentServiceProvider.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/attachment/ThriftAttachmentServiceProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Bosch.IO GmbH 2020.
+ * Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.attachment;
+
+import org.apache.thrift.protocol.TCompactProtocol;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.transport.THttpClient;
+import org.apache.thrift.transport.TTransportException;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentService;
+import org.eclipse.sw360.rest.resourceserver.core.ThriftServiceProvider;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ThriftAttachmentServiceProvider implements ThriftServiceProvider<AttachmentService.Iface> {
+    @Override
+    public AttachmentService.Iface getService(String thriftServerUrl) throws TTransportException {
+        THttpClient thriftClient = new THttpClient(thriftServerUrl + "/attachments/thrift");
+        TProtocol protocol = new TCompactProtocol(thriftClient);
+        return new AttachmentService.Client(protocol);
+    }
+}

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/ThriftServiceProvider.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/ThriftServiceProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Bosch.IO GmbH 2020.
+ * Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.core;
+
+import org.apache.thrift.transport.TTransportException;
+
+/**
+ * <p>
+ * A generic interface used by the REST services layer to obtain references to
+ * Thrift services.
+ * </p>
+ * <p>
+ * Via concrete implementations of this interface, {@code Sw360XXXService}
+ * classes can obtain their underlying Thrift service. The implementations are
+ * managed and injected by Spring. This makes it possible to inject mock
+ * services in tests.
+ * </p>
+ *
+ * @param <T> the type of the Thrift service provided by this interface
+ */
+@FunctionalInterface
+public interface ThriftServiceProvider<T> {
+    /**
+     * Returns a new instance of the underlying Thrift service that can be
+     * reached under the given base URL. As such Thrift services are typically
+     * not thread-safe, an implementation has to ensure that for each thread a
+     * different service instance is returned.
+     *
+     * @param thriftServerUrl the base URL for all Thrift services
+     * @return the Thrift service instance
+     * @throws TTransportException if an error occurs
+     */
+    T getService(String thriftServerUrl) throws TTransportException;
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/TestHelper.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/TestHelper.java
@@ -20,6 +20,7 @@ import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.MainlineState;
 import org.eclipse.sw360.datahandler.thrift.Source;
+import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.attachment.AttachmentInfo;
 import org.eclipse.sw360.rest.resourceserver.core.MultiStatus;
 import org.springframework.http.HttpStatus;
@@ -179,6 +180,14 @@ public class TestHelper {
         attachmentInfos.add(attachmentInfo2);
 
         return attachmentInfos;
+    }
+
+    public static User getTestUser() {
+        User user = new User();
+        user.setId("123456789");
+        user.setEmail("admin@sw360.org");
+        user.setFullname("John Doe");
+        return user;
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentServiceTest.java
@@ -16,6 +16,7 @@ import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentService;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage;
+import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.core.ThriftServiceProvider;
 import org.junit.Before;
@@ -35,6 +36,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -133,6 +135,21 @@ public class Sw360AttachmentServiceTest {
         Set<Attachment> filtered = attachmentService.filterAttachmentsToRemove(owner, allAttachments,
                 Arrays.asList(attachmentId(1), attachmentId(2)));
         assertThat(filtered).containsOnly(createAttachment(2));
+    }
+
+    @Test
+    public void testFilterAttachmentsToRemoveEvaluatesCheckStatus() throws TException {
+        Source owner = createSource();
+        Attachment attachment1 = createAttachment(1);
+        Attachment attachment2 = createAttachment(2);
+        attachment2.setCheckStatus(CheckStatus.ACCEPTED);
+        Set<Attachment> attachments = new HashSet<>(Arrays.asList(attachment1, attachment2));
+        when(thriftService.getAttachmentUsages(any(), anyString(), any()))
+                .thenReturn(Collections.emptyList());
+
+        Set<Attachment> filtered = attachmentService.filterAttachmentsToRemove(owner, attachments,
+                Arrays.asList(attachmentId(1), attachmentId(2)));
+        assertThat(filtered).containsOnly(attachment1);
     }
 
     @Test

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentServiceTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/attachment/Sw360AttachmentServiceTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Bosch.IO GmbH 2020.
+ * Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.rest.resourceserver.attachment;
+
+import org.apache.thrift.TException;
+import org.apache.thrift.transport.TTransportException;
+import org.eclipse.sw360.datahandler.thrift.Source;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentService;
+import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage;
+import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
+import org.eclipse.sw360.rest.resourceserver.core.ThriftServiceProvider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class Sw360AttachmentServiceTest {
+    @Mock
+    private ThriftServiceProvider<AttachmentService.Iface> serviceProvider;
+
+    @Mock
+    private RestControllerHelper<?> restControllerHelper;
+
+    @Mock
+    private AttachmentService.Iface thriftService;
+
+    @InjectMocks
+    private Sw360AttachmentService attachmentService;
+
+    private int sourceIdCounter;
+
+    @Before
+    public void setUp() throws TTransportException {
+        when(serviceProvider.getService(anyString())).thenReturn(thriftService);
+    }
+
+    private static String attachmentId(int idx) {
+        return "at" + idx;
+    }
+
+    private static Attachment createAttachment(int idx) {
+        return new Attachment(attachmentId(idx), "file" + idx);
+    }
+
+    private static Set<Attachment> createAttachmentSet(int count) {
+        return IntStream.range(1, count + 1)
+                .mapToObj(Sw360AttachmentServiceTest::createAttachment)
+                .collect(Collectors.toSet());
+    }
+
+    private Source createSource(Function<String, Source> srcCreator) {
+        return srcCreator.apply("id" + (++sourceIdCounter));
+    }
+
+    private Source createSource() {
+        return createSource(Source::releaseId);
+    }
+
+    private AttachmentUsage createAttachmentUsage(int idx, Function<String, Source> ownerSrcCreator) {
+        return new AttachmentUsage(createSource(), attachmentId(idx), createSource(ownerSrcCreator));
+    }
+
+    private AttachmentUsage createAttachmentUsage(int idx) {
+        return createAttachmentUsage(idx, Source::releaseId);
+    }
+
+    @Test
+    public void testFilterAttachmentsToRemoveIgnoresUnknownAttachments() throws TException {
+        Set<Attachment> attachmentSet = createAttachmentSet(4);
+
+        Set<Attachment> filtered = attachmentService.filterAttachmentsToRemove(Source.releaseId("r"),
+                new HashSet<>(attachmentSet), Arrays.asList(attachmentId(10), attachmentId(11)));
+        assertThat(filtered).isEmpty();
+        verifyZeroInteractions(thriftService);
+    }
+
+    @Test
+    public void testFilterAttachmentsToRemoveAllValid() throws TException {
+        Source owner = createSource();
+        Set<Attachment> allAttachments = createAttachmentSet(3);
+        AttachmentUsage usage1 = createAttachmentUsage(2);
+        AttachmentUsage usage2 = createAttachmentUsage(2);
+        AttachmentUsage usage3 = createAttachmentUsage(3);
+        when(thriftService.getAttachmentUsages(owner, attachmentId(2), null))
+                .thenReturn(Arrays.asList(usage1, usage2));
+        when(thriftService.getAttachmentUsages(owner, attachmentId(3), null))
+                .thenReturn(Collections.singletonList(usage3));
+
+        Set<Attachment> filtered = attachmentService.filterAttachmentsToRemove(owner, allAttachments,
+                Arrays.asList(attachmentId(2), attachmentId(3)));
+        assertThat(filtered).containsOnly(createAttachment(2), createAttachment(3));
+    }
+
+    @Test
+    public void testFilterAttachmentsToRemoveEvaluatesAttachmentUsages() throws TException {
+        Source owner = createSource();
+        List<AttachmentUsage> usages1 = Arrays.asList(createAttachmentUsage(1),
+                createAttachmentUsage(1, Source::projectId));
+        List<AttachmentUsage> usages2 = Arrays.asList(createAttachmentUsage(2), createAttachmentUsage(2));
+        Set<Attachment> allAttachments = createAttachmentSet(2);
+        when(thriftService.getAttachmentUsages(owner, attachmentId(1), null))
+                .thenReturn(usages1);
+        when(thriftService.getAttachmentUsages(owner, attachmentId(2), null))
+                .thenReturn(usages2);
+
+        Set<Attachment> filtered = attachmentService.filterAttachmentsToRemove(owner, allAttachments,
+                Arrays.asList(attachmentId(1), attachmentId(2)));
+        assertThat(filtered).containsOnly(createAttachment(2));
+    }
+
+    @Test
+    public void testFilterAttachmentsToRemoveHandlesExceptions() throws TException {
+        Source owner = createSource();
+        when(thriftService.getAttachmentUsages(owner, attachmentId(1), null))
+                .thenThrow(new TException("Thrift failure"));
+        when(thriftService.getAttachmentUsages(owner, attachmentId(2), null))
+                .thenReturn(Collections.emptyList());
+        Set<Attachment> allAttachments = createAttachmentSet(3);
+
+        Set<Attachment> filtered = attachmentService.filterAttachmentsToRemove(owner, allAttachments,
+                Arrays.asList(attachmentId(1), attachmentId(2)));
+        assertThat(filtered).containsOnly(createAttachment(2));
+        verify(thriftService).getAttachmentUsages(owner, attachmentId(2), null);
+    }
+}

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ComponentTest.java
@@ -15,9 +15,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
+import org.eclipse.sw360.datahandler.thrift.Source;
+import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
+import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.rest.resourceserver.TestHelper;
+import org.eclipse.sw360.rest.resourceserver.attachment.Sw360AttachmentService;
 import org.eclipse.sw360.rest.resourceserver.component.Sw360ComponentService;
 import org.eclipse.sw360.rest.resourceserver.user.Sw360UserService;
 import org.junit.Before;
@@ -32,15 +36,30 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -56,6 +75,9 @@ public class ComponentTest extends TestIntegrationBase {
 
     @MockBean
     private Sw360ComponentService componentServiceMock;
+
+    @MockBean
+    private Sw360AttachmentService attachmentServiceMock;
 
     private Component component;
     private final String componentId = "123456789";
@@ -74,10 +96,7 @@ public class ComponentTest extends TestIntegrationBase {
 
         given(this.componentServiceMock.getComponentsForUser(anyObject())).willReturn(componentList);
 
-        User user = new User();
-        user.setId("123456789");
-        user.setEmail("admin@sw360.org");
-        user.setFullname("John Doe");
+        User user = TestHelper.getTestUser();
 
         given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(user);
         given(this.userServiceMock.getUserByEmail("admin@sw360.org")).willReturn(user);
@@ -197,6 +216,69 @@ public class ComponentTest extends TestIntegrationBase {
                         new HttpEntity<>(null, headers),
                         String.class);
         TestHelper.handleBatchDeleteResourcesResponse(response, invalidComponentId, 500);
+    }
+
+    @Test
+    public void should_delete_attachments_successfully() throws TException, IOException {
+        final AtomicReference<Component> refUpdatedComponent = new AtomicReference<>();
+        List<Attachment> attachments = TestHelper.getDummyAttachmentsListForTest();
+        List<String> attachmentIds = Arrays.asList(attachments.get(0).attachmentContentId, "otherAttachmentId");
+        String strIds = String.join(",", attachmentIds);
+        component.setAttachments(new HashSet<>(attachments));
+        given(componentServiceMock.getComponentForUserById(componentId, TestHelper.getTestUser())).willReturn(component);
+        given(componentServiceMock.updateComponent(any(), eq(TestHelper.getTestUser())))
+                .will(invocationOnMock -> {
+                    refUpdatedComponent.set(new Component((Component) invocationOnMock.getArguments()[0]));
+                    return RequestStatus.SUCCESS;
+                });
+        given(attachmentServiceMock.filterAttachmentsToRemove(Source.componentId(componentId),
+                component.getAttachments(), attachmentIds))
+                .willReturn(Collections.singleton(attachments.get(1)));
+
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/components/" +
+                                componentId + "/attachments/" + strIds,
+                        HttpMethod.DELETE,
+                        new HttpEntity<>(null, getHeaders(port)),
+                        String.class);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        JsonNode jsonResponse = new ObjectMapper().readTree(response.getBody());
+        JsonNode jsonAttachments = jsonResponse.get("_embedded").get("sw360:attachments");
+        assertTrue(jsonAttachments.isArray());
+        Set<String> attachmentFileNames = StreamSupport.stream(jsonAttachments.spliterator(), false)
+                .map(node -> node.get("filename").textValue())
+                .collect(Collectors.toSet());
+        assertThat(attachmentFileNames, hasSize(1));
+        assertThat(attachmentFileNames, hasItem(attachments.get(0).getFilename()));
+
+        Component updatedComponent = refUpdatedComponent.get();
+        assertThat(updatedComponent, is(notNullValue()));
+        assertThat(updatedComponent.getAttachments(), hasSize(1));
+        assertThat(updatedComponent.getAttachments(), hasItem(attachments.get(0)));
+    }
+
+    @Test
+    public void should_delete_attachments_with_failure_handling() throws TException, IOException {
+        String attachmentId = TestHelper.getDummyAttachmentInfoListForTest().get(0).getAttachment()
+                .getAttachmentContentId();
+        Set<Attachment> attachments = new HashSet<>(TestHelper.getDummyAttachmentsListForTest());
+        component.setAttachments(attachments);
+        given(componentServiceMock.getComponentForUserById(componentId, TestHelper.getTestUser()))
+                .willReturn(component);
+        given(attachmentServiceMock.filterAttachmentsToRemove(Source.releaseId(componentId),
+                component.getAttachments(), Collections.singletonList(attachmentId)))
+                .willReturn(Collections.emptySet());
+
+        ResponseEntity<String> response =
+                new TestRestTemplate().exchange("http://localhost:" + port + "/api/components/" +
+                                componentId + "/attachments/" + attachmentId,
+                        HttpMethod.DELETE,
+                        new HttpEntity<>(null, getHeaders(port)),
+                        String.class);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        then(componentServiceMock)
+                .should(never())
+                .updateComponent(any(), any());
     }
 
 }


### PR DESCRIPTION
Fixes #897  

This PR adds the ability to delete attachments from components and releases.

The functionality is implemented by the controllers for components and releases with a helper function for checking whether an attachment can be deleted in the Sw360AttachmentService. (According to discussions in the SW360 tech call, attachments must not be deleted when they are used by a project; this is checked by evaluating the attachment usage relations.)

To test the new method of the attachment service, I added a unit test for the service layer. In order to allow injecting mock thrift services, a new service provider interface was introduced, which is basically a factory for thrift services. The factory can be injected by Spring. (As thrift client services are not thread-safe, new instances must be created for each request; so it is not possible to inject the services themselves.)

The new REST endpoints have been added to the documentation.

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
Test cases for the new functionality have been added for the controllers and the attachment service.
