### PR TITLE
fix(ReleaseUI): fix Spdx parser for License withh + sign

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTools.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTools.java
@@ -18,6 +18,11 @@ import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.*;
 import org.apache.jena.ext.xerces.util.XMLChar;
 
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -117,6 +122,20 @@ public class SPDXParserTools {
         for (int i = 0; i < label.length(); i++) {
             // label contain invalid NCName
             if (!XMLChar.isNCName(label.charAt(i))) {
+                if (Util.splitNamespaceXML(label) == label.length()) {
+                    try {
+                        label = URLDecoder.decode(label, StandardCharsets.UTF_8.name());
+                        URL url = new URL(label);
+                        if (null != url.getRef()) {
+                            return url.getRef();
+                        } else {
+                            String path = url.getPath();
+                            return path.substring(path.lastIndexOf('/') + 1);
+                        }
+                    } catch (UnsupportedEncodingException | MalformedURLException e) {
+                      return "";
+                    }
+                }
                 return label.substring(Util.splitNamespaceXML(label));
             }
         }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/clearingDetails.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/clearingDetails.jspf
@@ -275,9 +275,11 @@
             $cell.append($('<div>', { text: data.license}));
             $cell.append($list);
 
-            data.licenseIds.forEach(function(id) {
-                $list.append($('<li>', { text: id }));
-            });
+            if (data.licenseIds) {
+                data.licenseIds.forEach(function(id) {
+                    $list.append($('<li>', { text: id }));
+                });
+            }
 
             $cell.append($('<div>', { text: data.otherLicense}));
             $cell.append($otherList);

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -46,6 +46,7 @@ public class SW360Constants {
     public static final String NA = "n/a";
     public static final String LICENSE_NAME_UNKNOWN = "License name unknown";
     public static final String OBLIGATION_TOPIC_UNKNOWN = "Obligation topic unknown";
+    public static final String NO_ASSERTION = "noassertion";
     // Proper values of the "type" member to deserialize to CouchDB
     public static final String TYPE_OBLIGATION = "obligation";
     public static final String TYPE_OBLIGATIONS = "obligations";


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> Which issue is this pull request belonging to and how is it solving it?
* #1129 

> Did you add or update any new dependencies that are required for your change?
* No

Issue: closes #1129 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
* `Show License Info` button in `Clearing Details` tab under `Release Details Page` should display the license with `+` sign.
* Should display `Other Licenses` as well. (from `spdx:licenseInfoInFile` tag)

> Have you implemented any additional tests?
* No

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
