### PR TITLE
feat(ui): Allow access to merge/split of component and release based on user role configured in properties

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -43,6 +43,7 @@ public class PortalConstants {
     public static final Set<String> PROJECT_OBLIGATIONS_ACTION_SET;
     public static final Boolean IS_PROJECT_OBLIGATIONS_ENABLED;
     public static final Boolean CUSTOM_WELCOME_PAGE_GUIDELINE;
+    public static final UserGroup USER_ROLE_ALLOWED_TO_MERGE_OR_SPLIT_COMPONENT;
 
     // DO NOT CHANGE THIS UNLESS YOU KNOW WHAT YOU ARE DOING !!!
     // - friendly url mapping files must be changed
@@ -594,6 +595,7 @@ public class PortalConstants {
         API_TOKEN_MAX_VALIDITY_WRITE_IN_DAYS = props.getProperty("rest.apitoken.write.validity.days", "30");
         API_TOKEN_HASH_SALT = props.getProperty("rest.apitoken.hash.salt", "$2a$04$Software360RestApiSalt");
         API_WRITE_ACCESS_USERGROUP = UserGroup.valueOf(props.getProperty("rest.write.access.usergroup", UserGroup.ADMIN.name()));
+        USER_ROLE_ALLOWED_TO_MERGE_OR_SPLIT_COMPONENT = UserGroup.valueOf(props.getProperty("user.role.allowed.to.merge.or.split.component", UserGroup.ADMIN.name()));
     }
 
     private PortalConstants() {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -1277,7 +1277,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
 
                 setUsingDocs(request, user, client, releaseIds);
 
-                request.setAttribute(IS_USER_ALLOWED_TO_MERGE, PermissionUtils.isUserAtLeast(UserGroup.ADMIN, user));
+                request.setAttribute(IS_USER_ALLOWED_TO_MERGE, PermissionUtils.isUserAtLeast(USER_ROLE_ALLOWED_TO_MERGE_OR_SPLIT_COMPONENT, user));
 
                 // get vulnerabilities
                 putVulnerabilitiesInRequestComponent(request, id, user);
@@ -1352,7 +1352,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
 
                 setUsingDocs(request, releaseId, user, client);
                 putDirectlyLinkedReleaseRelationsInRequest(request, release);
-                request.setAttribute(IS_USER_ALLOWED_TO_MERGE, PermissionUtils.isUserAtLeast(UserGroup.ADMIN, user));
+                request.setAttribute(IS_USER_ALLOWED_TO_MERGE, PermissionUtils.isUserAtLeast(USER_ROLE_ALLOWED_TO_MERGE_OR_SPLIT_COMPONENT, user));
 
                 if (isNullOrEmpty(id)) {
                     id = release.getComponentId();

--- a/frontend/sw360-portlet/src/main/resources/sw360.properties
+++ b/frontend/sw360-portlet/src/main/resources/sw360.properties
@@ -209,3 +209,8 @@ portlets.activate= \
 	org.eclipse.sw360.portal.portlets.projectimport.WsImportPortlet
 
 logout.redirect.url=
+
+# Possible values are "ADMIN", "SW360_ADMIN", "CLEARING_ADMIN", "CLEARING_EXPERT", "ECC_ADMIN", "SECURITY_ADMIN", "USER"
+# ADMIN by default has merge/split access
+# Access follows isUserAtLeast(ROLE)
+#user.role.allowed.to.merge.or.split.component=ADMIN


### PR DESCRIPTION
> Allow access to merge/split of component and release based on user role configured in properties
> * Which issue is this pull request belonging to and how is it solving it? (*#977*)
> * Did you add or update any new dependencies that are required for your change? - No

### How To Test?
> Set value for `user.role.allowed.to.merge.or.split.component` and validate user with those roles are able to merge or split component.
```
# Possible values are "ADMIN", "SW360_ADMIN", "CLEARING_ADMIN", "CLEARING_EXPERT", "ECC_ADMIN", "SECURITY_ADMIN", "USER"
# ADMIN by default has merge/split access
# Access follows isUserAtLeast(ROLE)
#user.role.allowed.to.merge.or.split.component=ADMIN 
```
> Have you implemented any additional tests? - No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>