### PR TITLE
feat(ComponentUI): Added new filters in Advance search

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentSearchHandler.java
@@ -74,6 +74,12 @@ public class ComponentSearchHandler {
                     "    if(doc.name !== undefined && doc.name != null && doc.name.length >0) {  "+
                     "      ret.add(doc.name, {\"field\": \"name\"} );" +
                     "    }" +
+                    "    if(doc.createdBy && doc.createdBy.length) {  "+
+                    "      ret.add(doc.createdBy, {\"field\": \"createdBy\"} );" +
+                    "    }" +
+                    "    if(doc.createdOn && doc.createdOn.length) {  "+
+                    "      ret.add(doc.createdOn, {\"field\": \"createdOn\", \"type\": \"date\"} );" +
+                    "    }" +
                     "    return ret;" +
                     "}");
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -82,6 +82,10 @@ public class PortalConstants {
     public static final String VIEW_SIZE = "viewSize";
     public static final String TOTAL_ROWS = "totalRows";
     public static final String RESULT = "result";
+    public static final String DATE_RANGE = "dateRange";
+    public static final String END_DATE = "endDate";
+    public static final String EPOCH_DATE = "1970-01-01";
+    public static final String TO = "TO";
 
     public static final String IS_USER_AT_LEAST_CLEARING_ADMIN = "isUserAtLeastClearingAdmin";
     public static final String IS_USER_AT_LEAST_ECC_ADMIN = "isUserAtLeastECCAdmin";

--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -258,6 +258,7 @@ create.account=Create Account
 create.clearing.request=Create Clearing Request
 create.component=Create Component
 created.by=Created by
+created.by.email=Created by (Email)
 created.on=Created on
 created.successfully=created successfully
 create.license=Create License
@@ -1124,6 +1125,7 @@ this.project.x.contains=This project <b data-name="name"></b> contains:
 this.release.x.contains=This release <b data-name="name"></b> contains:
 this.release.x.contains.1=This release <span data-name="name"></span> contains
 title=Title
+to=To
 to.be.fulfilled.by.parent.project=To be fulfilled by parent project
 to.be.replaced=To be replaced
 todo=Todo

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -258,6 +258,7 @@ create.account=Tạo tài khoản
 create.clearing.request=Create Clearing Request
 create.component=Tạo thành phần
 created.by=Được tạo bởi
+created.by.email=Created by (Email)
 created.on=Được tạo ra trên
 created.successfully=created successfully
 create.license=Tạo giấy phép
@@ -1122,6 +1123,7 @@ this.project.x.contains=Dự án này <b data-name="name"></b> chứa:
 this.release.x.contains=Bản phát hành <b data-name="name"></b> này chứa:
 this.release.x.contains.1=Bản phát hành <span data-name="name"></span> chứa
 title=Tiêu đề
+to=To
 to.be.fulfilled.by.parent.project=To be fulfilled by parent project
 to.be.replaced=Sẽ được thay thế
 todo=Việc cần làm

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/ThriftEnumUtils.java
@@ -58,6 +58,12 @@ public class ThriftEnumUtils {
             Ternary.NO, "no",
             Ternary.YES, "yes");
 
+    private static final ImmutableMap<DateRange, String> MAP_DATE_RANGE_STRING = ImmutableMap.of(
+            DateRange.EQUAL, "=",
+            DateRange.LESS_THAN_OR_EQUAL_TO, "<=",
+            DateRange.GREATER_THAN_OR_EQUAL_TO, ">=",
+            DateRange.BETWEEN, "Between");
+
     private static final ImmutableMap<ProjectType, String> MAP_PROJECT_TYPE_STRING = ImmutableMap.of(
             ProjectType.CUSTOMER, "Customer Project" ,
             ProjectType.INTERNAL, "Internal Project" ,
@@ -271,6 +277,7 @@ public class ThriftEnumUtils {
             MAP_ENUMTYPE_MAP = ImmutableMap.<Class<? extends TEnum>, Map<? extends TEnum, String>>builder()
             .put(ComponentType.class, MAP_COMPONENT_TYPE_STRING)
             .put(Ternary.class, MAP_TERNARY_STRING)
+            .put(DateRange.class, MAP_DATE_RANGE_STRING)
             .put(ProjectType.class, MAP_PROJECT_TYPE_STRING)
             .put(AttachmentType.class, MAP_ATTACHMENT_TYPE_STRING)
             .put(ClearingState.class, MAP_CLEARING_STATUS_STRING)

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/LuceneAwareDatabaseConnector.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/LuceneAwareDatabaseConnector.java
@@ -186,8 +186,10 @@ public class LuceneAwareDatabaseConnector extends LuceneAwareCouchDbConnector {
 
     private static String formatSubquery(Set<String> filterSet, final String fieldName) {
         final Function<String, String> addType = input -> {
-            if (fieldName.equals("businessUnit") || fieldName.equals("tag") || fieldName.equals("projectResponsible")) {
+            if (fieldName.equals("businessUnit") || fieldName.equals("tag") || fieldName.equals("projectResponsible") || fieldName.equals("createdBy")) {
                 return fieldName + ":\"" + input + "\"";
+            } if (fieldName.equals("createdOn")) {
+                return fieldName + "<date>:" + input;
             } else {
                 return fieldName + ":" + input;
             }

--- a/libraries/lib-datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/sw360.thrift
@@ -122,6 +122,13 @@ enum ClearingRequestEmailTemplate {
     NEW_COMMENT = 3
 }
 
+enum DateRange {
+    EQUAL = 0,
+    LESS_THAN_OR_EQUAL_TO = 1,
+    GREATER_THAN_OR_EQUAL_TO = 2,
+    BETWEEN = 3
+}
+
 struct ConfigContainer {
     1: optional string id,
     2: optional string revision,


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
* Added two new filters in Advanced Search for Components.
* Filter by `Created By (Email)` and `Creation Date` of `Component`.

Issue: #902 

### Suggest Reviewer


### How To Test?
* User should be able to search the components based on two new filters `Created By (Email)` and `Creation Date` in Component list page.
* `Created On` filter should have 4 options 
    1. _=_   --> where component creation date is equal to user search date.
    1. _<=_   --> where component creation date is less than or equal to user search date.
    1. _>=_   --> where component creation date is greater than or equal to user search date.
    1. _between_   --> where component creation date is within the search date range.

![image](https://user-images.githubusercontent.com/50870174/86886758-1b04e100-c115-11ea-8373-9f61f6e7f09e.png)


### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: Abdul Kapti <abdul.mannankapti@siemens.com>
