### PR TITLE
feat(ui-rest): Provided option in attachment usage to include/exclude concluded licenses during LicenseInfo Generation

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentDatabaseHandler.java
@@ -164,7 +164,10 @@ public class AttachmentDatabaseHandler {
                         au.isSetUsageData() && au.getUsageData().getSetField().equals(UsageData._Fields.LICENSE_INFO)
                                 && au.getUsageData().getLicenseInfo().isSetProjectPath()
                                         ? au.getUsageData().getLicenseInfo().getProjectPath()
-                                        : "")))
+                                        : "",
+                        au.isSetUsageData() && au.getUsageData().getSetField().equals(UsageData._Fields.LICENSE_INFO)
+                                ? au.getUsageData().getLicenseInfo().isIncludeConcludedLicense()
+                                : false)))
                 .collect(Collectors.toList());
     }
 

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParser.java
@@ -46,6 +46,11 @@ public abstract class LicenseInfoParser {
 
     public abstract <T> List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment, User user, T context) throws TException;
 
+    public <T> List<LicenseInfoParsingResult> getLicenseInfosIncludeConcludedLicense(Attachment attachment,
+            boolean includeConcludedLicense, User user, T context) throws TException {
+        return new ArrayList<LicenseInfoParsingResult>();
+    }
+
     public <T> ObligationParsingResult getObligations(Attachment attachment, User user, T context) throws TException {
         return new ObligationParsingResult().setStatus(ObligationInfoRequestStatus.NO_APPLICABLE_SOURCE);
     }

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParser.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParser.java
@@ -57,11 +57,19 @@ public class SPDXParser extends LicenseInfoParser {
     }
 
     @Override
-    public <T> List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment, User user, T context) throws TException {
-        return Collections.singletonList(getLicenseInfo(attachment, user, context));
+    public <T> List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment, User user, T context)
+            throws TException {
+        return Collections.singletonList(getLicenseInfo(attachment, true, user, context));
     }
 
-    public <T> LicenseInfoParsingResult getLicenseInfo(Attachment attachment, User user, T context) throws TException {
+    @Override
+    public <T> List<LicenseInfoParsingResult> getLicenseInfosIncludeConcludedLicense(Attachment attachment,
+            boolean includeConcludedLicense, User user, T context) throws TException {
+        return Collections.singletonList(getLicenseInfo(attachment, includeConcludedLicense, user, context));
+    }
+
+    public <T> LicenseInfoParsingResult getLicenseInfo(Attachment attachment, boolean includeConcludedLicense, User user,
+            T context) throws TException {
         AttachmentContent attachmentContent = attachmentContentProvider.getAttachmentContent(attachment);
 
         final Optional<SpdxDocument> spdxDocument = openAsSpdx(attachmentContent, user, context);
@@ -70,7 +78,7 @@ public class SPDXParser extends LicenseInfoParser {
                     .setStatus(LicenseInfoRequestStatus.FAILURE);
         }
 
-        return getLicenseInfoFromSpdx(attachmentContent, spdxDocument.get());
+        return getLicenseInfoFromSpdx(attachmentContent, includeConcludedLicense, spdxDocument.get());
     }
 
     protected String getUriOfAttachment(AttachmentContent attachmentContent) throws URISyntaxException {

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandlerTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandlerTest.java
@@ -59,7 +59,7 @@ public class LicenseInfoHandlerTest {
     @Test(expected = IllegalStateException.class)
     public void testThatAttachmentMustBePartOfTheRelease() throws TException {
         Release release = Mockito.mock(Release.class);
-        handler.getLicenseInfoForAttachment(release, "123", user);
+        handler.getLicenseInfoForAttachment(release, "123", true, user);
     }
 
     @Test

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/LicenseInfoParserTest.java
@@ -44,6 +44,12 @@ public class LicenseInfoParserTest {
             public <T> List<LicenseInfoParsingResult> getLicenseInfos(Attachment attachment, User user, T context) throws TException {
                 return null;
             }
+
+            @Override
+            public <T> List<LicenseInfoParsingResult> getLicenseInfosIncludeConcludedLicense(Attachment attachment,
+                    boolean includeConcludedLicense, User user, T context) throws TException {
+                return null;
+            }
         };
         Arrays.stream(AttachmentType.values()).filter(SW360Constants.LICENSE_INFO_ATTACHMENT_TYPES::contains)
                 .forEach(attachmentType -> parser.getApplicableFileExtensions().stream().forEach(extension -> {

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
@@ -136,7 +136,7 @@ public class SPDXParserTest {
                 parser.getUriOfAttachment(attachmentContentStore.get(exampleFile)),
                 FILETYPE_SPDX_INTERNAL);
 
-        LicenseInfoParsingResult result = SPDXParserTools.getLicenseInfoFromSpdx(attachmentContent, spdxDocument);
+        LicenseInfoParsingResult result = SPDXParserTools.getLicenseInfoFromSpdx(attachmentContent, true, spdxDocument);
         assertIsResultOfExample(result.getLicenseInfo(), exampleFile, expectedLicenses, numberOfCoyprights,
                 exampleCopyright, exampleConcludedLicenseIds);
     }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -220,6 +220,9 @@ public class PortalConstants {
     public static final String ATTACHMENT_USAGES_RESTRICTED_COUNTS = "attachmentUsagesRestrictedCounts";
     public static final String SPDX_LICENSE_INFO = "spdxLicenseInfo";
     public static final String SELECTED_ATTACHMENTS_WITH_FULL_PATH = "selectedAttachmentIdsWithFullPath[]";
+    public static final String INCLUDE_CONCLUDED_LICENSE = "includeConcludedLicense";
+    public static final String INCLUDE_CONCLUDED_LICENSE_SHADOWS = "includeConcludedLicenseShadows";
+    public static final String ENABLE_CONCLUDED_LICENSE = "enableConcludedLicense";
 
     // ! Specialized keys for changelog
     public static final String LOAD_CHANGE_LOGS = "load_change_logs";
@@ -270,6 +273,7 @@ public class PortalConstants {
     public static final String MANUAL_ATTACHMENT_USAGES = "manualAttUsages";
     public static final String PROJECT_PATH = "projectPath";
     public static final String PROJECT_PATHS = "projectPaths";
+    public static final String PARENT_PROJECT_PATH = "parentProjectPath";
     public static final String SOURCE_PROJECT_ID = "sourceProjectId";
     public static final String PROJECT_OBLIGATIONS_INFO_BY_RELEASE = "projectObligationsInfoByRelease";
     public static final String LINKED_OBLIGATIONS = "linkedObligations";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/LinkedReleasesAndProjectsAwarePortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/LinkedReleasesAndProjectsAwarePortlet.java
@@ -185,6 +185,9 @@ public abstract class LinkedReleasesAndProjectsAwarePortlet extends AttachmentAw
                 log.error("Error getting projects!", e);
                 throw new PortletException("cannot load project " + projectIdOpt.get(), e);
             }
+            String parentProjectPath = request.getParameter(PortalConstants.PARENT_PROJECT_PATH);
+            request.setAttribute(PortalConstants.PARENT_PROJECT_PATH,
+                    parentProjectPath.concat(":").concat(projectIdOpt.get()));
         } else {
             project = new Project();
         }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -543,6 +543,8 @@ public class ComponentPortlet extends FossologyAwarePortlet {
         String releaseId = request.getParameter(PortalConstants.RELEASE_ID);
         String attachmentContentId = request.getParameter(PortalConstants.ATTACHMENT_ID);
         String attachmentName = request.getParameter(PortalConstants.ATTACHMENT_NAME);
+        boolean includeConcludedLicense = new Boolean(request.getParameter(PortalConstants.INCLUDE_CONCLUDED_LICENSE));
+
         ComponentService.Iface componentClient = thriftClients.makeComponentClient();
         LicenseInfoService.Iface licenseInfoClient = thriftClients.makeLicenseInfoClient();
 
@@ -551,7 +553,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
         try {
             Release release = componentClient.getReleaseById(releaseId, user);
             List<LicenseInfoParsingResult> licenseInfoResult = licenseInfoClient.getLicenseInfoForAttachment(release,
-                    attachmentContentId, user);
+                    attachmentContentId, includeConcludedLicense, user);
             if (attachmentName.endsWith(".rdf")) {
                 concludedLicenseIds = licenseInfoResult.stream()
                         .flatMap(singleResult -> singleResult.getLicenseInfo().getConcludedLicenseIds().stream())

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentSelectTable.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentSelectTable.jspf
@@ -57,6 +57,9 @@
             <th><input type="checkbox" class="form-check-input" checked="checked" id="selectAllCheckbox"/></th>
             <th><liferay-ui:message key="lvl" /></th>
             <th><liferay-ui:message key="name" /></th>
+            <core_rt:if test="${enableConcludedLicense}">
+                <th style="width:7%" id="conclusionHeader"><liferay-ui:message key="conclusions" /></th>
+            </core_rt:if>
             <th><liferay-ui:message key="type" /></th>
             <th><liferay-ui:message key="clearing.state" /></th>
             <th><liferay-ui:message key="uploaded.by" /></th>
@@ -90,6 +93,9 @@
                         </div>
                     </core_rt:if>
                 </td>
+                <core_rt:if test="${enableConcludedLicense}">
+                    <td></td>
+                </core_rt:if>
                 <td>
                     <sw360:DisplayEnum value="${projectLink.projectType}"/>
                 </td>
@@ -117,6 +123,9 @@
                             value="${releaseLink.vendor} ${releaseLink.name}" maxChar="50"/> <sw360:out
                             value="${releaseLink.version}"/></a>
                 </td>
+                <core_rt:if test="${enableConcludedLicense}">
+                    <td></td>
+                </core_rt:if>
                 <td>
                     <sw360:DisplayEnum value="${releaseLink.componentType}"/>
                 </td>
@@ -146,7 +155,7 @@
                     <core_rt:if test="${fn:length(releaseLink.attachments) gt 1}">class="selectable highlightWarning"</core_rt:if>
                 >
                     <td>
-                        <input type="checkbox" class="form-check-input"
+                        <input type="checkbox" class="form-check-input attachmentChkbox"
                                 name="<portlet:namespace/><%=PortalConstants.LICENSE_INFO_RELEASE_TO_ATTACHMENT%>"
                                 <core_rt:if test="${projectLinkTableMode == tableModeLicenseInfo}">value='${projectPath.concat(":").concat(releaseLink.id).concat(":").concat(releaseLink.releaseRelationship).concat(":").concat(attachment.attachmentContentId)}'</core_rt:if>
                                 <core_rt:if test="${projectLinkTableMode != tableModeLicenseInfo}">value='${releaseLink.id.concat(":").concat(attachment.attachmentContentId)}'</core_rt:if>
@@ -161,6 +170,17 @@
                     <td class="filename">
                         <sw360:out value="${attachment.filename}"/>
                     </td>
+                    <core_rt:if test='${enableConcludedLicense}'>
+                      <td>
+                        <core_rt:if test='${attachment.filename.toLowerCase().endsWith(".rdf")}'>
+                            <input type="checkbox" class="form-check-input concludedLicense" disabled="true"
+                                name="<portlet:namespace/><%=PortalConstants.INCLUDE_CONCLUDED_LICENSE%>"
+                                <core_rt:if test="${projectLinkTableMode == tableModeLicenseInfo}">value='${projectPath.concat(":").concat(releaseLink.id).concat(":").concat(releaseLink.releaseRelationship).concat(":").concat(attachment.attachmentContentId)}'</core_rt:if>
+                                <core_rt:if test="${projectLinkTableMode != tableModeLicenseInfo}">value='${releaseLink.id.concat(":").concat(attachment.attachmentContentId)}'</core_rt:if>
+                            />
+                        </core_rt:if>
+                      </td>
+                    </core_rt:if>
                     <td colspan="2">
                             <c:set var="mapKey">${releaseLink.id.concat("_").concat(attachment.attachmentContentId)}</c:set>
                             <core_rt:choose>
@@ -241,12 +261,26 @@
 
             $('#LinkedProjectsInfo').on('click', 'tr.selectable', function(event) {
                 var $row = $(event.target).parents('tr:first'),
-                    checked = $row.find(':checkbox').is(':checked');
+                    checked = $row.find(':checkbox:first').is(':checked');
 
                 if(!$(event.target).is(':checkbox') && !$(event.target).is('a')) {
-                    $row.find(':checkbox').prop('checked', !checked).trigger('change');
+                    $row.find(':checkbox:first').prop('checked', !checked).trigger('change');
+                    setIncludeConcludedLicense(!checked, $row);
+                } else {
+                    setIncludeConcludedLicense(checked, $row);
                 }
             });
+
+            function setIncludeConcludedLicense(checked, $row) {
+                let includeConcludedLicense = $row.find(':checkbox:eq(1)')
+                if(checked) {
+                    $(includeConcludedLicense).prop("disabled", false);
+                }
+                else {
+                    $(includeConcludedLicense).prop("checked", false);
+                    $(includeConcludedLicense).prop("disabled", true);
+                }
+            }
 
             function removeProjectLoader(ttParentId) {
                 button.finish($linkedProjectsInfoTable.find('tr[data-tt-id=' + ttParentId + '] button.use-subproject-selection'));
@@ -464,6 +498,17 @@
                             // this means a subproject selection has been loaded
                             removeProjectLoader(ttId);
                         }
+
+                        $(".attachmentChkbox").each(function(event){
+                            let selectedRow = $(this).parents('tr:first'),
+                                checked = $(this).is(':checked');
+                            let includeConcludedLicense = $(selectedRow).find(':checkbox:eq(1)')
+                            if(checked) {
+                                $(includeConcludedLicense).prop("disabled", false);
+                                $(includeConcludedLicense).prop("checked", true);
+                            }
+                        });
+
                         $('#infobar').removeClass('alert-info').addClass('alert-secondary').html($('<span>', {
                             text: "<liferay-ui:message key="no.previous.selection.found.if.you.have.writing.permissions.to.this.project.your.selection.will.be.stored.automatically.when.downloading" />"
                         }));
@@ -532,7 +577,6 @@
                 var warnings = [],
                     loadCountdown = countdown(attachmentUsages.length, function() { readyCallback(null, warnings); }),
                     config = $linkedProjectsInfoTable.data();
-
                 if (!prefix) {
                     // on first load (=prefix is empty) reset all default selected checkboxes if we have a stored selection
                     $("#selectAllCheckbox").prop('checked', false).trigger('change');
@@ -559,6 +603,13 @@
                     var releaseRelation = licenseinfoTableMode ? relationPlusColon : '';
 
                     $linkedProjectsInfoTable.find('tr input[value="' + inputPrefix + usage.owner.releaseId + ':' + releaseRelation + usage.attachmentContentId + '"]:first').prop('checked', true).trigger('change');
+                    $linkedProjectsInfoTable.find('tr input[value="' + inputPrefix + usage.owner.releaseId + ':' + releaseRelation + usage.attachmentContentId + '"]:eq(1)').prop('disabled', false).trigger('change');
+
+                    if(usage.usageData && usage.usageData.licenseInfo && 
+                            (usage.usageData.licenseInfo.includeConcludedLicense === null || usage.usageData.licenseInfo.includeConcludedLicense === undefined 
+                                    || usage.usageData.licenseInfo.includeConcludedLicense)) {
+                        $linkedProjectsInfoTable.find('tr input[value="' + inputPrefix + usage.owner.releaseId + ':' + releaseRelation + usage.attachmentContentId + '"]:eq(1)').prop('checked', true).trigger('change');
+                    }
 
                     if(usage.usageData.licenseInfo && usage.usageData.licenseInfo.excludedLicenseIds.length > 0) {
                         if (!usage.usageData.licenseInfo.projectPath) {
@@ -639,6 +690,10 @@
             function findReleaseName($linkedProjectsInfoTable, usage, prefix) {
                 var $row = $linkedProjectsInfoTable.find('tr[data-project-path="' + prefix + usage.usageData.licenseInfo.projectPath + '"][data-release-id=' + usage.owner.releaseId + ']:first');
                 return $row.find('td.release-name a').text();
+            }
+
+            if (!$(".concludedLicense")[0]) {
+                $("#conclusionHeader").html("").css("width","0%");
             }
 
             function countdown(value, callback) {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentUsages.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentUsages.jspf
@@ -34,7 +34,7 @@
         >
         <thead>
         <tr>
-            <th colspan="7" class="headlabel"><liferay-ui:message key="linked.releases.and.projects" />
+            <th colspan="8" class="headlabel"><liferay-ui:message key="linked.releases.and.projects" />
             <core_rt:if test="${projectList.size() > 1 or (projectList.size() == 1 and not empty projectList.get(0).linkedReleases)}">
                 (<a href="#" id="expandAll" class="text-primary"><liferay-ui:message key="expand.all" /> </a>|
                 <a href="#" id="collapseAll" class="text-primary"> <liferay-ui:message key="collapse.all" /></a>)
@@ -43,16 +43,20 @@
             </th>
         </tr>
         <tr>
-            <th rowspan="2"><liferay-ui:message key="name" /></th>
-            <th rowspan="2"><liferay-ui:message key="relation" /></th>
-            <th rowspan="2"><liferay-ui:message key="uploaded.by" /></th>
-            <th rowspan="2"><liferay-ui:message key="type" /></th>
-            <th colspan="3"><liferay-ui:message key="used.in" /></th>
+            <th rowspan="3"><liferay-ui:message key="name" /></th>
+            <th rowspan="3"><liferay-ui:message key="relation" /></th>
+            <th rowspan="3"><liferay-ui:message key="uploaded.by" /></th>
+            <th rowspan="3"><liferay-ui:message key="type" /></th>
+            <th colspan="4"><liferay-ui:message key="used.in" /></th>
         </tr>
         <tr>
-            <th><liferay-ui:message key="license.info" /></th>
-            <th><liferay-ui:message key="source.code.bundle" /></th>
-            <th><liferay-ui:message key="other" /></th>
+            <th colspan="2"><liferay-ui:message key="license.info" /></th>
+            <th rowspan="2"><liferay-ui:message key="source.code.bundle" /></th>
+            <th rowspan="2"><liferay-ui:message key="other" /></th>
+        </tr>
+        <tr>
+            <th></th>
+            <th class="p-1"><liferay-ui:message key="conclusions" /></th>
         </tr>
         </thead>
         <tbody>
@@ -75,6 +79,7 @@
             ajaxTreeTable.setup('AttachmentUsagesInfo', config.loadNodeUrl, function(table, node) {
                 var data = {};
                 data[config.portletNamespace + config.parentBranchKey] = node.id;
+                data[config.portletNamespace + 'parentProjectPath'] = $(node.row[0]).attr("data-tt-parentProjectPath");
                 data[config.portletNamespace + 'parentScopeGroupId'] = config.scopeGroupId;
                 return data;
             }, function(table, node, result) {
@@ -86,9 +91,10 @@
                 table.treetable("collapseNode", node.id);
                 table.treetable("expandNode", node.id);
                 attachCheckboxEventHandlers();
+                attachClickHandlerForLicInfo();
             });
             attachCheckboxEventHandlers();
-
+            attachClickHandlerForLicInfo();
             $('#saveAttachmentUsagesButton').click(saveAttachmentUsages);
         });
 
@@ -132,6 +138,11 @@
                 var $shadow = $("#" + this.id + "_shadow");
                 $shadow.prop('checked', true);
             });
+
+            $("#attachmentUsagesForm .trackChangeLicInfo").change(function() {
+                var $shadow = $("#attachmentUsagesForm").find('input[id="' + this.id + "_shadow" + '"]');
+                $shadow.prop('checked', true);
+            });
         }
 
         function saveAttachmentUsages() {
@@ -149,6 +160,26 @@
             }).fail(function(xhr, status, error){
                 alert.danger($form, "<liferay-ui:message key="couldnt.save.attachment.usages" />" + xhr.responseText, 6);
                 button.finish('#saveAttachmentUsagesButton');
+            });
+        }
+
+        function attachClickHandlerForLicInfo() {
+            $("#AttachmentUsagesInfo").find(".licInfo").on("change",function() {
+                let checked = $(this).prop("checked");
+                let includeConcludedLicense = $(this).parents("tr:eq(0)").find('.includeConcludedLicense');
+                if(checked) {
+                    $(includeConcludedLicense).prop("disabled", false);
+                }
+                else {
+                    $(includeConcludedLicense).prop("checked", false).trigger('change');
+                    $(includeConcludedLicense).prop("disabled", true);
+                }
+            });
+
+            $("#AttachmentUsagesInfo").find(".includeConcludedLicense").on("change",function() {
+                let $shadow = $("#" + $(this).val() + "_shadow");
+                $shadow.prop('checked', true);
+                $("#" + this.id + "_shadow").prop('checked', true);
             });
         }
     });

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentUsagesRows.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentUsagesRows.jspf
@@ -33,7 +33,7 @@
     <%--first element in the list is the root linked project --%>
     <core_rt:if test="${loop.index==0}"><core_rt:set var="new_root_id" value="${projectLink.nodeId}"/></core_rt:if>
     <core_rt:if test="${loop.index!=0}">
-        <tr data-tt-id="${projectLink.nodeId}" data-tt-branch="true"
+        <tr data-tt-id="${projectLink.nodeId}" data-tt-branch="true" data-tt-parentProjectPath="${parentProjectPath}"
             <%--attach children of the new root node to the existing node being expanded--%>
             <core_rt:if test="${projectLink.parentNodeId == new_root_id}">data-tt-parent-id="${parent_branch_id}"</core_rt:if>
             <core_rt:if test="${projectLink.parentNodeId != new_root_id}">data-tt-parent-id="${projectLink.parentNodeId}"</core_rt:if>
@@ -93,18 +93,39 @@
                 <td>
                     <input type="checkbox"
                            name="<portlet:namespace/><%=PortalConstants.PROJECT_SELECTED_ATTACHMENT_USAGES%>"
-                           value="${releaseLink.id}_<%=UsageData._Fields.LICENSE_INFO.getFieldName()%>_${attachment.attachmentContentId}"
-                           id="${releaseLink.id}_<%=UsageData._Fields.LICENSE_INFO.getFieldName()%>_${attachment.attachmentContentId}"
+                           value="${parentProjectPath}-${releaseLink.id}_<%=UsageData._Fields.LICENSE_INFO.getFieldName()%>_${attachment.attachmentContentId}"
+                           id="${parentProjectPath}-${releaseLink.id}_<%=UsageData._Fields.LICENSE_INFO.getFieldName()%>_${attachment.attachmentContentId}"
                            <core_rt:if test="${!licenseInfoAttachmentTypes.contains(attachment.attachmentType) or !writeAccessUser}">disabled</core_rt:if>
                            <core_rt:if test="${licInfoAttUsages.containsKey(attachment.attachmentContentId)}">checked="checked"</core_rt:if>
-                           class="form-check-input trackChange<core_rt:if test="${licInfoAttUsages.containsKey(attachment.attachmentContentId)}"> defaultChecked</core_rt:if>"
+                           class="form-check-input licInfo trackChange trackChangeLicInfo<core_rt:if test="${licInfoAttUsages.containsKey(attachment.attachmentContentId)}"> defaultChecked</core_rt:if>"
                     />
                     <input type="checkbox"
                            name="<portlet:namespace/><%=PortalConstants.PROJECT_SELECTED_ATTACHMENT_USAGES_SHADOWS%>"
-                           value="${releaseLink.id}_<%=UsageData._Fields.LICENSE_INFO.getFieldName()%>_${attachment.attachmentContentId}"
-                           id="${releaseLink.id}_<%=UsageData._Fields.LICENSE_INFO.getFieldName()%>_${attachment.attachmentContentId}_shadow"
+                           value="${parentProjectPath}-${releaseLink.id}_<%=UsageData._Fields.LICENSE_INFO.getFieldName()%>_${attachment.attachmentContentId}"
+                           id="${parentProjectPath}-${releaseLink.id}_<%=UsageData._Fields.LICENSE_INFO.getFieldName()%>_${attachment.attachmentContentId}_shadow"
                            style="display:none"
                     />
+                </td>
+                <td>
+                  <core_rt:if test='${attachment.filename.toLowerCase().endsWith(".rdf")}'>
+                    <input type="checkbox"
+                           id="${parentProjectPath}-${releaseLink.id}_<%=PortalConstants.INCLUDE_CONCLUDED_LICENSE_SHADOWS%>_${attachment.attachmentContentId}"
+                           name="<portlet:namespace/><%=PortalConstants.INCLUDE_CONCLUDED_LICENSE%>"
+                           value="${parentProjectPath}-${releaseLink.id}_<%=UsageData._Fields.LICENSE_INFO.getFieldName()%>_${attachment.attachmentContentId}"
+                           <core_rt:if test="${!licenseInfoAttachmentTypes.contains(attachment.attachmentType) 
+                               or !licInfoAttUsages.containsKey(attachment.attachmentContentId) or !writeAccessUser}">disabled</core_rt:if>
+                           <core_rt:if test="${licInfoAttUsages.containsKey(attachment.attachmentContentId) 
+                               && licInfoAttUsages.get(attachment.attachmentContentId).usageData.licenseInfo.includeConcludedLicense}">checked="checked"</core_rt:if>
+                           class="form-check-input includeConcludedLicense trackChange trackChangeLicInfo<core_rt:if test="${licInfoAttUsages.containsKey(attachment.attachmentContentId) 
+                               && licInfoAttUsages.get(attachment.attachmentContentId).usageData.licenseInfo.includeConcludedLicense}"> defaultChecked</core_rt:if>"
+                    />
+                    <input type="checkbox"
+                           name="<portlet:namespace/><%=PortalConstants.INCLUDE_CONCLUDED_LICENSE_SHADOWS%>"
+                           value="${parentProjectPath}-${releaseLink.id}_<%=UsageData._Fields.LICENSE_INFO.getFieldName()%>_${attachment.attachmentContentId}"
+                           id="${parentProjectPath}-${releaseLink.id}_<%=PortalConstants.INCLUDE_CONCLUDED_LICENSE_SHADOWS%>_${attachment.attachmentContentId}_shadow"
+                           style="display:none"
+                    />
+                  </core_rt:if>
                 </td>
                 <td>
                     <input type="checkbox"

--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -228,6 +228,7 @@ components.with.the.same.identifier.name=Components with the same identifier [na
 component.type=Component Type
 ComponentType=OSS: &#10COTS: &#10Internal: &#10Inner-Source: &#10Service: &#10Freeware: &#10Code Snippet:
 concluded.license.ids=Concluded License Ids:
+conclusions=Conclusions
 confirm=3. Confirm
 connect=Connect
 connection.configuration=Connection Configuration

--- a/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
@@ -229,6 +229,7 @@ components.with.the.same.identifier.name=同じ識別子[名前]を持つコン�
 component.type=コンポーネントタイプ
 ComponentType=OSS: &#10COTS: &#10内部: &#10内部ソース: &#10サービス: &#10フリーウェア: &#10コードスニペット.
 concluded.license.ids=決定済みライセンスID.
+conclusions=Conclusions
 confirm=3. 確認
 connect=接続
 connection.configuration=接続構成

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -229,6 +229,7 @@ components.with.the.same.identifier.name=Các thành phần có cùng định da
 component.type=Loại thành phần
 ComponentType=OSS: &#10COTS: &#10Nội bộ: &#10Nguồn nội bộ: &#10Dịch vụ: &#10Phần mềm miễn phí: &#10Đoạn mã:
 concluded.license.ids=Id giấy phép kết luận:
+conclusions=Conclusions
 confirm=3. Xác nhận
 connect=Kết nối
 connection.configuration=Cấu hình kết nối

--- a/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtilsTest.java
+++ b/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtilsTest.java
@@ -125,7 +125,7 @@ public class ProjectPortletUtilsTest {
         List<AttachmentUsage> attachmentUsages = ProjectPortletUtils.selectedAttachmentUsagesFromRequest(request);
         Assert.assertThat(attachmentUsages, Matchers.containsInAnyOrder(
                 new AttachmentUsage(Source.releaseId("r1"), "att1", Source.projectId("p1"))
-                        .setUsageData(UsageData.licenseInfo(new LicenseInfoUsage(Collections.emptySet()))),
+                        .setUsageData(UsageData.licenseInfo(new LicenseInfoUsage(Collections.emptySet()).setIncludeConcludedLicense(false))),
                 new AttachmentUsage(Source.releaseId("r2"), "att2", Source.projectId("p1"))
                         .setUsageData(UsageData.sourcePackage(new SourcePackageUsage()))
         ));

--- a/libraries/lib-datahandler/src/main/thrift/attachments.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/attachments.thrift
@@ -123,6 +123,7 @@ union UsageData {
 struct LicenseInfoUsage {
     1: required set<string> excludedLicenseIds;
     2: optional string projectPath;
+    3: optional bool includeConcludedLicense = true;
 }
 
 /**

--- a/libraries/lib-datahandler/src/main/thrift/licenseinfo.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/licenseinfo.thrift
@@ -115,7 +115,7 @@ service LicenseInfoService {
     /**
      * parses the attachment of one release for license information and returns the result.
      */
-    list<LicenseInfoParsingResult> getLicenseInfoForAttachment(1: Release release, 2: string attachmentContentId, 3: User user);
+    list<LicenseInfoParsingResult> getLicenseInfoForAttachment(1: Release release, 2: string attachmentContentId, 3: bool includeConcludedLicense, 4: User user);
 
     /**
      * parses the attachment of one release for obligations information and returns the result.
@@ -137,7 +137,7 @@ service LicenseInfoService {
      * get a copyright and license information file on all linked releases and linked releases of linked projects (recursively)
      * output format as specified by outputType
      */
-    LicenseInfoFile getLicenseInfoFile(1: Project project, 2: User user, 3: string outputGeneratorClassName, 4: map<string, set<string>> releaseIdsToSelectedAttachmentIds, 5: map<string, set<LicenseNameWithText>> excludedLicensesPerAttachment, 6: string externalIds);
+    LicenseInfoFile getLicenseInfoFile(1: Project project, 2: User user, 3: string outputGeneratorClassName, 4: map<string, map<string, bool>> releaseIdsToSelectedAttachmentIds, 5: map<string, set<LicenseNameWithText>> excludedLicensesPerAttachment, 6: string externalIds);
 
     /**
       * returns all available output types

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licenseinfo/Sw360LicenseInfoService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licenseinfo/Sw360LicenseInfoService.java
@@ -49,7 +49,8 @@ public class Sw360LicenseInfoService {
     }
 
     public LicenseInfoFile getLicenseInfoFile(Project project, User sw360User, String generatorClassNameWithVariant,
-                                              Map<String, Set<String>> selectedReleaseAndAttachmentIds, Map<String, Set<LicenseNameWithText>> excludedLicenses, String externalIds) {
+            Map<String, Map<String, Boolean>> selectedReleaseAndAttachmentIds,
+            Map<String, Set<LicenseNameWithText>> excludedLicenses, String externalIds) {
         try {
             LicenseInfoService.Iface sw360LicenseInfoClient = getThriftLicenseInfoClient();
             return sw360LicenseInfoClient.getLicenseInfoFile(project, sw360User, generatorClassNameWithVariant, selectedReleaseAndAttachmentIds, excludedLicenses, externalIds);
@@ -58,10 +59,10 @@ public class Sw360LicenseInfoService {
         }
     }
 
-    public List<LicenseInfoParsingResult> getLicenseInfoForAttachment(Release release, User sw360User, String attachmentContentId) {
+    public List<LicenseInfoParsingResult> getLicenseInfoForAttachment(Release release, User sw360User, String attachmentContentId, boolean includeConcludedLicense) {
         try {
             LicenseInfoService.Iface sw360LicenseInfoClient = getThriftLicenseInfoClient();
-            return sw360LicenseInfoClient.getLicenseInfoForAttachment(release, attachmentContentId, sw360User);
+            return sw360LicenseInfoClient.getLicenseInfoForAttachment(release, attachmentContentId, includeConcludedLicense, sw360User);
         } catch (TException e) {
             throw new RuntimeException(e);
         }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -349,6 +349,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         LicenseInfoUsage licenseInfoUsage1 = new LicenseInfoUsage(new HashSet<>());
         licenseInfoUsage1.setProjectPath("11223344:22334455");
         licenseInfoUsage1.setExcludedLicenseIds(Sets.newHashSet("22334455", "9988776655"));
+        licenseInfoUsage1.setIncludeConcludedLicense(false);
         UsageData usageData1 = new UsageData();
         usageData1.setLicenseInfo(licenseInfoUsage1);
         AttachmentUsage attachmentUsage1 = new AttachmentUsage(ownerSrc1, "aa1122334455bbcc", usedBySrc);
@@ -359,6 +360,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         LicenseInfoUsage licenseInfoUsage2 = new LicenseInfoUsage(new HashSet<>());
         licenseInfoUsage2.setProjectPath("11223344:22334455:445566778899");
         licenseInfoUsage2.setExcludedLicenseIds(Sets.newHashSet("44553322", "5566778899"));
+        licenseInfoUsage2.setIncludeConcludedLicense(true);
         UsageData usageData2 = new UsageData();
         usageData2.setLicenseInfo(licenseInfoUsage2);
         AttachmentUsage attachmentUsage2 = new AttachmentUsage(ownerSrc2, "aa1122334455ee", usedBySrc);
@@ -485,6 +487,8 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                 .description("The list of excluded License Ids."),
                         fieldWithPath("sw360:attachmentUsages[]usageData.licenseInfo.projectPath").description(
                                 "The hierarchy of project in which attachment is used. Ex: projectId1:subProjectId1:subProjectId2"),
+                        fieldWithPath("sw360:attachmentUsages[]usageData.licenseInfo.includeConcludedLicense").description(
+                                "Value to indicate whether to include concluded license"),
                         fieldWithPath("sw360:attachmentUsages").description(
                                 "An array of <<resources-project-get-attachmentusage, AttachmentUsages resources>>"))));
     }


### PR DESCRIPTION
> Provided option in attachment usage to include/exclude concluded licenses during LicenseInfo Generation
> * Which issue is this pull request belonging to and how is it solving it? (*#1074*)
> * Did you add or update any new dependencies that are required for your change?

### How To Test? - Refer #1074 
> - Change Attachment Usage with different file types from Attachment Tab and From LicenseInfo/Report Generation Page.
      - Verify Attachement Usage with proper info are getting created and deleted from DB based on selection. 
> - Old Attachement Usages should function normally - by default conclusions are included.
> - Download LicenseInfo and Report in different format with/without conclusions from UI and Rest

> Have you implemented any additional tests? - No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>