### PR TITLE
feat(ProjectUI):Added Expand/Collapse All and Search in AttachmentUsageTable

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentUsages.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentUsages.jspf
@@ -34,7 +34,13 @@
         >
         <thead>
         <tr>
-            <th colspan="7" class="headlabel"><liferay-ui:message key="linked.releases.and.projects" /></th>
+            <th colspan="7" class="headlabel"><liferay-ui:message key="linked.releases.and.projects" />
+            <core_rt:if test="${projectList.size() > 1 or (projectList.size() == 1 and not empty projectList.get(0).linkedReleases)}">
+                (<a href="#" id="expandAll" class="text-primary"><liferay-ui:message key="expand.all" /> </a>|
+                <a href="#" id="collapseAll" class="text-primary"> <liferay-ui:message key="collapse.all" /></a>)
+                <input id="nameSearch" type="input" placeholder="<liferay-ui:message key="search" />" class="float-right">
+            </core_rt:if>
+            </th>
         </tr>
         <tr>
             <th rowspan="2"><liferay-ui:message key="name" /></th>
@@ -55,14 +61,6 @@
                 <tr>
                     <td colspan="7"><liferay-ui:message key="no.linked.releases.or.projects" /></td>
                 </tr>
-                </thead>
-                <tbody>
-                    <%@include file="/html/projects/includes/attachmentUsagesRows.jspf"%>
-                    <core_rt:if test="${projectList.size() == 1 and empty projectList.get(0).linkedReleases}">
-                        <tr>
-                            <td colspan="7"><liferay-ui:message key="no.linked.releases.or.projects" /></td>
-                        </tr>
-                    </core_rt:if>
             </core_rt:if>
         </tbody>
     </table>
@@ -92,6 +90,41 @@
             attachCheckboxEventHandlers();
 
             $('#saveAttachmentUsagesButton').click(saveAttachmentUsages);
+        });
+
+        $("#nameSearch").on("keyup", function(event) {
+            let value = this.value.toLowerCase().trim(),
+                table = $("#AttachmentUsagesInfo");
+            if (!value) {
+                $("#AttachmentUsagesInfo tbody").find('tr').each(function(index) {
+                    let data = $(this).data();
+                    if (!data.ttParentId) {
+                        $(this).show();
+                        table.treetable("collapseNode", data.ttId);
+                    }
+                });
+                return;
+            }
+            $("#AttachmentUsagesInfo tbody tr").each(function(index) {
+                let data = $(this).data();
+                if (!data.ttParentId) {
+                    let text = $(this).find("td").first().text().trim().toLowerCase();
+                        isMatch = text.indexOf(value) !== -1;
+                    if (isMatch) {
+                        $(this).show();
+                        table.treetable("expandNode", data.ttId);
+                    } else {
+                        table.treetable("collapseNode", data.ttId);
+                        $(this).hide();
+                    }
+                }
+            });
+        });
+
+        $('a[href="#"]').click(function(e) {
+            e.preventDefault();
+            $('#AttachmentUsagesInfo').treetable(e.target.id);
+            return false;
         });
 
         function attachCheckboxEventHandlers(){

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentUsagesRows.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentUsagesRows.jspf
@@ -77,10 +77,7 @@
         <core_rt:forEach items="${releaseLink.attachments}" var="attachment" varStatus="attachmentloop">
             <tr data-tt-id="${releaseLink.nodeId}_${attachment.attachmentContentId}" data-tt-branch="false"
                 data-tt-parent-id="${releaseLink.nodeId}"
-                title="<liferay-ui:message key="created.on" />: ${attachment.createdOn} &#10; Status: ${attachment.checkStatus}
-                <core_rt:if test="${attachment.checkStatus != 'NOTCHECKED'}">
-			&#10; Checked By: ${attachment.checkedBy} &#10; Checked On: ${attachment.checkedOn}
-                </core_rt:if>"
+                title="<liferay-ui:message key="created.on" />: ${attachment.createdOn}&#10;Status: ${attachment.checkStatus} <core_rt:if test="${attachment.checkStatus != 'NOTCHECKED'}">&#10;Checked By: ${attachment.checkedBy}&#10;Checked On: ${attachment.checkedOn}</core_rt:if>"
             >
                 <td>
                     <sw360:out value="${attachment.filename}" maxChar="60"/>

--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -195,6 +195,7 @@ closed=Closed
 closed.clearing.requests=Closed Clearing Requests
 closed.moderation.requests=Closed Moderation Requests
 code.snippet=Code Snippet
+collapse.all=Collapse all
 comment=Comment
 comment.on.clearing.decision=Comment on clearing decision
 comment.on.moderation.decision=Comment on Moderation Decision

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -196,6 +196,7 @@ closed=Đã đóng
 closed.clearing.requests=Yêu cầu thanh toán bù trừ
 closed.moderation.requests=Yêu cầu kiểm duyệt đã đóng
 code.snippet=Code Snippet
+collapse.all=Collapse all
 comment=Giải thích
 comment.on.clearing.decision=Comment on clearing decision
 comment.on.moderation.decision=Giải thích về Quyết định kiểm duyệt


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
* Added `Expand All` and `Collapse All` button in `AttachmentUsageTable`. 
* `Expand All` and `Collapse All` button will expand `Directly Linked Releases and Projects` only. (and `sub-projects` if it is previously loaded).
* Added `Search` box in `AttachmentUsageTable` top right corner.
* `Search` will work only for `Directly Linked Releases and Projects` based on `Name` column.
* Fixed empty lines between `Status` and `CheckedBy` in `attachmanetUsage` tool-tip.
* Sample Screenshot.
![895](https://user-images.githubusercontent.com/50870174/87753267-dfa69880-c81f-11ea-8dee-8802c3d23c3b.jpg)


> * Did you add or update any new dependencies that are required for your change? `->` **NO**

Issue: #895 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
* Goto `AttachmentUsage` tab in `ProjectDetailsPage`.
* `Expand All` and `Collapse All` button and `Search` box should not be displayed if there are NO `Directly Linked Releases and Projects`.
* Test whether `Expand All`, `Collapse All` button and `Search` box is working as mentioned above summary.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: Abdul Kapti <abdul.mannankapti@siemens.com>
