### PR TITLE
fix(obligations):cover null pointer case if file with obligations is …

### DIFF
--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -249,7 +249,7 @@ public class SW360Utils {
     }
 
     public static Map<String, String> getReleaseIdtoAcceptedCLIMappings(Map<String, ObligationStatusInfo> obligationStatusMap) {
-        return obligationStatusMap.values().stream().flatMap(e -> e.getReleaseIdToAcceptedCLI().entrySet().stream())
+        return obligationStatusMap.values().stream().flatMap(e -> (e.getReleaseIdToAcceptedCLI() != null ? e.getReleaseIdToAcceptedCLI() : new HashMap<String,String>()).entrySet().stream())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (oldValue, newValue) -> oldValue));
     }
 


### PR DESCRIPTION
…missing

Signed-off-by: Michael C. Jaeger <michael.c.jaeger@siemens.com>

This small change covers a null pointer exception occuring if a license description file does not contain obligations while building the project view. otherwise a map built from a stream is not built up properly.

Issue: described here. 

### Suggest Reviewer

@JaideepPalit as the line was his proposal...

### How To Test?

tested on productive instance and this data set.
