### PR TITLE
chore(eclipse): Enable release and milestone builds

### DIFF
--- a/jenkins.eclipse/Jenkinsfile
+++ b/jenkins.eclipse/Jenkinsfile
@@ -61,18 +61,38 @@ spec:
         }
     }
 
+    environment {
+        COUNT = sh(
+                script: "printf \$(git rev-list `git rev-list --tags --no-walk --max-count=1`..HEAD --count)",
+                returnStdout: true
+        )
+    }
+
+    parameters {
+        booleanParam(
+            name: 'RELEASE',
+            defaultValue: false,
+            description: 'If true, it is a milestone build with a m1 version suffix, or, if false, an intermediate build with a version suffix based on the commit count')
+    }
     stages {
         stage('Deploy SW360') {
             steps {
                 container('sw360buildenv') {
+                    script {
+                        if (params.RELEASE) {
+                            VERSION_SUFFIX = "0-m1"
+                        } else {
+                            VERSION_SUFFIX = "0-" + COUNT
+                        }
+                    }
                     // FIXME: Removed the frontend from the build, because it does not build in the Container environment
                     // Plugin liferay-themes breaks the build
                     // FIXME: Removed backend utils form the build, it causes issues with signing the fat jar
                     sh """
-                        mvn --batch-mode -Peclipse-ci \
+                        mvn --batch-mode -Peclipse-ci -Pci \
                             clean deploy \
                             -pl '!frontend/sw360-portlet,!frontend/liferay-theme,!frontend,!backend/utils' \
-                            -DskipTests -DskipITs
+                            -DskipTests -DskipITs -Dcount=$VERSION_SUFFIX
                     """
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -692,14 +692,14 @@
             </build>
         </profile>
         <profile>
-        <activation>
-            <activeByDefault>false</activeByDefault>
-        </activation>
-        <id>ci</id>
-        <properties>
-            <!-- second of two places for version setting: minor version -->
-            <patchlevel>0.${count}</patchlevel>
-        </properties>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <id>ci</id>
+            <properties>
+                <!-- second of two places for version setting: minor version -->
+                <patchlevel>0.${count}</patchlevel>
+            </properties>
         </profile>
         <profile>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -698,7 +698,7 @@
             <id>ci</id>
             <properties>
                 <!-- second of two places for version setting: minor version -->
-                <patchlevel>0.${count}</patchlevel>
+                <patchlevel>1.${count}</patchlevel>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
fixes #981 

Insert mechanism to run either a commit count or a release build in the Eclipse CI Jenkinsfile. A boolean parameter allows to state that the build is a release build, the default case is a commit count build. The artifacts are deployed to the Eclipse Nexus. Builds are all release builds, so the build break during deployment, if a version is created for a second time. This is the standard behavior for a release build in the maven sense.

Issue: #981  

### Suggest Reviewer
@mcjaeger 

### How To Test?
Run the build and check the artifacts being deployed one Eclipse Nexus

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
