### PR TITLE
fix(excelexport): Projects with linked releases excel export error

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ReleaseSummary.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/ReleaseSummary.java
@@ -48,6 +48,7 @@ public class ReleaseSummary extends DocumentSummary<Release> {
 
         Set<String> vendorIds = fullDocuments
                 .stream()
+                .filter(Objects::nonNull)
                 .map(Release::getVendorId)
                 .filter(Objects::nonNull)
                 .filter(s -> !s.isEmpty())
@@ -56,6 +57,7 @@ public class ReleaseSummary extends DocumentSummary<Release> {
 
         List<Release> documents = new ArrayList<>(fullDocuments.size());
         for (Release fullDocument : fullDocuments) {
+            if (fullDocument == null) continue;
             Release document = summary(type, fullDocument, vendorById::get);
             if (document != null) documents.add(document);
         }

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/couchdb/SummaryAwareRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/couchdb/SummaryAwareRepository.java
@@ -42,6 +42,16 @@ public class SummaryAwareRepository<T> extends DatabaseRepository<T> {
         return makeSummaryFromFullDocs(type, documents);
     }
 
+    public List<T> makeSummary(SummaryType type, Collection<String> ids, boolean ignoreNotFound) {
+        if (ids == null) {
+            return Collections.emptyList();
+        }
+
+        List<T> documents = get(ids, ignoreNotFound);
+
+        return makeSummaryFromFullDocs(type, documents);
+    }
+
     public List<T> makeSummaryFromFullDocs(SummaryType type, Collection<T> docs) {
         return summary.makeSummary(type, docs);
     }

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -1715,7 +1715,7 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
     }
 
     public List<Release> getDetailedReleasesForExport(Set<String> ids) {
-        return releaseRepository.makeSummary(SummaryType.DETAILED_EXPORT_SUMMARY, ids);
+        return releaseRepository.makeSummary(SummaryType.DETAILED_EXPORT_SUMMARY, ids, true);
     }
 
     public List<Release> getFullReleases(Set<String> ids) {

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -881,9 +881,9 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return project;
     }
 
-    public List<Project> getProjectsById(List<String> id, User user) {
+    public List<Project> getProjectsById(List<String> ids, User user) {
 
-        List<Project> projects = repository.makeSummaryFromFullDocs(SummaryType.SUMMARY, repository.get(id));
+        List<Project> projects = repository.makeSummaryFromFullDocs(SummaryType.SUMMARY, repository.get(ids, true));
 
         List<Project> output = new ArrayList<>();
         for (Project project : projects) {

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseRepository.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/DatabaseRepository.java
@@ -209,6 +209,10 @@ public class DatabaseRepository<T> extends CouchDbRepositorySupport<T> {
         return connector.get(type, ids);
     }
 
+    public List<T> get(Collection<String> ids, boolean ignoreNotFound) {
+        return connector.get(type, ids, ignoreNotFound);
+    }
+
 
     /**
      * Creates, updates all objects in the supplied collection.


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Did you add or update any new dependencies that are required for your change? - No

Sometime if due to some reason, the release reference is present in project document, how ever it is not actually available in DB, then the whole export is not working. In this PR, fixed the null pointer and added a message like "Release not available" in the columns of excel report corresponding to the release fields.


### How To Test?
> How should these changes be tested by the reviewer?

Please refer the description.

> Have you implemented any additional tests? - No

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR

Signed-off-by: Smruti Prakash Sahoo <smruti.sahoo@siemens.com>

