### PR TITLE
fix(spdx): import large spdx rdf files

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTools.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTools.java
@@ -16,28 +16,72 @@ import com.google.common.collect.Sets;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.*;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.spdx.rdfparser.InvalidSPDXAnalysisException;
-import org.spdx.rdfparser.license.*;
-import org.spdx.rdfparser.model.*;
+import org.apache.jena.ext.xerces.util.XMLChar;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Node;
+import org.w3c.dom.Element;
+
+import org.apache.jena.rdf.model.impl.Util;
 
 import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhitespace;
 
 public class SPDXParserTools {
-
-    private static final Logger log = LogManager.getLogger(SPDXParserTools.class);
-
-    private static final String LICENSE_REF_PREFIX = "LicenseRef-";
-
     private static final String PROPERTIES_FILE_PATH = "/sw360.properties";
     private static final String PROPERTY_KEY_USE_LICENSE_INFO_FROM_FILES = "licenseinfo.spdxparser.use-license-info-from-files";
     private static final boolean USE_LICENSE_INFO_FROM_FILES;
+
+    private static final String XML_LITERAL = "^^http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral";
+    private static final String LICENSE_REF_PREFIX = "LicenseRef-";
+    private static final String RELATIONSHIP_TYPE_DESCRIBES = "relationshipType_describes";
+
+    // Namespace
+    private static final String SPDX_NAMESPACE = "http://spdx.org/rdf/terms#";
+    private static final String RDF_NAMESPACE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+
+    // RDF Properties
+    private static final String RDF_ABOUT = "about";
+    private static final String RDF_RESOURCE = "resource";
+    private static final String RDF_NODEID = "nodeID";
+
+    // SPDX Class
+    private static final String SPDX_FILE = "File";
+    private static final String SPDX_LICENSE = "License";
+    private static final String SPDX_PACKAGE = "Package";
+    private static final String SPDX_EXTRACTED_LICENSING_INFO = "ExtractedLicensingInfo";
+    private static final String SPDX_CONJUNCTIVE_LICENSE_SET = "ConjunctiveLicenseSet";
+    private static final String SPDX_DISJUNCTIVE_LICENSE_SET = "DisjunctiveLicenseSet";
+
+    private static final String SPDX_LICENSE_CONCLUDED = "licenseConcluded";
+    private static final String SPDX_MEMBER = "member";
+    private static final String SPDX_NAME = "name";
+    private static final String SPDX_LICENSE_ID = "licenseId";
+    private static final String SPDX_LICENSE_TEXT = "licenseText";
+    private static final String SPDX_EXTRACTED_TEXT = "extractedText";
+    private static final String SPDX_LICENSE_INFO_IN_FILE = "licenseInfoInFile";
+    private static final String SPDX_LICENSE_INFO_FROM_FILES = "licenseInfoFromFiles";
+    private static final String SDPX_LICENSE_INFO_IN_SNIPPETS = "licenseInfoInSnippet";
+    private static final String SPDX_SNIPPET_FROM_FILE = "snippetFromFile";
+    private static final String SPDX_LICENSE_DECLARED = "licenseDeclared";
+    private static final String SPDX_COPYRIGHT_TEXT = "copyrightText";
+    private static final String SPDX_RELATIONSHIP_TYPE = "relationshipType";
+    private static final String SPDX_RELATED_SPDX_ELEMENT = "relatedSpdxElement";
+    private static final String SPDX_LICENSE_NAME_VERSION_1 = "licenseName"; // old property name (pre 1.2 spec)
+    private static final String SPDX_REFERENCES_FILE = "referencesFile";
+    private static final String SPDX_HAS_FILE = "hasFile";
+    private static final String SPDX_DESCRIBES_PACKAGE = "describesPackage"; // old property name (pre 1.2 spec)
+
+    // Store spdx:License and spdx:ExtractedLicensingInfo index by their URI
+    private static HashMap<String, LicenseNameWithText> uriLicenseMap = new HashMap<String, LicenseNameWithText>();
+
+    // Store spdx:referencesFile index by their nodeID
+    private static HashMap<String, Element> nodeIDFileMap = new HashMap<String, Element>();
 
     static {
         Properties properties = CommonUtils.loadProperties(SPDXParserTools.class, PROPERTIES_FILE_PATH);
@@ -45,182 +89,529 @@ public class SPDXParserTools {
                 .valueOf(properties.getOrDefault(PROPERTY_KEY_USE_LICENSE_INFO_FROM_FILES, "true").toString());
     }
 
-    private static String extractLicenseName(AnyLicenseInfo licenseConcluded) {
-        return licenseConcluded.getResource().getLocalName();
+    // Make NodeList be iterable
+    private static Iterable<Node> iterable(final NodeList nodeList) {
+        return () -> new Iterator<Node>() {
+            private int index = 0;
+
+            @Override
+            public boolean hasNext() {
+                return index < nodeList.getLength();
+            }
+
+            @Override
+            public Node next() {
+                if (!hasNext())
+                    throw new NoSuchElementException();
+                return nodeList.item(index++);
+            }
+        };
     }
 
-    private static String extractLicenseName(ExtractedLicenseInfo extractedLicenseInfo) {
-        return !isNullEmptyOrWhitespace(extractedLicenseInfo.getName())
-                ? extractedLicenseInfo.getName()
-                : extractedLicenseInfo.getLicenseId().replaceAll(LICENSE_REF_PREFIX, "");
+    /*
+     * Get localName. Examples: http://spdx.org/rdf/terms#noassertion: localName is
+     * noassertion. http://spdx.org/licenses/LGPL-2.1: localName is LGPL-2.1.
+     * spdx:Package: localName is Package.
+     */
+    private static String getLocalName(String label) {
+        for (int i = 0; i < label.length(); i++) {
+            // label contain invalid NCName
+            if (!XMLChar.isNCName(label.charAt(i))) {
+                return label.substring(Util.splitNamespaceXML(label));
+            }
+        }
+        return label;
     }
 
+    /*
+     * Get node name without its namespace
+     */
+    private static String getNodeName(Node n) {
+        return n != null ? getLocalName(n.getNodeName()) : "";
+    }
 
-    private static Stream<LicenseNameWithText> getAllLicenseTextsFromInfo(AnyLicenseInfo spdxLicenseInfo) {
-        log.trace("Seen the spdxLicenseInfo=" + spdxLicenseInfo.toString() + "]");
-        if (spdxLicenseInfo instanceof LicenseSet) {
+    /*
+     * Get localName in attribute rdf:about or rdf:resource
+     */
+    private static String getResourceLocalName(Node n) {
+        if (n instanceof Element) {
+            Element e = (Element) n;
+            String[] attrs = { RDF_ABOUT, RDF_RESOURCE };
+            for (String attr : attrs) {
+                String label = e.getAttributeNS(RDF_NAMESPACE, attr);
+                if (!isNullEmptyOrWhitespace(label)) {
+                    return getLocalName(label);
+                }
+            }
+        }
+        return "";
+    }
 
-            LicenseSet LicenseSet = (LicenseSet) spdxLicenseInfo;
-            return Arrays.stream(LicenseSet.getMembers())
-                    .flatMap(SPDXParserTools::getAllLicenseTextsFromInfo);
+    /*
+     * Find all nodes (in all levels) with 'localName' inside node 'parent'.
+     */
+    private static Node[] findMultipleSpdxNodes(Node parent, String localName) {
+        NodeList childNodes = null;
+        if (parent instanceof Element) {
+            Element e = (Element) parent;
+            childNodes = e.getElementsByTagNameNS(SPDX_NAMESPACE, localName);
 
-        } else if (spdxLicenseInfo instanceof ExtractedLicenseInfo) {
+            // In ealier version (eg. v1.1), spdx document doesn't have namespace.
+            if (childNodes.getLength() == 0) {
+                childNodes = e.getElementsByTagName(localName);
+            }
+        } else if (parent instanceof Document) {
+            Document doc = (Document) parent;
+            childNodes = doc.getElementsByTagNameNS(SPDX_NAMESPACE, localName);
 
-            ExtractedLicenseInfo extractedLicenseInfo = (ExtractedLicenseInfo) spdxLicenseInfo;
-            return Stream.of(new LicenseNameWithText()
-                    .setLicenseName(extractLicenseName(extractedLicenseInfo))
-                    .setLicenseText(extractedLicenseInfo.getExtractedText()));
+            // In ealier version (eg. v1.1), spdx document doesn't have namespace.
+            if (childNodes.getLength() == 0) {
+                childNodes = doc.getElementsByTagName(localName);
+            }
+        }
 
-        } else if (spdxLicenseInfo instanceof License) {
+        if (childNodes == null) {
+            return new Node[] {};
+        }
 
-            License license = (License) spdxLicenseInfo;
-            return Stream.of(new LicenseNameWithText()
-                    .setLicenseName(extractLicenseName(license))
-                    .setLicenseText(license.getLicenseText()));
+        // Convert NodeList to Array
+        int noChilds = childNodes.getLength();
+        Node[] children = new Node[noChilds];
+        for (int i = 0; i < noChilds; i++) {
+            children[i] = childNodes.item(i);
+        }
 
-        } else if (spdxLicenseInfo instanceof OrLaterOperator) {
+        return children;
+    }
 
-            OrLaterOperator orLaterOperator = (OrLaterOperator) spdxLicenseInfo;
-            return getAllLicenseTextsFromInfo(orLaterOperator.getLicense())
-                    .map(lnwt -> lnwt.setLicenseName(lnwt.getLicenseName() + " or later"));
+    /*
+     * Find all childs with 'localName' in node 'parent'.
+     */
+    private static Node[] findMultipleSpdxChilds(Node parent, String localName) {
+        List<Node> childList = new ArrayList<>();
+        NodeList childs = parent.getChildNodes();
+        for (Node child : iterable(childs)) {
+            if (!isNullEmptyOrWhitespace(child.getLocalName()) && child.getLocalName().equals(localName)) {
+                childList.add(child);
+            }
+        }
 
-        } else if (spdxLicenseInfo instanceof WithExceptionOperator) {
+        // Convert List to Array
+        int noChilds = childList.size();
+        Node[] childArray = new Node[noChilds];
+        for (int i = 0; i < noChilds; i++) {
+            childArray[i] = childList.get(i);
+        }
+        return childArray;
+    }
 
-            WithExceptionOperator withExceptionOperator = (WithExceptionOperator) spdxLicenseInfo;
-            String licenseExceptionText = withExceptionOperator.getException()
-                    .getLicenseExceptionText();
-            return getAllLicenseTextsFromInfo(withExceptionOperator.getLicense())
-                    .map(licenseNWT -> licenseNWT
-                            .setLicenseText(licenseNWT.getLicenseText() + "\n\n" + licenseExceptionText)
-                            .setLicenseName(licenseNWT.getLicenseName() + " with " + withExceptionOperator.getException().getName()));
+    /*
+     * Find content of the first node that matches query.
+     */
+    private static String findFirstSpdxNodeContent(Node parent, String localName) {
+        Node[] childNodes = findMultipleSpdxNodes(parent, localName);
+        return childNodes.length > 0 ? childNodes[0].getTextContent() : "";
+    }
+
+    /*
+     * Find content of the first child that matches query.
+     */
+    private static String findFirstSpdxChildContent(Node parent, String localName) {
+        Node[] childNodes = findMultipleSpdxChilds(parent, localName);
+        return childNodes.length > 0 ? childNodes[0].getTextContent() : "";
+    }
+
+    /*
+     * Get license name of spdx:ExtractedLicensingInfo.
+     */
+    private static String getExtractedLicenseName(Node extractedLicenseInfo) {
+        String[] tagNames = { SPDX_NAME, SPDX_LICENSE_NAME_VERSION_1, SPDX_LICENSE_ID };
+        for (String tagName : tagNames) {
+            String name = findFirstSpdxNodeContent(extractedLicenseInfo, tagName);
+            if (!isNullEmptyOrWhitespace(name)) {
+                return name.replace(LICENSE_REF_PREFIX, "");
+            }
+        }
+        return "";
+    }
+
+    /*
+     * Get content of spdx:extractedText.
+     */
+    private static String getExtractedText(Node extractedLicenseInfo) {
+        return findFirstSpdxNodeContent(extractedLicenseInfo, SPDX_EXTRACTED_TEXT);
+    }
+
+    /*
+     * Get content of spdx:licenseText.
+     */
+    private static String getLicenseText(Node license) {
+        String licenseText = findFirstSpdxNodeContent(license, SPDX_LICENSE_TEXT);
+        if (!isNullEmptyOrWhitespace(licenseText) && licenseText.endsWith(XML_LITERAL)) {
+            licenseText = licenseText.substring(0, licenseText.length() - XML_LITERAL.length());
+        }
+        return licenseText;
+    }
+
+    /*
+     * Get spdx:member nodes.
+     */
+    private static Node[] getMembers(Node licenseSet) {
+        return findMultipleSpdxChilds(licenseSet, SPDX_MEMBER);
+    }
+
+    /*
+     * Get license ID in spdx:licenseId.
+     */
+    private static String getLicenseId(Node spdxLicenseInfo) {
+        return findFirstSpdxNodeContent(spdxLicenseInfo, SPDX_LICENSE_ID).replace(LICENSE_REF_PREFIX, "");
+    }
+
+    /*
+     * Get content of spdx:copyrightText.
+     */
+    private static String getCopyrightText(Node spdxItem) {
+        return findFirstSpdxChildContent(spdxItem, SPDX_COPYRIGHT_TEXT);
+    }
+
+    /*
+     * Get spdx:licenseConcluded node.
+     */
+    private static Node getLicenseConcluded(Node spdxItem) {
+        Node[] licenseConcludedNodes = findMultipleSpdxChilds(spdxItem, SPDX_LICENSE_CONCLUDED);
+        return licenseConcludedNodes.length > 0 ? licenseConcludedNodes[0] : null;
+    }
+
+    /*
+     * Get license info from File. This info is in spdx:licenseInfoInFile
+     * spdx:licenseInfoInSnippet or spdx:licenseInfoFromFiles.
+     */
+    private static Node[] getLicenseInfoFromFiles(Node spdxItem) {
+        String licenseInfoNodeName = SPDX_LICENSE_INFO_FROM_FILES;
+        switch (getNodeName(spdxItem)) {
+            case SPDX_FILE:
+                licenseInfoNodeName = SPDX_LICENSE_INFO_IN_FILE;
+                break;
+            case SPDX_SNIPPET_FROM_FILE:
+                licenseInfoNodeName = SDPX_LICENSE_INFO_IN_SNIPPETS;
+                break;
+            default:
+                break;
+        }
+
+        return findMultipleSpdxChilds(spdxItem, licenseInfoNodeName);
+    }
+
+    /*
+     * Get spdx:licenseDeclared in spdx:Package.
+     */
+    private static Node getLicenseDeclared(Node spdxPackage) {
+        Node[] licenseDeclareds = findMultipleSpdxChilds(spdxPackage, SPDX_LICENSE_DECLARED);
+        return licenseDeclareds.length > 0 ? licenseDeclareds[0] : null;
+    }
+
+    /*
+     * Get all licenses with text in spdx:ExtractedLicensingInfo and spdx:License
+     * with their uri.
+     */
+    private static HashMap<String, LicenseNameWithText> getLicenseTextFromMetadata(Document doc) {
+        HashMap<String, LicenseNameWithText> uriLicenseMap = new HashMap<String, LicenseNameWithText>();
+        String[] licenseTags = { SPDX_EXTRACTED_LICENSING_INFO, SPDX_LICENSE };
+
+        for (String licenseTag : licenseTags) {
+            Node[] licenses = findMultipleSpdxNodes(doc, licenseTag);
+            for (Node license : licenses) {
+                if (license instanceof Element) {
+                    Element e = (Element) license;
+                    String uri = e.getAttributeNS(RDF_NAMESPACE, RDF_ABOUT);
+
+                    // In earlier version, rdf:nodeID is used instead of rdf:about
+                    if (isNullEmptyOrWhitespace(uri))
+                        uri = e.getAttributeNS(RDF_NAMESPACE, RDF_NODEID);
+
+                    if (isNullEmptyOrWhitespace(uri))
+                        continue;
+
+                    String licenseName = extractLicenseName(e);
+                    String licenseID = getLicenseId(e);
+                    String licenseText = getExtractedText(e);
+                    if (isNullEmptyOrWhitespace(licenseText))
+                        licenseText = getLicenseText(e);
+                    uriLicenseMap.put(uri, new LicenseNameWithText().setLicenseName(licenseName)
+                            .setLicenseText(licenseText).setLicenseSpdxId(licenseID));
+                }
+            }
+        }
+
+        return uriLicenseMap;
+    }
+
+    /*
+     * Get all spdx:File in spdx:referencesFile. In ealier version, File is not in
+     * Package, but referencesFile.
+     */
+    private static HashMap<String, Element> getFileFromMetadata(Document doc) {
+        HashMap<String, Element> nodeIDFileMap = new HashMap<String, Element>();
+        Node[] referencesFiles = findMultipleSpdxNodes(doc, SPDX_REFERENCES_FILE);
+        for (Node referencesFile : referencesFiles) {
+            Node[] spdxFiles = findMultipleSpdxNodes(referencesFile, SPDX_FILE);
+            for (Node spdxFile : spdxFiles) {
+                if (spdxFile instanceof Element) {
+                    Element e = (Element) spdxFile;
+                    String uri = e.getAttributeNS(RDF_NAMESPACE, RDF_NODEID);
+                    if (!isNullEmptyOrWhitespace(uri)) {
+                        nodeIDFileMap.put(uri, e);
+                    }
+                }
+            }
+        }
+        return nodeIDFileMap;
+    }
+
+    /*
+     * Find license in uriLicenseMap.
+     */
+    private static LicenseNameWithText findInURILicenseMap(Node node) {
+        if (node instanceof Element) {
+            Element e = (Element) node;
+            String uri = e.getAttributeNS(RDF_NAMESPACE, RDF_RESOURCE);
+
+            // In earlier version (ex. v1.2), license is indexed by nodeID
+            if (isNullEmptyOrWhitespace(uri))
+                uri = e.getAttributeNS(RDF_NAMESPACE, RDF_NODEID);
+
+            if (!isNullEmptyOrWhitespace(uri) && uriLicenseMap.containsKey(uri))
+                return uriLicenseMap.get(uri);
+        }
+
+        return null;
+    }
+
+    /*
+     * Find file in nodeIDFileMap.
+     */
+    private static Node findInNodeIDFileMap(Node node) {
+        if (node instanceof Element) {
+            Element e = (Element) node;
+            String uri = e.getAttributeNS(RDF_NAMESPACE, RDF_NODEID);
+            if (!isNullEmptyOrWhitespace(uri) && nodeIDFileMap.containsKey(uri))
+                return nodeIDFileMap.get(uri);
+        }
+
+        return null;
+    }
+
+    /*
+     * Get spdx:File in spdx:Package.
+     */
+    private static Node[] getFiles(Node spdxPackage) {
+        Node[] filesInPackage = findMultipleSpdxNodes(spdxPackage, SPDX_FILE);
+
+        // In earlier version, spdx:File is stored in spdx:referencesFile,
+        // and spdx:Package contains spdx:hasFile map by nodeID.
+        List<Node> fileList = new ArrayList<>();
+        Node[] hasFiles = findMultipleSpdxNodes(spdxPackage, SPDX_HAS_FILE);
+        for (Node hasFile : hasFiles) {
+            Node file = findInNodeIDFileMap(hasFile);
+            if (file != null)
+                fileList.add(file);
 
         }
-        log.debug("the spdxLicenseInfo=[" + spdxLicenseInfo.toString() + "] did not contain any license information");
 
+        Node[] spdxFiles = new Node[fileList.size() + filesInPackage.length];
+        int i = 0;
+        for (Node spdxFile : fileList) {
+            spdxFiles[i] = spdxFile;
+            i++;
+        }
+        for (Node spdxFile : filesInPackage) {
+            spdxFiles[i] = spdxFile;
+            i++;
+        }
+
+        return spdxFiles;
+    }
+
+    /*
+     * Get all Elements that are child of all spdx:redlatedSpdxElement that have
+     * relationshipType_describes with document.
+     */
+    private static List<Node> getDocumentDescribes(Document doc) {
+        Node[] relTypeNodes = findMultipleSpdxNodes(doc, SPDX_RELATIONSHIP_TYPE);
+        List<Node> retval = new ArrayList<>();
+        for (Node relTypeNode : relTypeNodes) {
+            String relType = getResourceLocalName(relTypeNode);
+            if (relType.equals(RELATIONSHIP_TYPE_DESCRIBES)) {
+                Node parentNode = relTypeNode.getParentNode();
+                Node[] relatedElementNodes = findMultipleSpdxNodes(parentNode, SPDX_RELATED_SPDX_ELEMENT);
+                for (Node relatedElementNode : relatedElementNodes) {
+                    NodeList packageNodes = relatedElementNode.getChildNodes();
+                    for (Node child : iterable(packageNodes)) {
+                        retval.add(child);
+                    }
+                }
+            }
+        }
+
+        // In ealier version, spdx used spdx:describesPackage instead
+        Node[] describesPackages = findMultipleSpdxNodes(doc, SPDX_DESCRIBES_PACKAGE);
+        for (Node describesPackage : describesPackages) {
+            NodeList packageNodes = describesPackage.getChildNodes();
+            for (Node child : iterable(packageNodes)) {
+                retval.add(child);
+            }
+        }
+
+        return retval;
+    }
+
+    private static String extractLicenseName(Node license) {
+        switch (getNodeName(license)) {
+            case SPDX_EXTRACTED_LICENSING_INFO:
+                return getExtractedLicenseName(license);
+            default:
+                LicenseNameWithText lwt = findInURILicenseMap(license);
+                if (lwt != null) {
+                    return lwt.getLicenseName();
+                }
+
+                return getResourceLocalName(license).replace(LICENSE_REF_PREFIX, "");
+        }
+    }
+
+    private static Stream<LicenseNameWithText> getAllLicenseTextsFromInfo(Node spdxLicenseInfo) {
+        switch (getNodeName(spdxLicenseInfo)) {
+            case SPDX_CONJUNCTIVE_LICENSE_SET:
+            case SPDX_DISJUNCTIVE_LICENSE_SET:
+                return Arrays.stream(getMembers(spdxLicenseInfo)).flatMap(SPDXParserTools::getAllLicenseTextsFromInfo);
+            case SPDX_EXTRACTED_LICENSING_INFO:
+                return Stream.of(new LicenseNameWithText().setLicenseName(extractLicenseName(spdxLicenseInfo))
+                        .setLicenseText(getExtractedText(spdxLicenseInfo))
+                        .setLicenseSpdxId(getLicenseId(spdxLicenseInfo)));
+            case SPDX_LICENSE:
+                return Stream.of(new LicenseNameWithText().setLicenseName(extractLicenseName(spdxLicenseInfo))
+                        .setLicenseText(getLicenseText(spdxLicenseInfo))
+                        .setLicenseSpdxId(getLicenseId(spdxLicenseInfo)));
+            case SPDX_LICENSE_CONCLUDED:
+            case SPDX_MEMBER:
+                if (spdxLicenseInfo.hasChildNodes()) {
+                    NodeList childNodes = spdxLicenseInfo.getChildNodes();
+                    return IntStream.range(0, childNodes.getLength()).mapToObj(childNodes::item)
+                            .flatMap(SPDXParserTools::getAllLicenseTextsFromInfo);
+                }
+            default:
+                LicenseNameWithText lwt = findInURILicenseMap(spdxLicenseInfo);
+                if (lwt != null) {
+                    return Stream.of(lwt);
+                }
+
+                String licenseName = extractLicenseName(spdxLicenseInfo);
+                if (!isNullEmptyOrWhitespace(licenseName)) {
+                    return Stream.of(new LicenseNameWithText().setLicenseName(licenseName).setLicenseText(""));
+                }
+        }
         return Stream.empty();
     }
 
-    private static Stream<LicenseNameWithText> getAllLicenseTexts(SpdxItem spdxItem, boolean useLicenseInfoFromFiles, boolean includeConcludedLicense) {
-        Stream<LicenseNameWithText> licenseTexts = null;
+    private static Set<LicenseNameWithText> getAllLicenseTexts(Node spdxItem, boolean useLicenseInfoFromFiles,
+            boolean includeConcludedLicense) {
+        Set<LicenseNameWithText> licenseTexts = new HashSet<>();
         if (includeConcludedLicense) {
-            licenseTexts = getAllLicenseTextsFromInfo(spdxItem.getLicenseConcluded());
-        } else {
-            licenseTexts = Stream.<LicenseNameWithText>empty();
+            licenseTexts = getAllLicenseTextsFromInfo(getLicenseConcluded(spdxItem))
+                    .collect(Collectors.toCollection(HashSet::new));
         }
 
         if (useLicenseInfoFromFiles) {
-            licenseTexts = Stream.concat(licenseTexts,
-                    Arrays.stream(spdxItem.getLicenseInfoFromFiles())
-                            .flatMap(SPDXParserTools::getAllLicenseTextsFromInfo));
+            licenseTexts.addAll(Arrays.stream(getLicenseInfoFromFiles(spdxItem))
+                    .flatMap(SPDXParserTools::getAllLicenseTextsFromInfo)
+                    .collect(Collectors.toCollection(HashSet::new)));
         }
 
-        if (spdxItem instanceof SpdxPackage) {
-            SpdxPackage spdxPackage = (SpdxPackage) spdxItem;
-            try {
-                licenseTexts = Stream.concat(licenseTexts,
-                        getAllLicenseTextsFromInfo(spdxPackage.getLicenseDeclared()));
+        if (getNodeName(spdxItem).equals(SPDX_PACKAGE)) {
+            licenseTexts.addAll(getAllLicenseTextsFromInfo(getLicenseDeclared(spdxItem))
+                    .collect(Collectors.toCollection(HashSet::new)));
 
-                for (SpdxFile spdxFile : spdxPackage.getFiles()) {
-                    licenseTexts = Stream.concat(licenseTexts,
-                            getAllLicenseTexts(spdxFile, useLicenseInfoFromFiles, includeConcludedLicense));
-                }
-            } catch (InvalidSPDXAnalysisException e) {
-                log.error("Failed to analyse spdx package: " + spdxPackage.getName(), e);
-                throw new UncheckedInvalidSPDXAnalysisException(e);
+            for (Node spdxFile : getFiles(spdxItem)) {
+                licenseTexts.addAll(getAllLicenseTexts(spdxFile, useLicenseInfoFromFiles, includeConcludedLicense));
             }
         }
 
         return licenseTexts;
     }
 
-    private static Set<String> getAllConcludedLicenseIds(AnyLicenseInfo spdxLicenseInfo) {
+    private static Set<String> getAllConcludedLicenseIds(Node spdxLicenseInfo) {
         Set<String> result = Sets.newHashSet();
 
-        if (spdxLicenseInfo instanceof LicenseSet) {
-            LicenseSet licenseSet = (LicenseSet) spdxLicenseInfo;
-            result.addAll(Arrays.stream(licenseSet.getMembers())
-                    .flatMap(setMember -> SPDXParserTools.getAllConcludedLicenseIds(setMember).stream())
-                    .collect(Collectors.toSet()));
-
-        } else if (spdxLicenseInfo instanceof SimpleLicensingInfo) {
-            SimpleLicensingInfo simpleLicensingInfo = (SimpleLicensingInfo) spdxLicenseInfo;
-            String licenseId = simpleLicensingInfo.getLicenseId();
-            result.add(licenseId.replace("LicenseRef-", ""));
-
-        } else if (spdxLicenseInfo instanceof OrLaterOperator) {
-            OrLaterOperator orLaterOperator = (OrLaterOperator) spdxLicenseInfo;
-            result.addAll(SPDXParserTools.getAllConcludedLicenseIds(orLaterOperator.getLicense()));
-
-        } else if (spdxLicenseInfo instanceof WithExceptionOperator) {
-            WithExceptionOperator withExceptionOperator = (WithExceptionOperator) spdxLicenseInfo;
-            result.addAll(SPDXParserTools.getAllConcludedLicenseIds(withExceptionOperator.getLicense()));
-
+        switch (getNodeName(spdxLicenseInfo)) {
+            case SPDX_CONJUNCTIVE_LICENSE_SET:
+            case SPDX_DISJUNCTIVE_LICENSE_SET:
+                result.addAll(Arrays.stream(getMembers(spdxLicenseInfo))
+                        .flatMap(setMember -> SPDXParserTools.getAllConcludedLicenseIds(setMember).stream())
+                        .collect(Collectors.toSet()));
+                break;
+            case SPDX_LICENSE_CONCLUDED:
+            case SPDX_MEMBER:
+                if (spdxLicenseInfo.hasChildNodes()) {
+                    NodeList childNodes = spdxLicenseInfo.getChildNodes();
+                    for (Node child : iterable(childNodes)) {
+                        result.addAll(getAllConcludedLicenseIds(child));
+                    }
+                    break;
+                }
+            default:
+                String licenseId = getLicenseId(spdxLicenseInfo);
+                if (!isNullEmptyOrWhitespace(licenseId)) {
+                    result.add(licenseId);
+                } else {
+                    LicenseNameWithText lwt = findInURILicenseMap(spdxLicenseInfo);
+                    if (lwt != null)
+                        result.add(lwt.getLicenseSpdxId());
+                    else {
+                        licenseId = getResourceLocalName(spdxLicenseInfo);
+                        if (!isNullEmptyOrWhitespace(licenseId))
+                            result.add(licenseId.replace(LICENSE_REF_PREFIX, ""));
+                    }
+                }
+                break;
         }
-        // else SpdxNoAssertionLicense || SpdxNoneLicense -> skipped
 
         return result;
     }
 
-    private static Stream<String> getAllCopyrights(SpdxItem spdxItem) {
-        Stream<String> copyrights = Stream.of(spdxItem.getCopyrightText().trim());
-        if (spdxItem instanceof SpdxPackage) {
-            SpdxPackage spdxPackage = (SpdxPackage) spdxItem;
-            try {
-                copyrights = Stream.concat(copyrights,
-                        Arrays.stream(spdxPackage.getFiles())
-                                .flatMap(spdxFile -> getAllCopyrights(spdxFile)));
-            } catch (InvalidSPDXAnalysisException e) {
-                log.error("Failed to get files of package: " + spdxPackage.getName(), e);
-                throw new UncheckedInvalidSPDXAnalysisException(e);
-            }
+    private static Stream<String> getAllCopyrights(Node spdxItem) {
+        Stream<String> copyrights = Stream.empty();
+        String copyrightText = getCopyrightText(spdxItem).trim();
+        if (!isNullEmptyOrWhitespace(copyrightText)) {
+            copyrights = Stream.of(copyrightText);
+        }
+
+        if (getNodeName(spdxItem).equals(SPDX_PACKAGE)) {
+            copyrights = Stream.concat(copyrights,
+                    Arrays.stream(getFiles(spdxItem)).flatMap(spdxFile -> getAllCopyrights(spdxFile)));
         }
         return copyrights;
     }
 
-
     protected static LicenseInfoParsingResult getLicenseInfoFromSpdx(AttachmentContent attachmentContent,
-            boolean includeConcludedLicense, SpdxDocument doc) {
+            boolean includeConcludedLicense, Document doc) {
         LicenseInfo licenseInfo = new LicenseInfo().setFilenames(Arrays.asList(attachmentContent.getFilename()));
         licenseInfo.setLicenseNamesWithTexts(new HashSet<>());
         licenseInfo.setCopyrights(new HashSet<>());
+        Set<String> concludedLicenseIds = Sets.newHashSet();
 
-        try {
-            Set<String> concludedLicenseIds = Sets.newHashSet();
-            for (SpdxItem spdxItem : doc.getDocumentDescribes()) {
-                licenseInfo.getLicenseNamesWithTexts()
-                        .addAll(getAllLicenseTexts(spdxItem, USE_LICENSE_INFO_FROM_FILES, includeConcludedLicense)
-                                .collect(Collectors.toSet()));
-                licenseInfo.getCopyrights()
-                        .addAll(getAllCopyrights(spdxItem)
-                                .collect(Collectors.toSet()));
-                if (spdxItem instanceof SpdxPackage) {
-                    concludedLicenseIds.addAll(getAllConcludedLicenseIds(spdxItem.getLicenseConcluded()));
-                }
+        uriLicenseMap = getLicenseTextFromMetadata(doc);
+        nodeIDFileMap = getFileFromMetadata(doc);
+
+        for (Node spdxItem : getDocumentDescribes(doc)) {
+            licenseInfo.getLicenseNamesWithTexts()
+                    .addAll(getAllLicenseTexts(spdxItem, USE_LICENSE_INFO_FROM_FILES, includeConcludedLicense));
+            licenseInfo.getCopyrights().addAll(getAllCopyrights(spdxItem).collect(Collectors.toSet()));
+            if (getNodeName(spdxItem).equals(SPDX_PACKAGE)) {
+                concludedLicenseIds.addAll(getAllConcludedLicenseIds(getLicenseConcluded(spdxItem)));
             }
-            licenseInfo.setConcludedLicenseIds(concludedLicenseIds);
-        } catch (UncheckedInvalidSPDXAnalysisException e) {
-            return new LicenseInfoParsingResult()
-                    .setStatus(LicenseInfoRequestStatus.FAILURE)
-                    .setMessage(e.getInvalidSPDXAnalysisExceptionCause().getMessage());
-        } catch (InvalidSPDXAnalysisException e) {
-            return new LicenseInfoParsingResult()
-                    .setStatus(LicenseInfoRequestStatus.FAILURE)
-                    .setMessage(e.getMessage());
         }
+        licenseInfo.setConcludedLicenseIds(concludedLicenseIds);
 
-        return new LicenseInfoParsingResult()
-                .setLicenseInfo(licenseInfo)
-                .setStatus(LicenseInfoRequestStatus.SUCCESS);
-    }
-
-
-    private static class UncheckedInvalidSPDXAnalysisException extends RuntimeException {
-        UncheckedInvalidSPDXAnalysisException(InvalidSPDXAnalysisException te) {
-            super(te);
-        }
-
-        InvalidSPDXAnalysisException getInvalidSPDXAnalysisExceptionCause() {
-            return (InvalidSPDXAnalysisException) getCause();
-        }
+        return new LicenseInfoParsingResult().setLicenseInfo(licenseInfo).setStatus(LicenseInfoRequestStatus.SUCCESS);
     }
 }

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTools.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTools.java
@@ -197,12 +197,7 @@ public class SPDXParserTools {
         }
 
         // Convert List to Array
-        int noChilds = childList.size();
-        Node[] childArray = new Node[noChilds];
-        for (int i = 0; i < noChilds; i++) {
-            childArray[i] = childList.get(i);
-        }
-        return childArray;
+        return (Node[]) childList.toArray(new Node[0]);
     }
 
     /*

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTest.java
@@ -33,14 +33,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.spdx.rdfparser.SPDXDocumentFactory;
-import org.spdx.rdfparser.model.SpdxDocument;
+import org.w3c.dom.Document;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 import java.io.InputStream;
 import java.util.*;
 
 import static org.eclipse.sw360.licenseinfo.TestHelper.*;
-import static org.eclipse.sw360.licenseinfo.parsers.SPDXParser.FILETYPE_SPDX_INTERNAL;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -132,9 +133,11 @@ public class SPDXParserTest {
                 .setFilename(exampleFile);
 
         InputStream input = makeAttachmentContentStream(exampleFile);
-        SpdxDocument spdxDocument = SPDXDocumentFactory.createSpdxDocument(input,
-                parser.getUriOfAttachment(attachmentContentStore.get(exampleFile)),
-                FILETYPE_SPDX_INTERNAL);
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        dbFactory.setNamespaceAware(true);
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document spdxDocument = dBuilder.parse(input);
+        spdxDocument.getDocumentElement().normalize();
 
         LicenseInfoParsingResult result = SPDXParserTools.getLicenseInfoFromSpdx(attachmentContent, true, spdxDocument);
         assertIsResultOfExample(result.getLicenseInfo(), exampleFile, expectedLicenses, numberOfCoyprights,


### PR DESCRIPTION
Signed-off-by: Kouki Hama <kouki1.hama@toshiba.co.jp>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 　https://github.com/eclipse/sw360/issues/1011
spdx/tools takes a lot of time and resources to parse big rdf file (ie. >15M).
Use javax.xml.parsers and org.w3c.dom.Document for faster rdf reading,
and implement parser to get only information we need (licenses and copyrights)

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?

Import spdx files (ex,  made by fossology) from release  attachment :

Component/release -> Clearing details -> click show license info -> get results 

Generating the catalogue ("Generate License Info") with spdx rdf file


> Have you implemented any additional tests?

Import large spdx file from release attachment :
 
Component/release -> Clearing details -> click show license info -> get results

Generating the catalogue ("Generate License Info") with large spdx rdf file

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

### Thanks 
@dothanhtrung  and @tienlee  contributed and helped a lot.   

### Note 
We would like to explain about  this pull request on Feb 3rd sw360 telco by using https://github.com/eclipse/sw360/files/5877677/Meeting_SPDXParser_20210127.pdf