### PR TITLE
feat(rest): Accept 'downloadurl' in request body as 'sourceCodeDownloadurl' as an alternative to original value 'sourceCodeDownloadurl' for Create and update Release APIs

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -86,6 +86,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
@@ -628,6 +629,7 @@ public class ProjectController implements ResourceProcessor<RepositoryLinksResou
         User user = restControllerHelper.getSw360UserFromAuthentication();
         Project sw360Project = projectService.getProjectForUserById(id, user);
         ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mapper.registerModule(sw360Module);
         Project updateProject = mapper.convertValue(reqBodyMap, Project.class);
         sw360Project = this.restControllerHelper.updateProject(sw360Project, updateProject, reqBodyMap, mapOfProjectFieldsToRequestBody);


### PR DESCRIPTION
>  Accept 'downloadurl' in request body as 'sourceCodeDownloadurl' as an alternative to original value 'sourceCodeDownloadurl' for Create and update Release APIs.
     * Added previous config FAIL_ON_UNKNOWN_PROPERTIES = false for Update Project, Create/Update Release
> * Which issue is this pull request belonging to and how is it solving it? (*#1069*)
> * Did you add or update any new dependencies that are required for your change? - No

### How To Test?
> Test Create/Update Release with `downloadurl` in body.
    * `downloadurl` in request body should be accepted as `sourceCodeDownloadurl`.
    * If both `downloadurl` and `sourceCodeDownloadurl` then  `sourceCodeDownloadurl`  value should be considered.
    * Unknown property in requestBody like `unknownField` should not break functionality in Update Project, Create/Update Release and should work as expected.

> Have you implemented any additional tests? - No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>