### PR TITLE
Cleanup dependencies for backend services

### DIFF
--- a/backend/src-common/pom.xml
+++ b/backend/src-common/pom.xml
@@ -40,22 +40,7 @@
         <dependency>
             <groupId>org.spdx</groupId>
             <artifactId>spdx-tools</artifactId>
-            <version>2.1.0</version>
             <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- Needed by spdx-tools -->
         <dependency>
@@ -65,7 +50,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.8.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/backend/src/src-attachments/pom.xml
+++ b/backend/src/src-attachments/pom.xml
@@ -14,7 +14,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/backend/src/src-cvesearch/pom.xml
+++ b/backend/src/src-cvesearch/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.0</version>
         </dependency>
     </dependencies>    
 </project>

--- a/backend/src/src-fossology/pom.xml
+++ b/backend/src/src-fossology/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.54</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -46,7 +45,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.5</version>
         </dependency>
     </dependencies>
 </project>

--- a/backend/src/src-health/pom.xml
+++ b/backend/src/src-health/pom.xml
@@ -14,7 +14,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/backend/src/src-licenseinfo/pom.xml
+++ b/backend/src/src-licenseinfo/pom.xml
@@ -21,17 +21,6 @@
     <packaging>jar</packaging>
     <name>src-licenseinfo</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- We need at least 3.8.1 since it is a dependency from velocity -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.8.1</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.eclipse.sw360</groupId>
@@ -39,21 +28,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.tngtech.java</groupId>
-            <artifactId>junit-dataprovider</artifactId>
-            <version>1.12.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.spdx</groupId>
             <artifactId>spdx-tools</artifactId>
-            <version>2.1.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>
@@ -77,49 +53,45 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.8.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
-            <version>2.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.velocity.tools</groupId>
             <artifactId>velocity-tools-generic</artifactId>
-            <version>3.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>4.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>4.1.0</version>
         </dependency>
         <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>saxon-dom</artifactId>
-            <version>8.7</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tngtech.java</groupId>
+            <artifactId>junit-dataprovider</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>2.1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
-            <version>1.1.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
@@ -208,7 +208,7 @@ public class XhtmlGeneratorTest {
     @Test
     public void testGenerateOutputFile_parseSingleCopyright() throws Exception {
         String copyrights = findCopyrights(document3, releaseNameString(vendorName, releaseName, version1));
-        assertThat(copyrights, is("\n"+ cr));
+        assertThat(copyrights, is("\n"+ cr + "\n"));
     }
 
     @Test

--- a/backend/src/src-licenses/pom.xml
+++ b/backend/src/src-licenses/pom.xml
@@ -27,21 +27,6 @@
         <dependency>
             <groupId>org.spdx</groupId>
             <artifactId>spdx-tools</artifactId>
-            <version>2.1.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- Needed by spdx-tools -->
         <dependency>
@@ -51,7 +36,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.8.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/backend/src/src-vulnerabilities/pom.xml
+++ b/backend/src/src-vulnerabilities/pom.xml
@@ -25,9 +25,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
+            <groupId>com.github.cliftonlabs</groupId>
             <artifactId>json-simple</artifactId>
-            <version>1.1.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/backend/src/src-wsimport/pom.xml
+++ b/backend/src/src-wsimport/pom.xml
@@ -27,12 +27,10 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.0</version>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
+            <groupId>com.github.cliftonlabs</groupId>
             <artifactId>json-simple</artifactId>
-            <version>1.1.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/backend/utils/pom.xml
+++ b/backend/utils/pom.xml
@@ -28,7 +28,6 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.4</version>
         </dependency>
     </dependencies>
 

--- a/libraries/commonIO/pom.xml
+++ b/libraries/commonIO/pom.xml
@@ -65,7 +65,6 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/libraries/exporters/pom.xml
+++ b/libraries/exporters/pom.xml
@@ -91,12 +91,10 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>15.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -105,7 +103,6 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>3.16</version>
         </dependency>
 
         <dependency>

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ExcelExporter.java
@@ -14,8 +14,6 @@ import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
-import org.apache.poi.xssf.usermodel.XSSFCellStyle;
-import org.apache.poi.xssf.usermodel.XSSFFont;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.exporter.helper.ExporterHelper;
 import org.eclipse.sw360.exporter.utils.SubTable;
@@ -110,10 +108,10 @@ public class ExcelExporter<T, U extends ExporterHelper<T>> {
      */
     private static CellStyle createCellStyle(Workbook workbook) {
         CellStyle cellStyle = workbook.createCellStyle();
-        cellStyle.setBorderBottom(XSSFCellStyle.BORDER_THIN);
-        cellStyle.setBorderTop(XSSFCellStyle.BORDER_THIN);
-        cellStyle.setBorderRight(XSSFCellStyle.BORDER_THIN);
-        cellStyle.setBorderLeft(XSSFCellStyle.BORDER_THIN);
+        cellStyle.setBorderBottom(BorderStyle.THIN);
+        cellStyle.setBorderTop(BorderStyle.THIN);
+        cellStyle.setBorderRight(BorderStyle.THIN);
+        cellStyle.setBorderLeft(BorderStyle.THIN);
         return cellStyle;
     }
 
@@ -123,7 +121,7 @@ public class ExcelExporter<T, U extends ExporterHelper<T>> {
     private static CellStyle createHeaderStyle(Workbook workbook) {
         CellStyle headerCellStyle = createCellStyle(workbook);
         Font font = workbook.createFont();
-        font.setBoldweight(XSSFFont.BOLDWEIGHT_BOLD);
+        font.setBold(true);
         headerCellStyle.setFont(font);
         return headerCellStyle;
     }

--- a/libraries/lib-datahandler/pom.xml
+++ b/libraries/lib-datahandler/pom.xml
@@ -123,12 +123,10 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
         </dependency>
         <dependency>
             <groupId>com.github.ldriscoll</groupId>
             <artifactId>ektorplucene</artifactId>
-            <version>0.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -145,33 +143,39 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>15.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
             <groupId>org.ektorp</groupId>
             <artifactId>org.ektorp</artifactId>
-            <version>${ektorp.version}</version>
-            <exclusions>
-              <exclusion>
-                <groupId>net.sourceforge.findbugs</groupId>
-                <artifactId>annotations</artifactId>
-              </exclusion>
-            </exclusions>
+        </dependency>
+        <!-- Pull in newer versions of fasterxml (excluded by ektorp) -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.stephenc.findbugs</groupId>
             <artifactId>findbugs-annotations</artifactId>
-            <version>1.3.9-1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>${thrift.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,11 @@
 
         <slf4j.version>1.7.25</slf4j.version>
         <log4j2.version>2.7</log4j2.version>
+        <gson.version>2.8.0</gson.version>
+        <jcraft.version>0.1.54</jcraft.version>
+        <jackson.version>2.11.0</jackson.version>
         <junit-dataprovider.version>1.12.0</junit-dataprovider.version>
+        <poi.version>4.1.2</poi.version>
 
         <junit.version>4.13.1</junit.version>
         <jgiven.version>0.17.0</jgiven.version>
@@ -104,6 +108,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.github.cliftonlabs</groupId>
+                <artifactId>json-simple</artifactId>
+                <version>2.3.1</version>
+            </dependency>
             <!-- javax.annotation: java 11 compatibility -->
             <dependency>
               <groupId>javax.annotation</groupId>
@@ -152,6 +161,27 @@
                 <artifactId>commons-csv</artifactId>
                 <version>1.4</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.8.1</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-cli</groupId>
+                <artifactId>commons-cli</artifactId>
+                <version>1.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.thrift</groupId>
+                <artifactId>libthrift</artifactId>
+                <version>${thrift.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>commons-logging</artifactId>
+                        <groupId>commons-logging</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
             <!-- API, java.xml.bind module: java 11 compatibility -->
             <dependency>
                 <groupId>jakarta.xml.bind</groupId>
@@ -165,6 +195,142 @@
                 <version>${glassfish-jaxb.version}</version>
             </dependency>
             <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.10</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.ldriscoll</groupId>
+                <artifactId>ektorplucene</artifactId>
+                <version>0.2.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>net.sourceforge.findbugs</groupId>
+                        <artifactId>annotations</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <!-- Replaces ektorplucene findbugs exclusion-->
+            <dependency>
+                <groupId>com.github.stephenc.findbugs</groupId>
+                <artifactId>findbugs-annotations</artifactId>
+                <version>1.3.9-1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ektorp</groupId>
+                <artifactId>org.ektorp</artifactId>
+                <version>${ektorp.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-io</groupId>
+                        <artifactId>commons-io</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.2</version>
+            </dependency>
+            <!-- jackson is also used by fossology. Keep versions in sync -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+                <version>4.4.8</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${gson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.jcraft</groupId>
+                <artifactId>jsch</artifactId>
+                <version>${jcraft.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.spdx</groupId>
+                <artifactId>spdx-tools</artifactId>
+                <version>2.2.3</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.velocity</groupId>
+                <artifactId>velocity-engine-core</artifactId>
+                <version>2.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.velocity.tools</groupId>
+                <artifactId>velocity-tools-generic</artifactId>
+                <version>3.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi</artifactId>
+                <version>${poi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi-ooxml</artifactId>
+                <version>${poi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains</groupId>
+                <artifactId>annotations</artifactId>
+                <version>15.0</version>
+            </dependency>
+            <dependency>
+                <groupId>net.sf.saxon</groupId>
+                <artifactId>saxon-dom</artifactId>
+                <version>8.7</version>
+            </dependency>
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
@@ -175,6 +341,18 @@
                         <artifactId>hamcrest-core</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.dom4j</groupId>
+                <artifactId>dom4j</artifactId>
+                <version>2.1.3</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>jaxen</groupId>
+                <artifactId>jaxen</artifactId>
+                <version>1.1.6</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.tngtech.java</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,11 @@
         <spring-boot.version>1.5.8.RELEASE</spring-boot.version>
         <spring-restdocs.version>1.1.3.RELEASE</spring-restdocs.version>
 
-        <slf4j.version>1.7.25</slf4j.version>
-        <log4j2.version>2.7</log4j2.version>
-        <gson.version>2.8.0</gson.version>
+        <slf4j.version>1.7.30</slf4j.version>
+        <log4j2.version>2.13.3</log4j2.version>
+        <gson.version>2.8.6</gson.version>
         <jcraft.version>0.1.54</jcraft.version>
-        <jackson.version>2.11.0</jackson.version>
+        <jackson.version>2.11.3</jackson.version>
         <junit-dataprovider.version>1.12.0</junit-dataprovider.version>
         <poi.version>4.1.2</poi.version>
 


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Issue: None - cleanup

This PR aims to simplify the dependency tree for the backend. To obtain a less memory-intensive setup it would be great to package all backend-services together. This requires only one set of dependencies for all backend services to work reliably.

While trying to solve issues with different versions of dependencies, I also noticed that some of the dependencies are used in several places but not referenced from the dependencyManagement section of the parent pom, while others are. This PR therefore:

- aims to put all (backend) dependencies to the parent pom's dependencyManagement
- if two dependencies have different versions, tries to upgrade the dependencies
- also increases dependency versions for several minor dependencies
- update spdx tools dependency to the latest possible version
- update dependencies so that their natural transitive dependencies match the dependency versions used by sw360 whenever possible to avoid failures in transitive dependencies

## Testing

Note that moving versions to `dependencyManagement` may suddenly change the version of transitive dependencies due to the fact how Maven resolves dependencies. I tried to ensure that those dependencies still work well together and found no explicit problems - `mvn clean install` for instance runs cleanly.