### PR TITLE
feat(projectEdit): Project creators and moderators can edit few fields in a closed project

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -616,7 +616,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
     private boolean updateProjectAllowed(Project project, User user) {
         if (project.clearingState != null && project.clearingState.equals(ProjectClearingState.CLOSED)
-                && !PermissionUtils.isUserAtLeast(UserGroup.SW360_ADMIN, user)) {
+                && !PermissionUtils.isUserAtLeast(UserGroup.SW360_ADMIN, user) && !SW360Utils.isModeratorOrCreator(project, user)) {
             return false;
         }
         return true;

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -92,6 +92,7 @@ public class PortalConstants {
     public static final String IS_USER_AT_LEAST_ECC_ADMIN = "isUserAtLeastECCAdmin";
     public static final String IS_USER_ADMIN = "isUserAdmin";
     public static final String IS_CLEARING_EXPERT = "isClearingExpert";
+    public static final String IS_PROJECT_MEMBER = "isProjectMember";
 
     //! Specialized keys for licenses
     public static final String LICENSES_PORTLET_NAME = PORTLET_NAME_PREFIX + "licenses";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -1283,6 +1283,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 PortletUtils.setCustomFieldsDisplay(request, user, project);
                 addProjectBreadcrumb(request, response, project);
                 request.setAttribute(IS_USER_ADMIN, PermissionUtils.isUserAtLeast(UserGroup.SW360_ADMIN, user) ? YES : NO);
+                request.setAttribute(IS_PROJECT_MEMBER, SW360Utils.isModeratorOrCreator(project, user));
             } catch (SW360Exception sw360Exp) {
                 setSessionErrorBasedOnErrorCode(request, sw360Exp.getErrorCode());
             } catch (TException e) {
@@ -1643,6 +1644,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
         Set<Project> usingProjects;
         int allUsingProjectCount = 0;
         request.setAttribute(IS_USER_AT_LEAST_CLEARING_ADMIN, PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user));
+        request.setAttribute(IS_USER_ADMIN, PermissionUtils.isUserAtLeast(UserGroup.SW360_ADMIN, user) ? YES : NO);
 
         if (id != null) {
 
@@ -1675,6 +1677,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             request.setAttribute(ALL_USING_PROJECTS_COUNT, allUsingProjectCount);
             Map<RequestedAction, Boolean> permissions = project.getPermissions();
             DocumentState documentState = project.getDocumentState();
+            request.setAttribute(IS_PROJECT_MEMBER, SW360Utils.isModeratorOrCreator(project, user));
 
             addEditDocumentMessage(request, permissions, documentState);
         } else {
@@ -2209,7 +2212,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
         PortletUtils.handlePaginationSortOrder(request, paginationParameters, projectFilteredFields, PROJECT_NO_SORT);
         List<Project> projectList = getFilteredProjectList(request);
 
-        JSONArray jsonProjects = getProjectData(projectList, paginationParameters);
+        JSONArray jsonProjects = getProjectData(projectList, paginationParameters, request);
         JSONObject jsonResult = createJSONObject();
         jsonResult.put(DATATABLE_RECORDS_TOTAL, projectList.size());
         jsonResult.put(DATATABLE_RECORDS_FILTERED, projectList.size());
@@ -2222,7 +2225,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
         }
     }
 
-    public JSONArray getProjectData(List<Project> projectList, PaginationParameters projectParameters) {
+    public JSONArray getProjectData(List<Project> projectList, PaginationParameters projectParameters, ResourceRequest request) {
         List<Project> sortedProjects = sortProjectList(projectList, projectParameters);
         int count = PortletUtils.getProjectDataCount(projectParameters, projectList.size());
 
@@ -2243,6 +2246,8 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             jsonObject.put("lProjSize", String.valueOf(project.getLinkedProjectsSize()));
             jsonObject.put("lRelsSize", String.valueOf(project.getReleaseIdToUsageSize()));
             jsonObject.put("attsSize", String.valueOf(project.getAttachmentsSize()));
+            jsonObject.put(IS_PROJECT_MEMBER,
+                    SW360Utils.isModeratorOrCreator(project, UserCacheHolder.getUserFromRequest(request)));
             projectData.put(jsonObject);
         }
 

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/edit.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/edit.jsp
@@ -264,6 +264,10 @@ require(['jquery', 'modules/dialog', 'modules/listgroup', 'modules/validation', 
         disableLicenseInfoHeaderTextIfNecessary();
         disableObligationsTextIfNecessary();
         $('#LinkedReleasesInfo tbody tr #mainlineState').prop('disabled', false);
+        <core_rt:if test = "${(project.clearingState eq 'CLOSED') && (isUserAdmin != 'Yes') && isProjectMember && not addMode}">
+            $("form#projectEditForm select").prop("disabled", false);
+            $("form#projectEditForm input").prop("disabled", false);
+        </core_rt:if>
         <core_rt:if test="${not addMode and isProjectObligationsEnabled and isObligationPresent}">
             $('#updateObligationsButtonHidden').trigger('click');
         </core_rt:if>
@@ -369,7 +373,15 @@ require(['jquery', 'modules/dialog', 'modules/listgroup', 'modules/validation', 
             $('#obligationsText').prop('disabled', true);
         }
     }
-    
+
+    <core_rt:if test = "${(project.clearingState eq 'CLOSED') && (isUserAdmin != 'Yes') && isProjectMember && not addMode}">
+        $("form#projectEditForm :input:not([name^='_sw360_portlet_projects_externalIdKey'], [name^='_sw360_portlet_projects_externalIdValue'], [name='_sw360_portlet_projects_ENABLE_SVM'], [name='_sw360_portlet_projects_ENABLE_VULNERABILITIES_DISPLAY'], [type='hidden'])").prop("disabled", true);
+        $("form#projectEditForm select").prop("disabled", true);
+        $("form#projectEditForm button").prop("disabled", true);
+        $("form#projectEditForm button[id='add-external-id']").prop("disabled", false);
+        $("form#projectEditForm button[id='formSubmit']").prop("disabled", false);
+    </core_rt:if>
+
     $.ajax({
         url: '<%=obligationediturl%>',
         type: "GET",

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/detailOverview.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/detailOverview.jspf
@@ -64,7 +64,7 @@
 						<div class="btn-toolbar" role="toolbar">
 							<div class="btn-group" role="group">
 								<button type="button" class="btn btn-primary" onclick="window.location.href='<%=editProjectURL%>' + window.location.hash"
-									<core_rt:if test = "${(project.clearingState eq 'CLOSED') && (isUserAdmin != 'Yes')}">
+									<core_rt:if test = "${(project.clearingState eq 'CLOSED') && (isUserAdmin != 'Yes') && (not isProjectMember)}">
 										disabled="disabled"
 									</core_rt:if>
 								>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/administrationEdit.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/administrationEdit.jspf
@@ -12,6 +12,7 @@
 <%@page import="org.eclipse.sw360.datahandler.thrift.projects.ProjectState"%>
 <%@page import="org.eclipse.sw360.datahandler.thrift.projects.Project" %>
 <core_rt:set var="isUnknownCTeamEnabled" value='<%=PortalConstants.IS_CLEARING_TEAM_UNKNOWN_ENABLED%>'/>
+<core_rt:set var="clearingStateClosedAndUserNotAdmin" value="${(project.clearingState eq 'CLOSED') && (isUserAdmin != 'Yes')}"/>
 
 <table class="table edit-table three-columns" id="ProjectClearingInfo" title="<liferay-ui:message key="clearing" />">
     <thead>
@@ -22,9 +23,16 @@
     <tr>
         <td>
             <div class="form-group">
-                <label for="proj_projectclearingstate"><liferay-ui:message key="project.clearing.state" /></label>
+                <label for="proj_projectclearingstate"><liferay-ui:message key="project.clearing.state" />
+                <core_rt:if test = "${clearingStateClosedAndUserNotAdmin}">
+                    <clay:icon symbol="lock" />
+                </core_rt:if></label>
                 <select class="form-control" id="proj_projectclearingstate"
-                        name="<portlet:namespace/><%=Project._Fields.CLEARING_STATE%>">
+                        name="<portlet:namespace/><%=Project._Fields.CLEARING_STATE%>"
+                        <core_rt:if test = "${clearingStateClosedAndUserNotAdmin}">
+                            disabled="disabled"
+                        </core_rt:if>
+                >
                     <sw360:DisplayEnumOptions type="<%=ProjectClearingState.class%>" selected="${project.clearingState}"/>
                 </select>
                 <small class="form-text">

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/view.jsp
@@ -374,7 +374,7 @@
 
                 $clearingRequestAction.append($('<use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#check-square"/>'));
 
-                if(row.cState == 'CLOSED' && ${isUserAdmin != 'Yes'}) {
+                if(row.cState == 'CLOSED' && ${isUserAdmin != 'Yes'} & !(row.isProjectMember)) {
                     $editAction = $('<svg class="lexicon-icon disabled"><title><liferay-ui:message key="only.administrators.can.edit.a.closed.project" /></title><use href="/o/org.eclipse.sw360.liferay-theme/images/clay/icons.svg#pencil"/></svg>');
                 } else {
                     $editAction = render.linkTo(

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -649,4 +649,12 @@ public class SW360Utils {
                 .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue(), (oldValue, newValue) -> oldValue,
                         LinkedHashMap<String, ObligationStatusInfo>::new));
     }
+
+    public static boolean isModeratorOrCreator(Project project, User user) {
+        Set<String> users = new HashSet<String>();
+        Set<String> moderators = project.getModerators();
+        users.addAll(moderators);
+        users.add(project.getCreatedBy());
+        return users.contains(user.getEmail());
+    }
 }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? 

Closes: #1044 

> * Did you add or update any new dependencies that are required for your change? - 

No

Issue:  #1044 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?

Add some user as moderator to a project. Make the project clearing state to closed. Login with user which is added as a moderator and edit the project. All fields should be disabled except editing external id, security vulnerability monitoring and security vulnerabilities display
> Have you implemented any additional tests? - No

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR

Signed-off-by: Smruti Prakash Sahoo <smruti.sahoo@siemens.com>
