### PR TITLE
chore(eclipse): Publish SW360 artifacts in Eclipse infrastructure

### DIFF
--- a/jenkins.eclipse/Dockerfile
+++ b/jenkins.eclipse/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright (c) Bosch.IO GmbH 2021.
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+
+# This file is the basis for building SW360 in the Eclipse Foundation Jenkins Infrastructure.
+# The image has to be published to Docker Hub with the tag eclipse/sw360buildenv.
+# To publish the image, you need write access to the repository in the Docker Hub eclipse organization.
+# Versioning is done by a single number, e.g., eclipse/sw360buildenv:1
+# 
+# Build and push it from the jenkins-eclipse folder with
+# $ docker build -t eclipse/sw360buildenv:<version> --rm=true --force-rm=true .
+# $ docker login --username=yourhubuser --password-stdin
+# $ sudo docker push eclipse/sw360buildenv
+# 
+# See the Jenkinsfile for usage within the Jenkins environment.
+
+FROM maven:3.6.3-jdk-11
+
+ADD install-thrift.sh /install-thrift.sh
+RUN /install-thrift.sh
+
+CMD /bin/bash

--- a/jenkins.eclipse/Jenkinsfile
+++ b/jenkins.eclipse/Jenkinsfile
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Bosch.IO GmbH 2021.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+pipeline {
+    agent {
+        kubernetes {
+            label 'sw360-agent-pod'
+            yaml """
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - name: sw360buildenv
+    image: eclipse/sw360buildenv:2
+    tty: true
+    command:
+    - cat
+    env:
+    - name: "MAVEN_OPTS"
+      value: "-Duser.home=/home/jenkins -Xms2G -Xmx2G"
+    resources:
+      requests:
+        memory: "2048Mi"
+      limits:
+        memory: "2048Mi"
+    volumeMounts:
+    - name: settings-xml
+      mountPath: /home/jenkins/.m2/settings.xml
+      subPath: settings.xml
+      readOnly: true
+    - name: settings-security-xml
+      mountPath: /home/jenkins/.m2/settings-security.xml
+      subPath: settings-security.xml
+      readOnly: true
+    - name: m2-repo
+      mountPath: /home/jenkins/.m2/repository
+  volumes:
+  - name: settings-xml
+    secret:
+      secretName: m2-secret-dir
+      items:
+      - key: settings.xml
+        path: settings.xml
+  - name: settings-security-xml
+    secret:
+      secretName: m2-secret-dir
+      items:
+      - key: settings-security.xml
+        path: settings-security.xml
+  - name: m2-repo
+    emptyDir: {}
+"""
+        }
+    }
+
+    stages {
+        stage('Deploy SW360') {
+            steps {
+                container('sw360buildenv') {
+                    // FIXME: Removed the frontend from the build, because it does not build in the Container environment
+                    // Plugin liferay-themes breaks the build
+                    // FIXME: Removed backend utils form the build, it causes issues with signing the fat jar
+                    sh """
+                        mvn --batch-mode -Peclipse-ci \
+                            clean deploy \
+                            -pl '!frontend/sw360-portlet,!frontend/liferay-theme,!frontend,!backend/utils' \
+                            -DskipTests -DskipITs
+                    """
+                }
+            }
+        }
+    }
+}

--- a/jenkins.eclipse/buildContainer.sh
+++ b/jenkins.eclipse/buildContainer.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright (c) Bosch.IO GmbH 2021.
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+
+# Usage ./buildContainer.sh <version>
+
+if [ -z "$1" ]
+  then
+    echo "No version supplied"
+    exit 1
+fi
+
+echo "Script assumes that you are already logged into docker hub for pushing the new image."
+echo "If not, please run 'docker login --username=<yourhubuser> --password-stdin' prior to running the script."
+
+cp ../scripts/install-thrift.sh .
+docker build -t eclipse/sw360buildenv:$1 --rm=true --force-rm=true .
+sudo docker push eclipse/sw360buildenv:$1
+sudo docker push eclipse/sw360buildenv
+rm -f install-thrift.sh
+
+echo "Please update Jenkinsfile to new version and push the change."

--- a/pom.xml
+++ b/pom.xml
@@ -701,5 +701,68 @@
             <patchlevel>0.${count}</patchlevel>
         </properties>
         </profile>
+        <profile>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <id>eclipse-ci</id>
+
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>repo.eclipse.org</id>
+                    <url>https://repo.eclipse.org/content/repositories/cbi</url>
+                    <releases>
+                      <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                      <enabled>true</enabled>
+                    </snapshots>        
+                </pluginRepository>
+            </pluginRepositories>
+
+            <distributionManagement>
+                <repository>
+                    <id>repo.eclipse.org</id>
+                    <name>Project Repository - Releases</name>
+                    <url>https://repo.eclipse.org/content/repositories/sw360-releases/</url>
+                </repository>
+                <snapshotRepository>
+                    <id>repo.eclipse.org</id>
+                    <name>Project Repository - Snapshots</name>
+                    <url>https://repo.eclipse.org/content/repositories/sw360-snapshots/</url>
+                </snapshotRepository>
+            </distributionManagement>
+            
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.eclipse.cbi.maven.plugins</groupId>
+                            <artifactId>eclipse-jarsigner-plugin</artifactId>
+                            <version>1.1.5</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.eclipse.cbi.maven.plugins</groupId>
+                        <artifactId>eclipse-jarsigner-plugin</artifactId>
+                        <configuration>
+                            <resigningStrategy>OVERWRITE</resigningStrategy>
+                            <excludeInnerJars>true</excludeInnerJars>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>sign</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                     </plugin>        
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Add the necessary infrastructure for publishing SW360 artifacts in the Eclipse Maven Repository.

Contains:

- Dockerfile for a build container published to Docker Hub, that is used in the Eclipse environment for the build. The container has to be published manually, a script for doing that and a readme for the container is provided additionally
- Jenkinsfile that is used by the EF Jenkins infrastructure

Issue: #981

Issue is not completely solved, since this pr only adds snapshot releases, real releases and milestones will be added with an additional change.

### Suggest Reviewer
n/a

### How To Test?
Test is to run the SW360 build on our Jenkins server https://ci.eclipse.org/sw360/

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
