### PR TITLE
fix(ProjectModeration): Fixed isWriteActionAllowedOnProject check for project update

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -380,7 +380,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             return RequestStatus.FAILED_SANITY_CHECK;
         } else if (!isDependenciesExists(project, user)) {
             return RequestStatus.INVALID_INPUT;
-        } else if (isWriteActionAllowedOnProject(project, user)) {
+        } else if (isWriteActionAllowedOnProject(actual, user)) {
             copyImmutableFields(project,actual);
             project.setAttachments( getAllAttachmentsToKeep(toSource(actual), actual.getAttachments(), project.getAttachments()) );
             setReleaseRelations(project, user, actual);
@@ -811,6 +811,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         List<ModerationRequest> moderationRequestsForDocumentId = moderator.getModerationRequestsForDocumentId(id);
 
         Project project = getProjectById(id,user);
+        Visibility actualVisbility = project.getVisbility();
         DocumentState documentState;
         if (moderationRequestsForDocumentId.isEmpty()) {
             documentState = CommonUtils.getOriginalDocumentState();
@@ -823,6 +824,12 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 project = moderator.updateProjectFromModerationRequest(project,
                         moderationRequest.getProjectAdditions(),
                         moderationRequest.getProjectDeletions());
+
+                if (moderationRequest.getProjectAdditions() != null && moderationRequest.getProjectDeletions() != null
+                        && moderationRequest.getProjectAdditions().getVisbility() == moderationRequest
+                                .getProjectDeletions().getVisbility()) {
+                    project.setVisbility(actualVisbility);
+                }
                 documentState = CommonUtils.getModeratedDocumentState(moderationRequest);
             } else {
                 documentState = new DocumentState().setIsOriginalDocument(true).setModerationState(moderationRequestsForDocumentId.get(0).getModerationState());

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/entitlement/ProjectModerator.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/entitlement/ProjectModerator.java
@@ -111,6 +111,11 @@ public class ProjectModerator extends Moderator<Project._Fields, Project> {
                 continue;
             }
 
+            if (field == Project._Fields.VISBILITY && projectAdditions != null && projectDeletions != null
+                    && projectAdditions.getVisbility() == projectDeletions.getVisbility()) {
+                continue;
+            }
+
             switch (field) {
                 case LINKED_PROJECTS:
                     project = updateEnumMap(


### PR DESCRIPTION


> Fixed isWriteActionAllowedOnProject check for project update
> * Fixed incorrect value for Visibility in Edit Project view which has existing moderation request

> * Which issue is this pull request belonging to and how is it solving it? (*#909*)
> * Did you add or update any new dependencies that are required for your change? - No

### How To Test?
> - Steps mentioned in issue #909 

> - To test - `incorrect value for Visibility in Edit Project view which has existing moderation request`
    Create a project with visibility as `Everyone` . Create moderation request without making any changes to visiblity.
    On Editing the project. The Project with moderation request changes should load , and visibility should be correct `Everyone`.

> Have you implemented any additional tests? - No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>