### PR TITLE
feat(ui): Display Id in summary page of project, component and release

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/summary.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/summary.jspf
@@ -23,6 +23,10 @@
         </tr>
     </thead>
     <tr>
+        <td><liferay-ui:message key="id" />:</td>
+        <td><sw360:out value="${component.id}"/></td>
+    </tr>
+    <tr>
         <td><liferay-ui:message key="name" />:</td>
         <td><sw360:out value="${component.name}"/></td>
     </tr>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/summaryRelease.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/summaryRelease.jspf
@@ -18,6 +18,10 @@
         </tr>
         </thead>
         <tr>
+            <td><liferay-ui:message key="id" />:</td>
+            <td><sw360:out value="${release.id}"/></td>
+        </tr>
+        <tr>
             <td><liferay-ui:message key="cpe.id3" />:</td>
             <td><sw360:out value="${release.cpeid}"/></td>
         </tr>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/summary.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/summary.jspf
@@ -22,6 +22,10 @@
     </tr>
     </thead>
     <tr>
+        <td><liferay-ui:message key="id" />:</td>
+        <td><sw360:out value="${project.id}"/></td>
+    </tr>
+    <tr>
         <td><liferay-ui:message key="name" />:</td>
         <td><sw360:out value="${project.name}"/></td>
     </tr>

--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -1309,6 +1309,7 @@ license.obligation=License Obligation
 obligation.title= Obligation Title
 obligation.text=Obligation Text
 linked.obligations=Linked Obligations
+id=Id
 
 ## Refer to http://cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/ and add your datatables language
 

--- a/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
@@ -1313,6 +1313,7 @@ license.obligation=License Obligation
 obligation.title=Obligation Title
 obligation.text=Obligation Text
 linked.obligations=Linked Obligations
+id=Id
 
 ## Refer to http://cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/ and add your datatables language
 

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -1315,6 +1315,7 @@ license.obligation=License Obligation
 obligation.title= Obligation Title
 obligation.text=Obligation Text
 linked.obligations=Linked Obligations
+id=Id
 
 ## Refer to http://cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/ and add your datatables language
 


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Displayed unique id(DB Ids) of project, component and release in respective the summary page.

> * Which issue is this pull request belonging to and how is it solving it? (*#1076*)
> * Did you add or update any new dependencies that are required for your change?

Issue: Closes: #1076 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer? - Need to test the UI, if it displayed correctly.
> Have you implemented any additional tests? - No

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR

Signed-off-by: Smruti Prakash Sahoo <smruti.sahoo@siemens.com>