### PR TITLE
feat(MyProjectsUI):Add additional filter to My Projects homepage based on project clearing state.

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/homepage/myprojects/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/homepage/myprojects/view.jsp
@@ -27,7 +27,7 @@
             <span title="Config" class="dropdown-toggle float-none" data-toggle="dropdown" id="configId">
                 <clay:icon symbol="select-from-list" />
             </span>
-            <ul class="dropdown-menu" id="dropdownmenu" name="<portlet:namespace/>roles"
+            <ul class="dropdown-menu" id="dropdownmenu" name="<portlet:namespace/>rolesandclearingstate"
                 aria-labelledby="configId">
                 <li class="dropdown-header">Role in Project</li>
                 <li><hr class="my-2" /></li>
@@ -65,6 +65,24 @@
                     <input type="checkbox" class="form-check-input ml-4" id="securityResponsible"
                     <core_rt:if test="${userRoles==null||userRoles.SECURITY_RESPONSIBLES}">checked="checked"</core_rt:if>>
                     <label class="form-check-label" for="securityResponsible">Security Responsible</label>
+                </li>
+                <li><hr class="my-2" /></li>
+                <li class="dropdown-header">Clearing State</li>
+                <li><hr class="my-2" /></li>
+                <li>
+                    <input type="checkbox" class="form-check-input ml-4" id="open"
+                    <core_rt:if test="${clearingState==null||clearingState.OPEN}">checked="checked"</core_rt:if> />
+                    <label class="form-check-label" for="open">Open</label>
+                </li>
+                <li>
+                    <input type="checkbox" class="form-check-input ml-4" id="closed"
+                    <core_rt:if test="${clearingState==null||clearingState.CLOSED}">checked="checked"</core_rt:if>>
+                    <label class="form-check-label" for="closed">Closed</label>
+                </li>
+                <li>
+                    <input type="checkbox" class="form-check-input ml-4" id="inProgress"
+                    <core_rt:if test="${clearingState==null||clearingState.IN_PROGRESS}">checked="checked"</core_rt:if>>
+                    <label class="form-check-label" for="inProgress">In Progress</label>
                 </li>
                 <li><hr class="my-2" /></li>
                 <li>


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
  - Added additional filter logic for My Projects based on the project Clearing State.
> * Which issue is this pull request belonging to and how is it solving it? (*#1136*)
> * Did you add or update any new dependencies that are required for your change? No

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
      - Login to SW360.
      - Navigate to My Projects in the Home Page.
      - Check the additional filter in the My Projects Drop down.(Open, In Progress and Closed)
      - In My Projects the projects will be populated based on the selection made on the check box.
      
       Screenshot for reference:
       
![image](https://user-images.githubusercontent.com/56516845/110114617-cc721a00-7d69-11eb-8913-65dfbf9d901c.png)

 
  
> Have you implemented any additional tests?
    No
### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: Ravindra Kumar kumar.ravindra@siemens.com