### PR TITLE
fix(Obligation): Expand/Collapse all columns including comment using single leftmost toggle button for a row

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligations.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligations.jspf
@@ -89,7 +89,7 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
             "type": "<sw360:out value='${projectObligations.type}'/>",
             "id": "<sw360:out value='${projectObligations.id}'/>",
             "comment": "<sw360:out value='${projectObligations.comment}'/>",
-            "text": '<sw360:out value="${projectObligations.text}" maxChar="200" />',
+            "text": '<sw360:out value="${projectObligations.text}"/>',
             "modifiedBy": '${projectObligations.modifiedBy}',
             "modifiedOn": '${projectObligations.modifiedOn}'
         });
@@ -117,7 +117,7 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
             { "data": "id", className: 'text-center' },
             { "data": function(row) {
                             return $('<span></span>').html(row.comment).text();
-                      }, render: $.fn.dataTable.render.ellipsis
+                      }, className: 'obl-comment', render: $.fn.dataTable.render.ellipsis
             },
         ],
         "columnDefs": [
@@ -154,7 +154,9 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
         'createdRow': function (row, data, dataIndex, cell) {
             if (data.rIds < 1) {
                 $(row).addClass('orphan');
-                $(row).find(".details-control").removeClass('details-control').html('');
+                if(!data.text||data.text.length==0){
+                    data.text=data.obligation;
+                }
             }
             if (data.modifiedBy && data.modifiedOn) {
                 $(row).attr('title', 'Modified by: ' + data.modifiedBy + ' | Modified on: ' + data.modifiedOn);
@@ -193,16 +195,6 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
             .replace('<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_PAGENAME%>', page)
             .replace('<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_ID%>', id);
     }
-
-    /* Add event listener for opening and closing list of licenses */
-    $('#obligationsDetailTable tbody').on('click', 'td .TogglerLicenseList', function () {
-        render.toggleExpandableList($(this), 'License');
-    });
-
-    /* Add event listener for opening and closing list of releases */
-    $('#obligationsDetailTable tbody').on('click', 'td .TogglerReleaseList', function () {
-        render.toggleExpandableList($(this), 'Release');
-    });
 
     /* Add event listener for opening and closing individual child row */
     $('#obligationsDetailTable tbody').on('click', 'td.details-control', function () {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligationsEdit.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligationsEdit.jspf
@@ -100,7 +100,7 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
             "type": "<sw360:out value='${projectObligations.type}'/>",
             "id": "<sw360:out value='${projectObligations.id}'/>",
             "comment": "<sw360:out value='${projectObligations.comment}'/>",
-            "text": '<sw360:out value="${projectObligations.text}" maxChar="200" />',
+            "text": '<sw360:out value="${projectObligations.text}"/>',
             "modifiedBy": "${projectObligations.modifiedBy}",
             "modifiedOn": "${projectObligations.modifiedOn}"
         });
@@ -156,8 +156,10 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
         "createdRow": function (row, data, dataIndex, cell) {
             if (data.releaseLinks < 1) {
                 $(row).addClass('orphan');
-                $(row).find(".details-control").removeClass('details-control').html('');
                 $(row).find("input,select").attr('disabled', true);
+                if(!data.text||data.text.length==0){
+                    data.text=data.obligation;
+                }
             }
             if (data.modifiedBy && data.modifiedOn) {
                 $(row).attr('title', '<liferay-ui:message key="modified.by" />: ' + data.modifiedBy + ' | <liferay-ui:message key="modified.on" />: ' + data.modifiedOn);
@@ -250,7 +252,7 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
     // delete action
     function deleteObligation(tr) {
         var $dialog,
-            topic = $(tr).find('td:eq(1)').text()[0].nodeValue;
+            topic = $(tr).find('td:eq(1)').text();
 
         function deleteObligationInternal(callback) {
             jQuery.ajax({
@@ -263,7 +265,7 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
                 success: function (data) {
                     callback();
                     if (data.result == 'SUCCESS') {
-                        table.row('#' + topic).remove().draw(false);
+                        table.row(tr).remove().draw(false);
                         $dialog.close();
                         let count = $('#detailTab #obligtionsCount').text(),
                             fulfilled = count.split(' / ')[0],
@@ -291,16 +293,6 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
             deleteObligationInternal(callback);
         });
     }
-
-    /* Add event listener for opening and closing list of licenses */
-    $('#editObligationsTable tbody').on('click', 'td .TogglerLicenseList', function () {
-        render.toggleExpandableList($(this), '<liferay-ui:message key="license" />');
-    });
-
-    /* Add event listener for opening and closing list of releases */
-    $('#editObligationsTable tbody').on('click', 'td .TogglerReleaseList', function () {
-        render.toggleExpandableList($(this), '<liferay-ui:message key="license" />');
-    });
 
     /* Add event listener for opening and closing individual child row */
     $('#editObligationsTable').on('click', 'td.details-control', function () {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/utils/render.js
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/utils/render.js
@@ -60,16 +60,6 @@ define('utils/render', [
         var $container = $('<div/>', {
             style: 'display: flex;'
         }),
-            $toggler = $('<div/>', {
-                'class': 'Toggler' + urlType + 'List',
-                'style': 'margin-right: 0.25rem; cursor: pointer;'
-            }),
-            $togglerOn = $('<div/>', {
-                'class': 'Toggler_on'
-            }).html('&#x25BC'),
-            $togglerOff = $('<div/>', {
-                'class': 'Toggler_off'
-            }).html('&#x25BA'),
             $collapsed = $('<div/>', {
                 'class': urlType + 'ListHidden'
             }).text(cutUrlList(urls, truncate, delimiter)),
@@ -77,10 +67,8 @@ define('utils/render', [
                 'class': urlType + 'ListShown'
             }).html(urls);
 
-        $togglerOn.hide();
         $expanded.hide();
-        $toggler.append($togglerOff, $togglerOn);
-        $container.append($toggler, $collapsed, $expanded);
+        $container.append($collapsed, $expanded);
         return $container[0].outerHTML;
     }
 
@@ -108,6 +96,22 @@ define('utils/render', [
         listShown.toggle();
     }
 
+    function expandExpandableList(thisObj, type) {
+        let listHidden = thisObj.find('.' + type + 'ListHidden'),
+            listShown = thisObj.find('.' + type + 'ListShown');
+
+        listHidden.hide();
+        listShown.show();
+    }
+
+    function collapseExpandableList(thisObj, type) {
+        let listHidden = thisObj.find('.' + type + 'ListHidden'),
+            listShown = thisObj.find('.' + type + 'ListShown');
+
+        listShown.hide();
+        listHidden.show();
+    }
+
     function toggleChildRow(thisObj, table) {
         let tr = thisObj.closest('tr'),
             row = table.row(tr);
@@ -117,14 +121,33 @@ define('utils/render', [
             row.child.hide();
             tr.removeClass('shown');
             row.child().removeClass('active');
+            collapseExpandableList(tr, "License");
+            collapseExpandableList(tr, "Release");
+            collapseComment(tr);
         } else {
             tr.find("td:first").html('&#x25BC');
             row.child(createChildRow(row.data())).show();
             tr.addClass('shown');
             row.child().addClass('active');
+            expandExpandableList(tr, "License");
+            expandExpandableList(tr, "Release");
+            expandComment(tr);
         }
     }
 
+    function expandComment(tr) {
+        let obl_comment = tr.find('td.obl-comment').find('span');
+        if(obl_comment.hasClass('text-truncate')){
+            obl_comment.removeClass('text-truncate').css({"white-space": "pre-wrap","word-break": "break-all"});
+        }
+    }
+
+    function collapseComment(tr) {
+        let obl_comment = tr.find('td.obl-comment').find('span');
+        if(!obl_comment.hasClass('text-truncate')){
+            obl_comment.addClass('text-truncate').removeAttr("style");
+        }
+    }
     /*
      * Define function for child row creation, which will contain additional data for a clicked table row
      */
@@ -139,7 +162,7 @@ define('utils/render', [
     function toggleAllChildRows(thisObj, table) {
         let textShown = thisObj.attr('data-show') === 'true';
 
-        table.rows(':not(.orphan)').every(function (rowIdx, tableLoop, rowLoop) {
+        table.rows().every(function (rowIdx, tableLoop, rowLoop) {
             let tr = $(this.node()),
                 row = table.row(tr);
 
@@ -148,14 +171,20 @@ define('utils/render', [
                     $(tr).find('td:first').html('&#x25BA');
                     row.child.hide();
                     tr.removeClass('shown');
-                    row.child().removeClass('active')
+                    row.child().removeClass('active');
+                    collapseExpandableList(tr, "License");
+                    collapseExpandableList(tr, "Release");
+                    collapseComment(tr);
                 }
             } else {
                 if (!row.child.isShown()) {
                     $(tr).find('td:first').html('&#x25BC');
                     row.child(createChildRow(row.data())).show();
                     tr.addClass('shown');
-                    row.child().addClass('active')
+                    row.child().addClass('active');
+                    expandExpandableList(tr, "License");
+                    expandExpandableList(tr, "Release");
+                    expandComment(tr);
                 }
             }
         });


### PR DESCRIPTION
> Expand/Collapse all columns including comment using single leftmost toggle button for a row
>   * Remove truncate for Obligation Text
>   * Added expand collapse column feature for comments

> * Which issue is this pull request belonging to and how is it solving it? (*#1016*)
> * Did you add or update any new dependencies that are required for your change? - No

### How To Test?
> In Project -> Obligation
> - There should be single leftmost toggle button for a row , to expand row content along with comment
> - There should be no truncate for Obligation Text
> - Delete Individual orphaned obligation, should work

> Have you implemented any additional tests? - No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>