### PR TITLE
fix(spdx license import): Change quotes marks in jsp for "Release overview from component details license import" 

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/licenseAdmin/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/licenseAdmin/view.jsp
@@ -115,9 +115,9 @@ require(['jquery', 'modules/dialog', 'modules/validation'], function($, dialog, 
                 callback();
             }).done(function (data) {
                 if (data.result == 'SUCCESS') {
-                    $dialog.success(<liferay-ui:message key="i.imported.x.out.of.y.spdx.licenses.z" />, true);
+                    $dialog.success('<liferay-ui:message key="i.imported.x.out.of.y.spdx.licenses.z" />', true);
                 }else {
-                    $dialog.alert("<liferay-ui:message key="i.could.not.import.all.spdx.license.information" />");
+                    $dialog.alert('<liferay-ui:message key="i.could.not.import.all.spdx.license.information" />');
                 }
             }).fail(function(){
                 $dialog.alert('<liferay-ui:message key="something.went.wrong" />');
@@ -150,9 +150,9 @@ require(['jquery', 'modules/dialog', 'modules/validation'], function($, dialog, 
                callback();
             }).done(function (data) {
                 if (data.result == 'SUCCESS') {
-                    $dialog.success("<liferay-ui:message key="i.deleted.x.out.of.y.documents.in.the.database" />", true);
+                    $dialog.success('<liferay-ui:message key="i.deleted.x.out.of.y.documents.in.the.database" />', true);
                 }else {
-                    $dialog.alert("<liferay-ui:message key="i.could.not.delete.the.license.information" />");
+                    $dialog.alert('<liferay-ui:message key="i.could.not.delete.the.license.information" />');
                 }
             }).fail(function(){
                 $dialog.alert('<liferay-ui:message key="something.went.wrong" />');


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue:  #915 


### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

Popup message and get SPDX info from external server. 

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

