### PR TITLE
feat(clearingreport): Feature to select template for Project Clearing Report

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -108,14 +108,15 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
                 new TextGenerator(DISCLOSURE, "License Disclosure as TEXT"),
                 new XhtmlGenerator(DISCLOSURE, "License Disclosure as XHTML"),
                 new DocxGenerator(DISCLOSURE, "License Disclosure as DOCX"),
-                new DocxGenerator(REPORT, "Project Clearing Report as DOCX")
+                new DocxGenerator(REPORT, "Project Clearing Report as DOCX"),
+                new JsonGenerator(REPORT, "Project Clearing Report as JSON")
         );
         // @formatter:on
     }
 
     @Override
     public LicenseInfoFile getLicenseInfoFile(Project project, User user, String outputGenerator,
-            Map<String, Map<String, Boolean>> releaseIdsToSelectedAttachmentIds, Map<String, Set<LicenseNameWithText>> excludedLicensesPerAttachment, String externalIds)
+            Map<String, Map<String, Boolean>> releaseIdsToSelectedAttachmentIds, Map<String, Set<LicenseNameWithText>> excludedLicensesPerAttachment, String externalIds, String fileName)
             throws TException {
         assertNotNull(project);
         assertNotNull(user);
@@ -154,7 +155,7 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
             filteredExtIdMap = extIdMap.entrySet().stream().filter(x->externalId.contains(x.getKey())).collect(Collectors.toMap(Entry::getKey, Entry::getValue));
         }
 
-        Object output = generator.generateOutputFile(projectLicenseInfoResults, project, obligationsResults, user, filteredExtIdMap, obligationsStatusInfoMap);
+        Object output = generator.generateOutputFile(projectLicenseInfoResults, project, obligationsResults, user, filteredExtIdMap, obligationsStatusInfoMap, fileName);
         if (output instanceof byte[]) {
             licenseInfoFile.setGeneratedOutput((byte[]) output);
         } else if (output instanceof String) {

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/DocxGenerator.java
@@ -101,7 +101,7 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
     }
 
     @Override
-    public byte[] generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, Project project, Collection<ObligationParsingResult> obligationResults, User user, Map<String, String> externalIds, Map<String, ObligationStatusInfo> obligationsStatus) throws SW360Exception {
+    public byte[] generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, Project project, Collection<ObligationParsingResult> obligationResults, User user, Map<String, String> externalIds, Map<String, ObligationStatusInfo> obligationsStatus, String fileName) throws SW360Exception {
         String licenseInfoHeaderText = project.getLicenseInfoHeaderText();
 
         ByteArrayOutputStream docxOutputStream = new ByteArrayOutputStream();
@@ -126,7 +126,12 @@ public class DocxGenerator extends OutputGenerator<byte[]> {
                     }
                     break;
                 case REPORT:
-                    docxTemplateFile = CommonUtils.loadResource(DocxGenerator.class, DOCX_TEMPLATE_REPORT_FILE);
+                    if (CommonUtils.isNullEmptyOrWhitespace(fileName)) {
+                        docxTemplateFile = CommonUtils.loadResource(DocxGenerator.class, DOCX_TEMPLATE_REPORT_FILE);
+                    } else {
+                        docxTemplateFile = CommonUtils.loadResource(DocxGenerator.class,
+                                System.getProperty("file.separator") + fileName + "." + DOCX_OUTPUT_TYPE);
+                    }
                     xwpfDocument = new XWPFDocument(new ByteArrayInputStream(docxTemplateFile.get()));
                     if (docxTemplateFile.isPresent()) {
                         fillReportDocument(

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/JsonGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/JsonGenerator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Siemens AG, 2021. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.licenseinfo.outputGenerators;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Properties;
+
+import org.eclipse.sw360.datahandler.common.CommonUtils;
+import org.eclipse.sw360.datahandler.thrift.SW360Exception;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoParsingResult;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.ObligationParsingResult;
+import org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatVariant;
+import org.eclipse.sw360.datahandler.thrift.projects.ObligationStatusInfo;
+import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+/*
+ * TODO: This class under development until the json template or structure is ready.
+ */
+public class JsonGenerator extends OutputGenerator<String> {
+
+    private static final String JSON_MIME_TYPE = "application/json";
+    private static final String JSON_OUTPUT_TYPE = "json";
+
+    public static final String PROPERTIES_FILE_PATH = "/sw360.properties";
+
+    public JsonGenerator(OutputFormatVariant outputFormatVariant, String description) {
+        super(JSON_OUTPUT_TYPE, description, true, JSON_MIME_TYPE, outputFormatVariant);
+        Properties props = CommonUtils.loadProperties(JsonGenerator.class, PROPERTIES_FILE_PATH);
+    }
+
+    @Override
+    public String generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, Project project, Collection<ObligationParsingResult> obligationResults, User user, Map<String, String> externalIds, Map<String, ObligationStatusInfo> obligationsStatus, String fileName) throws SW360Exception {
+        return "";
+        
+    }
+}

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/OutputGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/OutputGenerator.java
@@ -64,7 +64,7 @@ public abstract class OutputGenerator<T> {
         this.outputVariant = variant;
     }
 
-    public abstract T generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, Project project, Collection<ObligationParsingResult> obligationResults, User user, Map<String,String> externalIds, Map<String, ObligationStatusInfo> obligationsStatus) throws SW360Exception;
+    public abstract T generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, Project project, Collection<ObligationParsingResult> obligationResults, User user, Map<String,String> externalIds, Map<String, ObligationStatusInfo> obligationsStatus, String fileName) throws SW360Exception;
 
     public String getOutputType() {
         return outputType;

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/TextGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/TextGenerator.java
@@ -37,7 +37,7 @@ public class TextGenerator extends OutputGenerator<String> {
     }
 
     @Override
-    public String generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, Project project, Collection<ObligationParsingResult> obligationResults, User user, Map<String,String> externalIds, Map<String, ObligationStatusInfo> obligationsStatus) throws SW360Exception {
+    public String generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, Project project, Collection<ObligationParsingResult> obligationResults, User user, Map<String,String> externalIds, Map<String, ObligationStatusInfo> obligationsStatus, String fileName) throws SW360Exception {
         String projectName = project.getName();
         String projectVersion = project.getVersion();
         String licenseInfoHeaderText = project.getLicenseInfoHeaderText();

--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGenerator.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGenerator.java
@@ -38,7 +38,7 @@ public class XhtmlGenerator extends OutputGenerator<String> {
     }
 
     @Override
-    public String generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, Project project, Collection<ObligationParsingResult> obligationResults, User user, Map<String,String> externalIds, Map<String, ObligationStatusInfo> obligationsStatus) throws SW360Exception {
+    public String generateOutputFile(Collection<LicenseInfoParsingResult> projectLicenseInfoResults, Project project, Collection<ObligationParsingResult> obligationResults, User user, Map<String,String> externalIds, Map<String, ObligationStatusInfo> obligationsStatus, String fileName) throws SW360Exception {
         String projectName = project.getName();
         String projectVersion = project.getVersion();
         String licenseInfoHeaderText = project.getLicenseInfoHeaderText();

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/outputGenerators/XhtmlGeneratorTest.java
@@ -136,10 +136,10 @@ public class XhtmlGeneratorTest {
         Map<String, String> externalIds = Collections.emptyMap();
         Map<String, ObligationStatusInfo> obligationsStatus = Collections.emptyMap();
 
-        xmlString = xhtmlGenerator.generateOutputFile(lipresults, p, obligationResults, null, externalIds, obligationsStatus);
-        xmlString2 = xhtmlGenerator.generateOutputFile(lipresults2, p, obligationResults, null, externalIds, obligationsStatus);
-        xmlString3 = xhtmlGenerator.generateOutputFile(lipresults3, p, obligationResults, null, externalIds, obligationsStatus);
-        xmlStringEmpty = xhtmlGenerator.generateOutputFile(lipresultsEmpty, p, obligationResults, null, externalIds, obligationsStatus);
+        xmlString = xhtmlGenerator.generateOutputFile(lipresults, p, obligationResults, null, externalIds, obligationsStatus, "");
+        xmlString2 = xhtmlGenerator.generateOutputFile(lipresults2, p, obligationResults, null, externalIds, obligationsStatus, "");
+        xmlString3 = xhtmlGenerator.generateOutputFile(lipresults3, p, obligationResults, null, externalIds, obligationsStatus, "");
+        xmlStringEmpty = xhtmlGenerator.generateOutputFile(lipresultsEmpty, p, obligationResults, null, externalIds, obligationsStatus, "");
 
         generateDocumentsFromXml();
     }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -44,6 +44,8 @@ public class PortalConstants {
     public static final Boolean IS_PROJECT_OBLIGATIONS_ENABLED;
     public static final Boolean CUSTOM_WELCOME_PAGE_GUIDELINE;
     public static final UserGroup USER_ROLE_ALLOWED_TO_MERGE_OR_SPLIT_COMPONENT;
+    public static final String CLEARING_REPORT_TEMPLATE_TO_FILENAMEMAPPING;
+    public static final String CLEARING_REPORT_TEMPLATE_FORMAT;
 
     // DO NOT CHANGE THIS UNLESS YOU KNOW WHAT YOU ARE DOING !!!
     // - friendly url mapping files must be changed
@@ -609,6 +611,8 @@ public class PortalConstants {
         API_TOKEN_HASH_SALT = props.getProperty("rest.apitoken.hash.salt", "$2a$04$Software360RestApiSalt");
         API_WRITE_ACCESS_USERGROUP = UserGroup.valueOf(props.getProperty("rest.write.access.usergroup", UserGroup.ADMIN.name()));
         USER_ROLE_ALLOWED_TO_MERGE_OR_SPLIT_COMPONENT = UserGroup.valueOf(props.getProperty("user.role.allowed.to.merge.or.split.component", UserGroup.ADMIN.name()));
+        CLEARING_REPORT_TEMPLATE_TO_FILENAMEMAPPING = props.getProperty("org.eclipse.sw360.licensinfo.projectclearing.templatemapping", "");
+        CLEARING_REPORT_TEMPLATE_FORMAT = props.getProperty("org.eclipse.sw360.licensinfo.projectclearing.templateformat", "docx");
     }
 
     private PortalConstants() {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayOutputFormats.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayOutputFormats.java
@@ -19,6 +19,7 @@ import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.tagext.SimpleTagSupport;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 
@@ -30,6 +31,7 @@ public class DisplayOutputFormats extends SimpleTagSupport {
     private Collection<OutputFormatInfo> options;
     private String selected;
     private OutputFormatVariant variantToSkip;
+    private Collection<String> formatsToShow;
 
     public void setOptions(Collection<OutputFormatInfo> options) throws JspException {
         this.options = options;
@@ -43,6 +45,10 @@ public class DisplayOutputFormats extends SimpleTagSupport {
         this.variantToSkip = variantToSkip;
     }
 
+    public void setFormatsToShow(Collection<String> formatsToShow) {
+        this.formatsToShow = formatsToShow;
+    }
+
     public void doTag() throws JspException, IOException {
         writeOptions(options);
     }
@@ -50,7 +56,9 @@ public class DisplayOutputFormats extends SimpleTagSupport {
     private void writeOptions(Collection<OutputFormatInfo> options) throws IOException {
         JspWriter jspWriter = getJspContext().getOut();
         boolean isChecked=true;
-        options = options.stream().filter(ofInfo -> !ofInfo.getVariant().equals(variantToSkip)).collect(Collectors.toCollection(ArrayList::new));
+        options = options.stream().filter(ofInfo -> !ofInfo.getVariant().equals(variantToSkip))
+                .filter(ofInfo -> (Objects.isNull(formatsToShow)) || formatsToShow.contains(ofInfo.getFileExtension()))
+                .collect(Collectors.toCollection(ArrayList::new));
         for (OutputFormatInfo option : options) {
             String optionDescription = option.getDescription();
             String optionValue = option.getGeneratorClassName() + "::" + option.getVariant();

--- a/frontend/sw360-portlet/src/main/resources/META-INF/customTags.tld
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/customTags.tld
@@ -264,6 +264,12 @@
             <type>org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatVariant</type>
             <rtexprvalue>true</rtexprvalue>
         </attribute>
+        <attribute>
+            <name>formatsToShow</name>
+            <required>false</required>
+            <type>java.util.Collection</type>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
     </tag>
     <tag>
         <name>DisplayUser</name>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/licenseInfo.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/licenseInfo.jsp
@@ -8,6 +8,7 @@
   ~ SPDX-License-Identifier: EPL-2.0
   --%>
 <%@ page import="java.util.Map"%>
+<%@ page import="java.util.Arrays"%>
 <%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 <%@ page import="org.eclipse.sw360.datahandler.thrift.licenseinfo.OutputFormatVariant" %>
 <%@ page import="com.liferay.portal.kernel.portlet.PortletURLFactoryUtil" %>
@@ -70,78 +71,100 @@
     <%@ include file="/html/utils/includes/pageSpinner.jspf" %>
 </core_rt:if>
 
+<c:set var="clReportTmplateMappings" value="<%=PortalConstants.CLEARING_REPORT_TEMPLATE_TO_FILENAMEMAPPING%>"/>
+<c:set var="clearingReportTemplate" value="${fn:split(clReportTmplateMappings, ',')}"/>
+
+<c:set var="templateFormats" value="<%=PortalConstants.CLEARING_REPORT_TEMPLATE_FORMAT%>"/>
+<c:set var="tmpFormat" value="${fn:split(templateFormats, ',')}"/>
+
 <div class="dialogs auto-dialogs">
-<div id="downloadLicenseInfoDialog" class="modal fade" tabindex="-1" role="dialog">
-<div class="modal-dialog modal-lg modal-dialog-centered modal-info" role="document">
-  <!-- <div class="modal-dialog" role="document"> -->
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title"><liferay-ui:message key="select.other.options" /></h5>
-        <button id="closeModalButton" type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
-      <div class="modal-body"
-                    style="position: relative; overflow-y: auto; max-height: 400px;">
-                    <c:if test="${not empty relations}">
-                        <div class="form-group form-check">
-                            <label for="projectRelation"
-                                class="font-weight-bold h3">Uncheck project
-                                release relationships to be excluded:</label>
-                            <c:forEach var="projectReleaseRelation" items="${relations}">
-                                <div class="checkbox form-check">
-                                    <label> <input name="releaseRelationSelection" type="checkbox"
-                                        <c:if test = "${empty usedProjectReleaseRelations}">checked="checked"</c:if>
-                                        <c:if test = "${not empty usedProjectReleaseRelations and (fn:contains(usedProjectReleaseRelations, projectReleaseRelation))}">checked="checked"</c:if>
-                                        value="${projectReleaseRelation}">
-                                        <sw360:DisplayEnum value='${projectReleaseRelation}' bare="true" /> </input>
-                                    </label>
-                                </div>
-                            </c:forEach>
-                        </div>
-                    </c:if>
-                    <c:if test="${not empty linkedProjectRelation}">
-                        <div class="form-group form-check">
-                            <label for="projectRelation"
-                                class="font-weight-bold h3">Uncheck Linked Project
-                                Relationships to be excluded:</label>
-                            <c:forEach var="projectRelation" items="${linkedProjectRelation}">
-                                <div class="checkbox form-check">
-                                    <label> <input name="projectRelationSelection" type="checkbox"
-                                        <c:if test = "${usedLinkedProjectRelation == null}">checked="checked"</c:if>
-                                        <c:if test = "${usedLinkedProjectRelation != null and (fn:contains(usedLinkedProjectRelation, projectRelation))}">checked="checked"</c:if>
-                                        value="${projectRelation}">
-                                        <sw360:DisplayEnum value='${projectRelation}' bare="true" /> </input>
-                                    </label>
-                                </div>
-                            </c:forEach>
-                        </div>
-                    </c:if>
-                    <c:if test="${not onlyClearingReport}">
-					    <c:if test="${not empty externalIds}">
-					        <div class="form-group form-check">
-						        <label for="externalIdLabel" class="font-weight-bold h3"><liferay-ui:message key="select.the.external.ids" />:</label>
-							        <c:forEach var="extId" items="${externalIds}">
-									    <div class="checkbox form-check">
-										    <label><input id="<%=PortalConstants.EXTERNAL_ID_SELECTED_KEYS%>" name="externalIdsSelection" type="checkbox" value="${extId}">
-									        <c:out value="${extId}" /></input></label>
-									   </div>
-							        </c:forEach>
-					       </div>
-					    </c:if>
-					    <div class="form-group form-check">
-						    <label for="outputFormatLabel" class="licenseInfoOpFormat font-weight-bold h3"><liferay-ui:message key="select.output.format" />:</label>
-						    <sw360:DisplayOutputFormats options='${licenseInfoOutputFormats}' variantToSkip="<%=OutputFormatVariant.REPORT%>"/>
-					    </div>
-                    </c:if>
-	  </div>
-      <div class="modal-footer">
-        <button id="downloadFileModal" type="button" value="Download" class="btn btn-primary"><liferay-ui:message key="download" /></button>
-        <button type="button" class="btn btn-secondary" data-dismiss="modal"><liferay-ui:message key="close" /></button>
-      </div>
-    </div>
-  </div>
-</div>
+	<div id="downloadLicenseInfoDialog" class="modal fade" tabindex="-1" role="dialog">
+		<div class="modal-dialog modal-lg modal-dialog-centered modal-info" role="document">
+			<!-- <div class="modal-dialog" role="document"> -->
+			<div class="modal-content">
+				<div class="modal-header">
+					<h5 class="modal-title">
+						<liferay-ui:message key="select.other.options" />
+					</h5>
+					<button id="closeModalButton" type="button" class="close" data-dismiss="modal" aria-label="Close">
+						<span aria-hidden="true">&times;</span>
+					</button>
+				</div>
+				<div class="modal-body" style="position: relative; overflow-y: auto; max-height: 400px;">
+					<c:if test="${not empty relations}">
+						<div class="form-group form-check">
+							<label for="projectRelation" class="font-weight-bold h3">Uncheck project release relationships to be excluded:</label>
+							<c:forEach var="projectReleaseRelation" items="${relations}">
+								<div class="checkbox form-check">
+									<label> <input name="releaseRelationSelection" type="checkbox"
+										<c:if test = "${empty usedProjectReleaseRelations}">checked="checked"</c:if>
+										<c:if test = "${not empty usedProjectReleaseRelations and (fn:contains(usedProjectReleaseRelations, projectReleaseRelation))}">checked="checked"</c:if>
+										value="${projectReleaseRelation}"> <sw360:DisplayEnum value='${projectReleaseRelation}' bare="true" /> </input>
+									</label>
+								</div>
+							</c:forEach>
+						</div>
+					</c:if>
+					<c:if test="${not empty linkedProjectRelation}">
+						<div class="form-group form-check">
+							<label for="projectRelation" class="font-weight-bold h3">Uncheck Linked Project Relationships to be excluded:</label>
+							<c:forEach var="projectRelation" items="${linkedProjectRelation}">
+								<div class="checkbox form-check">
+									<label> <input name="projectRelationSelection" type="checkbox"
+										<c:if test = "${usedLinkedProjectRelation == null}">checked="checked"</c:if>
+										<c:if test = "${usedLinkedProjectRelation != null and (fn:contains(usedLinkedProjectRelation, projectRelation))}">checked="checked"</c:if>
+										value="${projectRelation}"> <sw360:DisplayEnum value='${projectRelation}' bare="true" /> </input>
+									</label>
+								</div>
+							</c:forEach>
+						</div>
+					</c:if>
+					<c:if test="${not onlyClearingReport}">
+						<c:if test="${not empty externalIds}">
+							<div class="form-group form-check">
+								<label for="externalIdLabel" class="font-weight-bold h3"><liferay-ui:message key="select.the.external.ids" />:</label>
+								<c:forEach var="extId" items="${externalIds}">
+									<div class="checkbox form-check">
+										<label><input id="<%=PortalConstants.EXTERNAL_ID_SELECTED_KEYS%>" name="externalIdsSelection" type="checkbox" value="${extId}">
+											<c:out value="${extId}" /></input></label>
+									</div>
+								</c:forEach>
+							</div>
+						</c:if>
+						<div class="form-group form-check">
+							<label for="outputFormatLabel"
+								class="licenseInfoOpFormat font-weight-bold h3"><liferay-ui:message key="select.output.format" />:</label>
+							<sw360:DisplayOutputFormats options='${licenseInfoOutputFormats}' variantToSkip="<%=OutputFormatVariant.REPORT%>" />
+						</div>
+					</c:if>
+					<c:if test="${onlyClearingReport eq 'true' and not empty clearingReportTemplate[0]}">
+						<label for="OrganisationSelection" class="font-weight-bold h3"><liferay-ui:message key="templates" />:</label>
+						<c:forEach var="clRepTemp" items="${clearingReportTemplate}">
+							<c:set var="org" value="${fn:split(clRepTemp, ':')}" />
+							<div class="radio form-check">
+								<label><input type="radio" name="org" value="${org[0]}" checked>${org[0]}</label>
+							</div>
+						</c:forEach>
+					</c:if>
+					<c:if test="${onlyClearingReport eq 'true' and not empty  tmpFormat[0]}">
+						<div class="form-group form-check">
+							<label for="outputFormatLabel" class="licenseInfoOpFormat font-weight-bold h3"><liferay-ui:message key="select.output.format" />:</label>
+							<sw360:DisplayOutputFormats options='${licenseInfoOutputFormats}' variantToSkip="<%=OutputFormatVariant.DISCLOSURE%>"
+								formatsToShow='<%=Arrays.asList(PortalConstants.CLEARING_REPORT_TEMPLATE_FORMAT.split(","))%>' />
+						</div>
+					</c:if>
+				</div>
+				<div class="modal-footer">
+					<button id="downloadFileModal" type="button" value="Download" class="btn btn-primary">
+						<liferay-ui:message key="download" />
+					</button>
+					<button type="button" class="btn btn-secondary" data-dismiss="modal">
+						<liferay-ui:message key="close" />
+					</button>
+				</div>
+			</div>
+		</div>
+	</div>
 </div>
 
 <script>
@@ -259,6 +282,7 @@ require(['jquery', 'modules/dialog'], function($, dialog) {
     }
 
     function downloadClearingReportOnly(isEmptyFile) {
+        let licenseInfoSelectedOutputFormat = $('input[name="outputFormat"]:checked').val();
         if(isEmptyFile === "undefined" || !isEmptyFile) {
             let releaseRelations = [];
             let selectedProjectRelations = [];
@@ -271,10 +295,19 @@ require(['jquery', 'modules/dialog'], function($, dialog) {
                 selectedProjectRelations.push($(this).val());
             });
             var selectedProjectRelationsHidden = selectedProjectRelations.join();
-            $('#downloadLicenseInfoForm').append('<input id="licensInfoFileFormat" type="hidden" value="DocxGenerator::REPORT" name="<portlet:namespace/><%=PortalConstants.LICENSE_INFO_SELECTED_OUTPUT_FORMAT%>" />');
+            $('#downloadLicenseInfoForm').append('<input id="licensInfoFileFormat" type="hidden" name="<portlet:namespace/><%=PortalConstants.LICENSE_INFO_SELECTED_OUTPUT_FORMAT%>" />');
             $('#downloadLicenseInfoForm').append('<input id="isSubProjPresent" type="hidden" name="<portlet:namespace/><%=PortalConstants.IS_LINKED_PROJECT_PRESENT%>"/>');
             $('#downloadLicenseInfoForm').append('<input id="releaseRelationship" type="hidden" name="<portlet:namespace/><%=PortalConstants.SELECTED_PROJECT_RELEASE_RELATIONS%>"/>');
             $('#downloadLicenseInfoForm').append('<input id="selectedProjectRelations" type="hidden" name="<portlet:namespace/><%=PortalConstants.SELECTED_PROJECT_RELATIONS%>"/>');
+            $('#downloadLicenseInfoForm').append('<input id="template" type="hidden" name="<portlet:namespace/>tmplate"/>');
+            selectedtemplate = $("input[name='org']:checked").val();
+            $("#template").val(selectedtemplate);
+
+            if(licenseInfoSelectedOutputFormat){
+                $("#licensInfoFileFormat").val(licenseInfoSelectedOutputFormat);
+            } else {
+                $("#licensInfoFileFormat").val("DocxGenerator::REPORT");
+            }
             $("#isSubProjPresent").val(${not empty linkedProjectRelation});
             $("#releaseRelationship").val(releaseRelationsHidden);
             $("#selectedProjectRelations").val(selectedProjectRelationsHidden);
@@ -284,8 +317,9 @@ require(['jquery', 'modules/dialog'], function($, dialog) {
             let actionUrlaft = $('#downloadLicenseInfoForm').attr('action');
             $('#downloadLicenseInfoForm').submit();
         } else {
-            $('#downloadLicenseInfoForm').append('<input id="licensInfoFileFormat" type="hidden" value="DocxGenerator::REPORT" name="<portlet:namespace/><%=PortalConstants.LICENSE_INFO_SELECTED_OUTPUT_FORMAT%>" />');
+            $('#downloadLicenseInfoForm').append('<input id="licensInfoFileFormat" type="hidden" name="<portlet:namespace/><%=PortalConstants.LICENSE_INFO_SELECTED_OUTPUT_FORMAT%>" />');
             $('#downloadLicenseInfoForm').append('<input id="isEmptyFile" type="hidden" value="Yes" name="<portlet:namespace/><%=PortalConstants.LICENSE_INFO_EMPTY_FILE%>" />');
+            $("#licensInfoFileFormat").val(licenseInfoSelectedOutputFormat);
             let actionUrl = $('#downloadLicenseInfoForm').attr('action');
             cleanedActionUrl = removeUnusedParam(actionUrl);
             $('#downloadLicenseInfoForm').attr('action', cleanedActionUrl);

--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -1313,6 +1313,7 @@ obligation.title= Obligation Title
 obligation.text=Obligation Text
 linked.obligations=Linked Obligations
 id=Id
+templates=Templates
 
 ## Refer to http://cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/ and add your datatables language
 

--- a/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
@@ -1317,6 +1317,7 @@ obligation.title=Obligation Title
 obligation.text=Obligation Text
 linked.obligations=Linked Obligations
 id=Id
+templates=Templates
 
 ## Refer to http://cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/ and add your datatables language
 

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -1319,6 +1319,7 @@ obligation.title= Obligation Title
 obligation.text=Obligation Text
 linked.obligations=Linked Obligations
 id=Id
+templates=Templates
 
 ## Refer to http://cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/ and add your datatables language
 

--- a/frontend/sw360-portlet/src/main/resources/sw360.properties
+++ b/frontend/sw360-portlet/src/main/resources/sw360.properties
@@ -214,3 +214,11 @@ logout.redirect.url=
 # ADMIN by default has merge/split access
 # Access follows isUserAtLeast(ROLE)
 #user.role.allowed.to.merge.or.split.component=ADMIN
+
+# This property is used to put mapping of template to corresponding filename viz. template:filename. This
+# property is optional. If there is no value. it will pick the default one.
+
+#org.eclipse.sw360.licensinfo.projectclearing.templatemapping=
+
+#Here we can put template formats such as docx,json,xml etc.
+#org.eclipse.sw360.licensinfo.projectclearing.templateformat=

--- a/libraries/lib-datahandler/src/main/thrift/licenseinfo.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/licenseinfo.thrift
@@ -137,7 +137,7 @@ service LicenseInfoService {
      * get a copyright and license information file on all linked releases and linked releases of linked projects (recursively)
      * output format as specified by outputType
      */
-    LicenseInfoFile getLicenseInfoFile(1: Project project, 2: User user, 3: string outputGeneratorClassName, 4: map<string, map<string, bool>> releaseIdsToSelectedAttachmentIds, 5: map<string, set<LicenseNameWithText>> excludedLicensesPerAttachment, 6: string externalIds);
+    LicenseInfoFile getLicenseInfoFile(1: Project project, 2: User user, 3: string outputGeneratorClassName, 4: map<string, map<string, bool>> releaseIdsToSelectedAttachmentIds, 5: map<string, set<LicenseNameWithText>> excludedLicensesPerAttachment, 6: string externalIds, 7: string fileName);
 
     /**
       * returns all available output types

--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -382,7 +382,7 @@ include::{snippets}/should_document_patch_releases/http-response.adoc[]
 [[resources-project-get-download-licenseinfo]]
 ==== Download License Info
 
-A `GET` request is used to download license info for the project.
+A `GET` request is used to download license info for the project. Please set the request parameter `&template=<TEMPLATE_NAME>` for variant `REPORT` to choose specific template.
 
 ===== Request parameter
 include::{snippets}/should_document_get_download_license_info/request-parameters.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
@@ -46,6 +46,7 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
     public static final String API_TOKEN_MAX_VALIDITY_READ_IN_DAYS;
     public static final String API_TOKEN_MAX_VALIDITY_WRITE_IN_DAYS;
     public static final Set<String> DOMAIN;
+    public static final String REPORT_FILENAME_MAPPING;
 
     static {
         Properties props = CommonUtils.loadProperties(Sw360ResourceServer.class, SW360_PROPERTIES_FILE_PATH);
@@ -54,6 +55,7 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
         API_TOKEN_HASH_SALT = props.getProperty("rest.apitoken.hash.salt", "$2a$04$Software360RestApiSalt");
         DOMAIN = CommonUtils.splitToSet(props.getProperty("domain",
                 "Application Software, Documentation, Embedded Software, Hardware, Test and Diagnostics"));
+        REPORT_FILENAME_MAPPING = props.getProperty("org.eclipse.sw360.licensinfo.projectclearing.templatemapping", "");
     }
 
     @Bean

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licenseinfo/Sw360LicenseInfoService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/licenseinfo/Sw360LicenseInfoService.java
@@ -50,10 +50,10 @@ public class Sw360LicenseInfoService {
 
     public LicenseInfoFile getLicenseInfoFile(Project project, User sw360User, String generatorClassNameWithVariant,
             Map<String, Map<String, Boolean>> selectedReleaseAndAttachmentIds,
-            Map<String, Set<LicenseNameWithText>> excludedLicenses, String externalIds) {
+            Map<String, Set<LicenseNameWithText>> excludedLicenses, String externalIds, String fileName) {
         try {
             LicenseInfoService.Iface sw360LicenseInfoClient = getThriftLicenseInfoClient();
-            return sw360LicenseInfoClient.getLicenseInfoFile(project, sw360User, generatorClassNameWithVariant, selectedReleaseAndAttachmentIds, excludedLicenses, externalIds);
+            return sw360LicenseInfoClient.getLicenseInfoFile(project, sw360User, generatorClassNameWithVariant, selectedReleaseAndAttachmentIds, excludedLicenses, externalIds, fileName);
         } catch (TException e) {
             throw new RuntimeException(e);
         }

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -342,7 +342,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         LicenseInfoFile licenseInfoFile = new LicenseInfoFile();
         licenseInfoFile.setGeneratedOutput(new byte[0]);
         given(this.licenseInfoMockService.getLicenseInfoFile(anyObject(), anyObject(), anyObject(), anyObject(),
-                anyObject(),anyObject())).willReturn(licenseInfoFile);
+                anyObject(),anyObject(), anyObject())).willReturn(licenseInfoFile);
 
         Source ownerSrc1 = Source.releaseId("9988776655");
         Source usedBySrc = Source.projectId(project.getId());
@@ -1172,7 +1172,8 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                                 + Arrays.asList("DocxGenerator", "XhtmlGenerator", "TextGenerator")),
                                 parameterWithName("variant").description("All the possible values for variants are "
                                         + Arrays.asList(OutputFormatVariant.values())),
-                                parameterWithName("externalIds").description("The external Ids of the project"))));
+                                parameterWithName("externalIds").description("The external Ids of the project")
+                                )));
     }
 
     @Test


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*#1104*)
> * Did you add or update any new dependencies that are required for your change? - No


Added two new properties `org.eclipse.sw360.licensinfo.projectclearing.templatemapping` and `org.eclipse.sw360.licensinfo.projectclearing.templateformat` in `sw360.properties` file where we can place template mapping(such as template:filename) and formats. Accordingly the templates along with formats will be shown in the UI while downloading clearing report and the corresponding file will be selected for download.

Issue: 
Closes: #1104

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?

* Need to test the existing feature to download clearing report and ReadMe OSS without any values in the properties mentioned in the description both in UI and REST
* And after adding mapping and formats in properties, need to test if the format and template selections are coming in the UI and the corresponding template is being downloaded

> Have you implemented any additional tests? - No

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: Smruti Prakash Sahoo <smruti.sahoo@siemens.com>
