### PR TITLE
feat(REST): Whitelisting field in REST API response

### DIFF
--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ClearingRequestRepository.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ClearingRequestRepository.java
@@ -10,7 +10,6 @@
 
 package org.eclipse.sw360.moderation.db;
 
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -18,7 +17,6 @@ import java.util.Set;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseRepository;
-import org.eclipse.sw360.datahandler.thrift.ClearingRequestState;
 import org.eclipse.sw360.datahandler.thrift.projects.ClearingRequest;
 import org.ektorp.support.View;
 

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -163,7 +163,6 @@ class JacksonCustomizations {
                 "setAdditionalData",
                 "setLinkedObligationId",
                 "linkedObligationId",
-                "clearingRequestId",
                 "setClearingRequestId",
                 "todosIterator"
         })
@@ -202,6 +201,10 @@ class JacksonCustomizations {
             @Override
             @JsonProperty(access = Access.WRITE_ONLY)
             abstract public String getLeadArchitect();
+
+            @Override
+            @JsonProperty(access = Access.READ_ONLY)
+            abstract public String getClearingRequestId();
         }
 
 	static abstract class EmbeddedProjectMixin extends ProjectMixin {

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -167,6 +167,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         project.setExternalIds(externalIds);
         project.setAdditionalData(additionalData);
         project.setPhaseOutSince("2020-06-24");
+        project.setClearingRequestId("CR-1");
 
         projectListByName.add(project);
         projectList.add(project);
@@ -216,6 +217,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         project2.setPhaseOutSince("2020-06-02");
         project2.setClearingTeam("Unknown");
         project2.setContributors(new HashSet<>(Arrays.asList("admin@sw360.org", "jane@sw360.org")));
+        project2.setClearingRequestId("CR-2");
 
         projectList.add(project2);
 
@@ -437,6 +439,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("_embedded.sw360:projects[]enableVulnerabilitiesDisplay").description("Displaying vulnerabilities flag."),
                                 fieldWithPath("_embedded.sw360:projects[]state").description("The project active status, possible values are: " + Arrays.asList(ProjectState.values())),
                                 fieldWithPath("_embedded.sw360:projects[]phaseOutSince").description("The project phase-out date"),
+                                fieldWithPath("_embedded.sw360:projects[]clearingRequestId").description("Clearing Request id associated with project."),
                                 fieldWithPath("_embedded.sw360:projects[]_links").description("Self <<resources-index-links,Links>> to Project resource"),
                                 fieldWithPath("_embedded.sw360:projects[]_embedded.createdBy").description("The user who created this project"),
                                 fieldWithPath("_embedded.sw360:projects[]_embedded.clearingTeam").description("The clearingTeam of the project"),
@@ -494,6 +497,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("enableVulnerabilitiesDisplay").description("Displaying vulnerabilities flag."),
                                 fieldWithPath("state").description("The project active status, possible values are: " + Arrays.asList(ProjectState.values())),
                                 fieldWithPath("phaseOutSince").description("The project phase-out date"),
+                                fieldWithPath("clearingRequestId").description("Clearing Request id associated with project."),
                                 fieldWithPath("_links").description("<<resources-index-links,Links>> to other resources"),
                                 fieldWithPath("_embedded.createdBy").description("The user who created this project"),
                                 fieldWithPath("_embedded.sw360:projects").description("An array of <<resources-projects, Projects resources>>"),
@@ -830,7 +834,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                         fieldWithPath("securityResponsibles")
                                 .description("An array of users responsible for security of the project."),
                         fieldWithPath("state").description("The project active status, possible values are: " + Arrays.asList(ProjectState.values())),
-                        fieldWithPath("phaseOutSince").description("The project phase-out date"),
+                        fieldWithPath("clearingRequestId").description("Clearing Request id associated with project."),
                         fieldWithPath("projectResponsible")
                                 .description("A user who is responsible for the project."),
                                   fieldWithPath("_links")


### PR DESCRIPTION
Signed-off-by: Abdul Kapti <abdul.mannankapti@siemens.com>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
 * Whitelisted `clearingRequestId` field in REST API response for project.
 * Added check for `CR Id` while updating/adding a project.
 * Did you add or update any new dependencies that are required for your change? **No**

Issue: #918 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
* Getting project details via REST endpoint (`GET` request `api/projects/<projectId>` and `api/projects/?allDetails=true`) should have `ClearingRequestId` field in response.
* Creating a new project via REST endpoint (`POST` request at `/api/projects/`) should fail if `ClearingRequestId` field is passed while creating the project.
* Updating of project via REST endpoint should fail if `ClearingRequestId` field value is changed in update request, The same should work while creating `CR` via web application UI.



### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
