### PR TITLE
feat(ProjectReleaseRelation): Added new Field comment, createdOn, createdBy in ProjectReleaseRelation

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -1596,6 +1596,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
             ProjectReleaseRelationship rel = (ProjectReleaseRelationship) relation;
             releaseLink.setReleaseRelationship(rel.getReleaseRelation());
             releaseLink.setMainlineState(rel.getMainlineState());
+            releaseLink.setComment(rel.getComment());
         } else if (relation instanceof ReleaseRelationship) {
             releaseLink.setReleaseRelationship((ReleaseRelationship) relation);
         } else {

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtil.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtil.java
@@ -39,9 +39,12 @@ import org.eclipse.sw360.datahandler.couchdb.DatabaseMixInForChangeLog.COTSDetai
 import org.eclipse.sw360.datahandler.couchdb.DatabaseMixInForChangeLog.ClearingInformationMixin;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseMixInForChangeLog.EccInformationMixin;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseMixInForChangeLog.ObligationStatusInfoMixin;
+import org.eclipse.sw360.datahandler.couchdb.DatabaseMixInForChangeLog.ProjectReleaseRelationshipMixin;
+import org.eclipse.sw360.datahandler.couchdb.DatabaseMixInForChangeLog.ProjectTodoMixin;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseMixInForChangeLog.RepositoryMixin;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseMixInForChangeLog.VendorMixin;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseRepository;
+import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage;
@@ -59,6 +62,7 @@ import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
 import org.eclipse.sw360.datahandler.thrift.projects.ObligationStatusInfo;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectObligation;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectTodo;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 
@@ -683,6 +687,8 @@ public class DatabaseHandlerUtil {
             mapper.addMixInAnnotations(EccInformation.class, EccInformationMixin.class);
             mapper.addMixInAnnotations(Vendor.class, VendorMixin.class);
             mapper.addMixInAnnotations(Repository.class, RepositoryMixin.class);
+            mapper.addMixInAnnotations(ProjectReleaseRelationship.class, ProjectReleaseRelationshipMixin.class);
+            mapper.addMixInAnnotations(ProjectTodo.class, ProjectTodoMixin.class);
         }
         return mapper;
     }

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -333,6 +333,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         project.createdBy = user.getEmail();
         project.createdOn = getCreatedOn();
         project.businessUnit = getBUFromOrganisation(user.getDepartment());
+        setRequestedDateAndTrimComment(project, null, user);
 
         // Add project to database and return ID
         repository.add(project);
@@ -377,6 +378,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             return RequestStatus.INVALID_INPUT;
         } else if (isWriteActionAllowedOnProject(actual, user)) {
             copyImmutableFields(project,actual);
+            setRequestedDateAndTrimComment(project, actual, user);
             project.setAttachments( getAllAttachmentsToKeep(toSource(actual), actual.getAttachments(), project.getAttachments()) );
             setReleaseRelations(project, user, actual);
             updateProjectDependentLinkedFields(project, actual);
@@ -401,6 +403,52 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             return RequestStatus.SUCCESS;
         } else {
             return moderator.updateProject(project, user);
+        }
+    }
+
+    private void setRequestedDateAndTrimComment(Project project, Project actual, User user) {
+        Set<String> actualReleaseIds = null;
+        if (Objects.nonNull(actual) && Objects.nonNull(actual.getReleaseIdToUsage())) {
+            actualReleaseIds = CommonUtils.nullToEmptySet(actual.getReleaseIdToUsage().keySet());
+        }
+        final Set<String> actualReleaseIdsFinal = CommonUtils.nullToEmptySet(actualReleaseIds);
+        Set<String> updatedReleaseIds = null;
+        Map<String, ProjectReleaseRelationship> updatedProjectReleaseIdToUsage = project.getReleaseIdToUsage();
+        if (Objects.nonNull(updatedProjectReleaseIdToUsage)) {
+            updatedReleaseIds = CommonUtils.nullToEmptySet(updatedProjectReleaseIdToUsage.keySet());
+        } else {
+            updatedReleaseIds = new HashSet<>();
+        }
+
+        updatedReleaseIds.stream().filter(updatedReleaseId -> !actualReleaseIdsFinal.contains(updatedReleaseId))
+                .forEach(updatedReleaseId -> {
+                    ProjectReleaseRelationship projectReleaseRelationship = updatedProjectReleaseIdToUsage
+                            .get(updatedReleaseId);
+                    if (Objects.nonNull(projectReleaseRelationship)) {
+                        projectReleaseRelationship.setCreatedOn(SW360Utils.getCreatedOn());
+                        projectReleaseRelationship.setCreatedBy(user.getEmail());
+                    }
+                });
+
+        updatedReleaseIds.stream().filter(commonReleaseId -> actualReleaseIdsFinal.contains(commonReleaseId))
+                .forEach(commonReleaseId -> {
+                    ProjectReleaseRelationship projectReleaseRelationship = updatedProjectReleaseIdToUsage
+                            .get(commonReleaseId);
+                    ProjectReleaseRelationship actualProjectReleaseRelationship = actual.getReleaseIdToUsage()
+                            .get(commonReleaseId);
+                    if (Objects.nonNull(projectReleaseRelationship)
+                            && Objects.nonNull(actualProjectReleaseRelationship)) {
+                        projectReleaseRelationship.setCreatedOn(actualProjectReleaseRelationship.getCreatedOn());
+                        projectReleaseRelationship.setCreatedBy(actualProjectReleaseRelationship.getCreatedBy());
+                    }
+                });
+
+        if (Objects.nonNull(updatedProjectReleaseIdToUsage)) {
+            project.getReleaseIdToUsage().entrySet().stream().forEach(entry -> {
+                if (Objects.nonNull(entry.getValue()) && Objects.nonNull(entry.getValue().getComment())) {
+                    entry.getValue().setComment(entry.getValue().getComment().trim());
+                }
+            });
         }
     }
 
@@ -1347,13 +1395,14 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         linkedReleases.entrySet().stream().forEach(rl -> wrapTException(() -> {
             String relation = ThriftEnumUtils.enumToString(rl.getValue().getReleaseRelation());
             String projectMailLineState = ThriftEnumUtils.enumToString(rl.getValue().getMainlineState());
+            String comment = rl.getValue().getComment();
             String releaseId = rl.getKey();
             if (releaseOrigin.containsKey(releaseId))
                 return;
             Release rel = componentDatabaseHandler.getRelease(releaseId, user);
             Map<String, ReleaseRelationship> releaseIdToRelationship = rel.getReleaseIdToRelationship();
             releaseOrigin.put(releaseId, SW360Utils.printName(rel));
-            Map<String, String> row = createReleaseCSRow(relation, projectMailLineState, rel, clearingStatusList, user);
+            Map<String, String> row = createReleaseCSRow(relation, projectMailLineState, rel, clearingStatusList, user, comment);
             if (releaseIdToRelationship != null && !releaseIdToRelationship.isEmpty()) {
                 flattenlinkedReleaseOfRelease(releaseIdToRelationship, projectOrigin, releaseOrigin, clearingStatusList,
                         user);
@@ -1376,7 +1425,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             Release rel = componentDatabaseHandler.getRelease(releaseId, user);
             Map<String, ReleaseRelationship> subReleaseIdToRelationship = rel.getReleaseIdToRelationship();
             releaseOrigin.put(releaseId, SW360Utils.printName(rel));
-            Map<String, String> row = createReleaseCSRow(relation, projectMailLineState, rel, clearingStatusList, user);
+            Map<String, String> row = createReleaseCSRow(relation, projectMailLineState, rel, clearingStatusList, user, "");
             if (subReleaseIdToRelationship != null && !subReleaseIdToRelationship.isEmpty()) {
                 flattenlinkedReleaseOfRelease(subReleaseIdToRelationship, projectOrigin, releaseOrigin,
                         clearingStatusList, user);
@@ -1403,7 +1452,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
     }
 
     private Map<String, String> createReleaseCSRow(String relation, String projectMailLineState, Release rl,
-            List<Map<String, String>> clearingStatusList, User user) throws SW360Exception {
+            List<Map<String, String>> clearingStatusList, User user, String comment) throws SW360Exception {
         Map<String, String> row = new HashMap<>();
         Component component = componentDatabaseHandler.getComponent(rl.getComponentId(), user);
         String releaseId = rl.getId();
@@ -1417,6 +1466,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         row.put("releaseMainlineState", ThriftEnumUtils.enumToString(rl.getMainlineState()));
         row.put("clearingState", ThriftEnumUtils.enumToString(rl.getClearingState()));
         row.put("projectMainlineState", projectMailLineState);
+        row.put("comment", CommonUtils.nullToEmptyString(comment));
         clearingStatusList.add(row);
         return row;
     }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtils.java
@@ -190,11 +190,12 @@ public class ProjectPortletUtils {
         String[] ids = request.getParameterValues(Project._Fields.RELEASE_ID_TO_USAGE.toString() + ReleaseLink._Fields.ID.toString());
         String[] relations = request.getParameterValues(Project._Fields.RELEASE_ID_TO_USAGE.toString() + ProjectReleaseRelationship._Fields.RELEASE_RELATION.toString());
         String[] mainlStates = request.getParameterValues(Project._Fields.RELEASE_ID_TO_USAGE.toString() + ProjectReleaseRelationship._Fields.MAINLINE_STATE.toString());
+        String[] comments = request.getParameterValues(Project._Fields.RELEASE_ID_TO_USAGE.toString() + ProjectReleaseRelationship._Fields.COMMENT.toString());
         if (ids != null && relations != null && mainlStates != null && ids.length == relations.length && ids.length == mainlStates.length) {
             for (int k = 0; k < ids.length; ++k) {
                 ReleaseRelationship relation = ReleaseRelationship.findByValue(Integer.parseInt(relations[k]));
                 MainlineState mainlState = MainlineState.findByValue(Integer.parseInt(mainlStates[k]));
-                releaseUsage.put(ids[k], new ProjectReleaseRelationship(relation, mainlState));
+                releaseUsage.put(ids[k], new ProjectReleaseRelationship(relation, mainlState).setComment(comments[k]));
             }
         }
     }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/administrationEdit.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/administrationEdit.jspf
@@ -289,7 +289,9 @@
         $('.datepicker').datepicker({changeMonth:true,changeYear:true,dateFormat: "yy-mm-dd"});
 
         function setDefaultTextAndResize(textarea) {
+            if(!textarea) return;
             $(textarea).val($(textarea).data("defaulttext"));
+            if(!$(textarea)[0]) return;
             $(textarea).height($(textarea)[0].scrollHeight);
         }
     });

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/clearingStatus.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/clearingStatus.jsp
@@ -54,13 +54,14 @@
         >
             <thead>
                 <tr>
-                    <th style="width:46%"><liferay-ui:message key="name" /></th>
+                    <th style="width:40%"><liferay-ui:message key="name" /></th>
                     <th style="width:7%"><liferay-ui:message key="type" /></th>
                     <th style="width:7%"><liferay-ui:message key="relation" /></th>
-                    <th style="width:15%"><liferay-ui:message key="main.licenses" /></th>
+                    <th style="width:12%"><liferay-ui:message key="main.licenses" /></th>
                     <th style="width:7%"><liferay-ui:message key="state" /></th>
                     <th style="width:7%"><liferay-ui:message key="release.mainline.state" /></th>
                     <th style="width:7%"><liferay-ui:message key="project.mainline.state" /></th>
+                    <th style="width:9%"><liferay-ui:message key="comment" /></th>
                     <th style="width:4%"><liferay-ui:message key="actions" /></th>
                </tr>
            </thead>
@@ -114,8 +115,17 @@ AUI().use('liferay-portlet-url', function () {
                     }, render: {display: renderState}, "defaultContent": ""},
                     {title: "<liferay-ui:message key="release.mainline.state" />", data : "releaseMainlineState", "defaultContent": ""},
                     {title: "<liferay-ui:message key="project.mainline.state" />", data : "projectMainlineState", "defaultContent": ""},
+                    {title: "<liferay-ui:message key="comment" />",  data: "comment", "defaultContent": "", render: $.fn.dataTable.render.ellipsis},
                     {title: "<liferay-ui:message key="actions" />",  data: "id", "orderable": false, "defaultContent": "", render: {display: renderActions}, className: "two actions" }
                 ],
+                "columnDefs": [
+                    {
+                        "targets": 9,
+                        "createdCell": function (td) {
+                            $(td).css('max-width', '10rem');
+                        }
+                    }
+                    ],
                 "order": [[ 0, "asc" ]],
                 fnDrawCallback: datatables.showPageContainer,
             language: {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/ajax/linkedProjectsRows.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/ajax/linkedProjectsRows.jspf
@@ -52,6 +52,8 @@
             </td>
             <td>
             </td>
+            <td>
+            </td>
             <td class="editProjectAction" data-projectid="${projectLink.id}">
             </td>
         </tr>
@@ -88,6 +90,11 @@
             <td>
                 <core_rt:if test='${not empty requestScope["projectReleaseRelation"][releaseLink.id]}'>
                     <sw360:DisplayEnum value='${requestScope["projectReleaseRelation"][releaseLink.id]["mainlineState"]}'/>
+                </core_rt:if>
+            </td>
+            <td>
+                <core_rt:if test='${not empty requestScope["projectReleaseRelation"][releaseLink.id]}'>
+                     <sw360:out value='${requestScope["projectReleaseRelation"][releaseLink.id]["comment"]}' maxChar="20" />
                 </core_rt:if>
             </td>
             <td class="editAction" data-releaseid="${releaseLink.id}">

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/ajax/linkedReleasesAjax.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/ajax/linkedReleasesAjax.jsp
@@ -60,6 +60,13 @@
                 </select>
             </div>
         </td>
+        <td>
+            <div class="form-group">
+                <input id="releaseComment" name="<portlet:namespace/><%=Project._Fields.RELEASE_ID_TO_USAGE%><%=ProjectReleaseRelationship._Fields.COMMENT%>"
+                type="text" placeholder="<liferay-ui:message key="enter.comment" />" class="form-control"
+                    value="<sw360:out value="${releaseLink.comment}"/>"/>
+            </div>
+        </td>
         <td class="content-middle">
             <svg class="action lexicon-icon" data-row-id="releaseLinkRow${uuid}" data-release-name="<sw360:out value='${releaseLink.longName}' jsQuoting="true"/>">
                 <title><liferay-ui:message key="delete" /></title>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/ajax/linkedReleasesClearingStatusRows.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/ajax/linkedReleasesClearingStatusRows.jsp
@@ -51,6 +51,8 @@
                 <sw360:DisplayEnum value='${requestScope["projectReleaseRelation"][releaseLink.id]["mainlineState"]}' />
             </core_rt:if>
         </td>
+        <td>
+        </td>
         <td class="editAction" data-releaseid="${releaseLink.id}"></td>
     </tr>
 </core_rt:forEach>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/linkedReleasesEdit.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/linkedReleasesEdit.jspf
@@ -12,13 +12,14 @@
 <%@ page import="org.eclipse.sw360.datahandler.thrift.ReleaseRelationship" %>
 
 <h4 class="mt-4"><liferay-ui:message key="linked.releases" /></h4>
-<table class="table edit-table four-columns-with-actions" id="LinkedReleasesInfo">
+<table class="table edit-table five-columns-with-actions" id="LinkedReleasesInfo">
     <thead>
         <tr>
             <th><liferay-ui:message key="release.name" /></th>
             <th><liferay-ui:message key="release.version" /></th>
             <th><liferay-ui:message key="release.relation" /> <sw360:DisplayEnumInfo type="<%=ReleaseRelationship.class%>"/></th>
             <th><liferay-ui:message key="project.mainline.state" /> <sw360:DisplayEnumInfo type="<%=MainlineState.class%>"/></th>
+            <th><liferay-ui:message key="comments" /></th>
             <th></th>
         </tr>
     </thead>

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -597,6 +597,9 @@ public class SW360Utils {
             jgen.writeStartObject();
             jgen.writeObjectField("releaseRelation", value.getReleaseRelation());
             jgen.writeObjectField("mainlineState", value.getMainlineState());
+            jgen.writeObjectField("comment", nullToEmpty(value.getComment()));
+            jgen.writeObjectField("createdBy", nullToEmpty(value.getCreatedBy()));
+            jgen.writeObjectField("createdOn", nullToEmpty(value.getCreatedOn()));
             jgen.writeEndObject();
         }
     }

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseMixInForChangeLog.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseMixInForChangeLog.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.sw360.datahandler.couchdb;
 
+import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogs;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangedFields;
@@ -18,6 +19,7 @@ import org.eclipse.sw360.datahandler.thrift.components.ClearingInformation;
 import org.eclipse.sw360.datahandler.thrift.components.EccInformation;
 import org.eclipse.sw360.datahandler.thrift.components.Repository;
 import org.eclipse.sw360.datahandler.thrift.projects.ObligationStatusInfo;
+import org.eclipse.sw360.datahandler.thrift.projects.ProjectTodo;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -210,5 +212,27 @@ public class DatabaseMixInForChangeLog {
         "setRepositorytype"
     })
     public static abstract class RepositoryMixin extends Repository {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties({
+        "setComment",
+        "setMainlineState",
+        "setReleaseRelation",
+        "setCreatedOn",
+        "setCreatedBy"
+    })
+    public static abstract class ProjectReleaseRelationshipMixin extends ProjectReleaseRelationship {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties({
+        "setComments",
+        "setTodoId",
+        "setUserId",
+        "setUpdated",
+        "setFulfilled"
+    })
+    public static abstract class ProjectTodoMixin extends ProjectTodo {
     }
 }

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -357,7 +357,8 @@ struct ReleaseLink{
     32: optional list<Attachment> attachments,
     33: optional ComponentType componentType,
     100: optional set<string> licenseIds,
-    101: optional set<string> licenseNames
+    101: optional set<string> licenseNames,
+    102: optional string comment
 }
 
 struct ReleaseClearingStatusData {

--- a/libraries/lib-datahandler/src/main/thrift/sw360.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/sw360.thrift
@@ -139,6 +139,9 @@ struct ConfigContainer {
 struct ProjectReleaseRelationship {
     1: required ReleaseRelationship releaseRelation,
     2: required MainlineState mainlineState,
+    3: optional string comment,
+    4: optional string createdOn,
+    5: optional string createdBy,
 }
 
 struct VerificationStateInfo {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/serializer/JsonReleaseRelationSerializer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/serializer/JsonReleaseRelationSerializer.java
@@ -14,6 +14,8 @@ package org.eclipse.sw360.rest.resourceserver.core.serializer;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
 import org.eclipse.sw360.rest.resourceserver.project.ProjectController;
 import org.eclipse.sw360.rest.resourceserver.release.ReleaseController;
@@ -43,6 +45,9 @@ public class JsonReleaseRelationSerializer extends JsonSerializer<Map<String, Pr
             ProjectReleaseRelationship projectReleaseRelationship = releaseRelation.getValue();
             linkedRelease.put("relation", projectReleaseRelationship.getReleaseRelation().name());
             linkedRelease.put("mainlineState", projectReleaseRelationship.getMainlineState().name());
+            linkedRelease.put("comment", CommonUtils.nullToEmptyString(projectReleaseRelationship.getComment()));
+            linkedRelease.put("createdBy", CommonUtils.nullToEmptyString(projectReleaseRelationship.getCreatedBy()));
+            linkedRelease.put("createdOn", CommonUtils.nullToEmptyString(projectReleaseRelationship.getCreatedOn()));
             linkedRelease.put("release", releaseLink);
             linkedReleases.add(linkedRelease);
         }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -119,7 +119,8 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
 
         Map<String, ProjectReleaseRelationship> linkedReleases = new HashMap<>();
         Map<String, ProjectRelationship> linkedProjects = new HashMap<>();
-        ProjectReleaseRelationship projectReleaseRelationship = new ProjectReleaseRelationship(CONTAINED, MAINLINE);
+        ProjectReleaseRelationship projectReleaseRelationship = new ProjectReleaseRelationship(CONTAINED, MAINLINE)
+                .setComment("Test Comment").setCreatedOn("2020-08-05").setCreatedBy("admin@sw360.org");
 
         Map<String, String> externalIds = new HashMap<>();
         externalIds.put("portal-id", "13319-XX3");


### PR DESCRIPTION
> Added new Field comment, createdOn, createdBy in ProjectReleaseRelation
>   - comment field is available in UI, REST and Excel
>   - createdOn , createdBy is not available in UI but available in REST and Excel.

> * Which issue is this pull request belonging to and how is it solving it? (*#946* , *#225*)
> * Did you add or update any new dependencies that are required for your change?

### How To Test?
> Create or Update Project with Linked Release, add some comment.
> - Excepted behaviour, comment , createdOn, createdBy fields should be reflected in Excel , REST, ChangeLogs.
> - Note 
>     - Comment is available in UI, Excel and REST. 
>        - In UI, it should be available in `Project Edit Page` and `Clearing Status tab - Tree and List View`.
>     - `createdOn` and `createdBy` is not available in UI . But available in Excel and REST. And the value of these field are only set if new ProjectReleaseRelation is added.

> Have you implemented any additional tests? - No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>