### PR TITLE
fix(Language_ja): change datatables.lang's URL

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
@@ -1280,4 +1280,4 @@ component.obligation=コンポーネントオブリゲーション
 
 ## Refer to http://cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/ and add your datatables language
 
-datatables.lang=https://cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/English.json
+datatables.lang=https://cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/Japanese.json


### PR DESCRIPTION
Signed-off-by: Kouki Hama <kouki1.hama@toshiba.co.jp>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

For adapting  to [Refer to http://cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/ and add your datatables language]

#948 

Change to Japanese
Datatable language:
https://cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/Japanese.json

### Suggest Reviewer
> You can suggest reviewers here with an @mention.
@mcjaeger 

He commented this point in slack chat.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
