### PR TITLE
fix(AttachmentTableUI): Fixed department of user not displayed correctly in Attachment table due to presence of Ampersand

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/attachmentsDetail.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/attachmentsDetail.jsp
@@ -125,9 +125,15 @@
                         { "data": "fileName" },
                         { "data": "size" },
                         { "data": "type" },
-                        { "data": "uploadedTeam" },
+                        { "data": function(row) {
+                                      return $('<span></span>').html(row.uploadedTeam).text();
+                                  }
+                        },
                         { "data": "uploadedBy" },
-                        { "data": "checkedTeam" },
+                        { "data": function(row) {
+                                      return $('<span></span>').html(row.checkedTeam).text();
+                                  }
+                        },
                         { "data": "checkedBy" },
                         { "data": "usage", "render": renderAttachmentUsages, orderable: false, className: 'text-center' },
                         { "data": "actions", className: "one action", orderable: false }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/editAttachments.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/editAttachments.jspf
@@ -107,7 +107,10 @@
               /*  0 */ { data: "filename", render: renderFilename, className: 'content-middle' },
               /*  1 */ { data: "attachmentType", render: $.fn.dataTable.render.inputSelect('attachmentTypes', config.inputTypeName, 'attachmentType toplabelledInput', 'textlabel stackedLabel') },
               /*  2 */ { data: "createdComment", defaultContent: "", render: $.fn.dataTable.render.inputText(config.inputCreatedCommentName, 'toplabelledInput', 'Enter comments') },
-              /*  3 */ { data: "createdTeam", defaultContent: "", render: $.fn.dataTable.render.ellipsis, className: 'content-middle' },
+              /*  3 */ { data: function(row) {
+                                   return $('<span></span>').html(row.createdTeam).text();
+                               }, defaultContent: "", render: $.fn.dataTable.render.ellipsis, className: 'content-middle'
+                       },
               /*  4 */ { data: "createdBy", defaultContent: "", render: $.fn.dataTable.render.ellipsis, className: 'content-middle'  },
               /*  5 */ { data: "createdOn", defaultContent: "", className: 'content-middle' },
               /*  6 */ { data: "checkStatus", render: $.fn.dataTable.render.inputSelect('checkStatuses', config.inputCheckStatusName, 'toplabelledInput', 'textlabel stackedLabel') },
@@ -118,7 +121,10 @@
                                                           }
                                                       })
                          },
-              /*  8 */ { data: "checkedTeam", defaultContent: "", render: $.fn.dataTable.render.ellipsis, className: 'content-middle' },
+              /*  8 */ { data: function(row) {
+                                   return $('<span></span>').html(row.checkedTeam).text();
+                               }, defaultContent: "", render: $.fn.dataTable.render.ellipsis, className: 'content-middle'
+                       },
               /*  9 */ { data: "checkedBy", defaultContent: "", render: $.fn.dataTable.render.ellipsis, className: 'content-middle' },
               /* 10 */ { data: "checkedOn", defaultContent: "", className: 'content-middle' },
               /* 11 */ { data: "actions", orderable: false, render: $.fn.dataTable.render.actions( [{ key: 'attachmentContentId', 'class': 'delete-attachment', icon: 'trash', title: '<liferay-ui:message key="delete.attachment" />', approvalKey: 'checkStatus', usageCountsKey: 'usageCounts'}] ), className: "content-middle one action" }


### PR DESCRIPTION
> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*#913*)
> * Did you add or update any new dependencies that are required for your change? - No

### How To Test?
> Create a user with department containing `&` like `AAA BBB&CC DD`
> - Add attachment or approve attachment in Project, Component, Release.
> - The Attachment Table in Detail or Edit view should show correct Department.

> Have you implemented any additional tests? - No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>
