### PR TITLE
feat(PredefinedTags):Predefined tags per group in the Projects Tag field.

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtil.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtil.java
@@ -696,4 +696,11 @@ public class DatabaseHandlerUtil {
         }
         return mapper;
     }
+
+    public static String trimProjectTag(String projectTag) {
+        if (projectTag != null) {
+            projectTag = projectTag.replaceAll(",$", "");
+        }
+        return projectTag;
+    }
 }

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -1370,6 +1370,8 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         project.setAdditionalData(DatabaseHandlerUtil.trimMapOfStringKeyStringValue(project.getAdditionalData()));
 
         project.setRoles(DatabaseHandlerUtil.trimMapOfStringKeySetValue(project.getRoles()));
+
+        project.setTag(DatabaseHandlerUtil.trimProjectTag(project.getTag()));
     }
 
     public List<Map<String, String>> getClearingStateInformationForListView(String projectId, User user)

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -578,6 +578,8 @@ public class PortalConstants {
 
     public static final String EXTERNAL_ID_SELECTED_KEYS = "externalIds";
 
+    public static final String PREDEFINED_TAGS;
+
     static {
         Properties props = CommonUtils.loadProperties(PortalConstants.class, PROPERTIES_FILE_PATH);
 
@@ -613,6 +615,7 @@ public class PortalConstants {
         USER_ROLE_ALLOWED_TO_MERGE_OR_SPLIT_COMPONENT = UserGroup.valueOf(props.getProperty("user.role.allowed.to.merge.or.split.component", UserGroup.ADMIN.name()));
         CLEARING_REPORT_TEMPLATE_TO_FILENAMEMAPPING = props.getProperty("org.eclipse.sw360.licensinfo.projectclearing.templatemapping", "");
         CLEARING_REPORT_TEMPLATE_FORMAT = props.getProperty("org.eclipse.sw360.licensinfo.projectclearing.templateformat", "docx");
+        PREDEFINED_TAGS = props.getProperty("project.tag", "[]");
     }
 
     private PortalConstants() {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/utils/_tagautocomplete.scss
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/utils/_tagautocomplete.scss
@@ -1,0 +1,18 @@
+/*
+ * Copyright Siemens AG, 2019. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+*.ui-autocomplete
+{
+max-height: 200px;
+overflow-y: auto;
+overflow-x: hidden;
+}
+

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/edit.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/edit.jsp
@@ -65,6 +65,7 @@
     <core_rt:set var="addMode"  value="${empty project.id}" />
     <core_rt:set var="pageName"  value="<%= request.getParameter("pagename") %>" />
     <core_rt:set var="isProjectObligationsEnabled" value='<%=PortalConstants.IS_PROJECT_OBLIGATIONS_ENABLED%>'/>
+    <core_rt:set var="tagAutocomplete" value='<%=PortalConstants.PREDEFINED_TAGS%>'/>
 </c:catch>
 
 <%--These variables are used as a trick to allow referencing enum values in EL expressions below--%>
@@ -237,13 +238,15 @@
 
 <%@ include file="/html/utils/includes/requirejs.jspf" %>
 <script>
-require(['jquery', 'modules/dialog', 'modules/listgroup', 'modules/validation', 'bridges/jquery-ui' ], function($, dialog, listgroup, validation) {
+require(['jquery', 'modules/autocomplete', 'modules/dialog', 'modules/listgroup', 'modules/validation', 'bridges/jquery-ui' ], function($, autocomplete, dialog, listgroup, validation) {
     document.title = $("<span></span>").html("<sw360:ProjectName project="${project}"/> - " + document.title).text();
 
     listgroup.initialize('detailTab', $('#detailTab').data('initial-tab') || 'tab-Summary');
 
     validation.enableForm('#projectEditForm');
     validation.jumpToFailedTab('#projectEditForm');
+
+    autocomplete.prepareForMultipleHits('proj_tag', ${tagAutocomplete});
 
     $('#formSubmit').click(
         function () {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/basicInfo.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/basicInfo.jspf
@@ -14,11 +14,14 @@
 <%@ page import="org.eclipse.sw360.datahandler.thrift.Visibility" %>
 <%@ page import="org.eclipse.sw360.datahandler.thrift.projects.ProjectClearingState" %>
 <%@ page import="static org.eclipse.sw360.datahandler.thrift.projects.projectsConstants.CLEARING_TEAM_UNKNOWN" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %> 
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+
+<style><%@include file="/css/utils/_tagautocomplete.scss"%></style>
 
 <core_rt:set var="clearingTeamsStringSet" value='<%=PortalConstants.SET_CLEARING_TEAMS_STRING%>'/>
 <core_rt:set var="preferredCountryCodes" value='<%=PortalConstants.PREFERRED_COUNTRY_CODES%>'/>
 <core_rt:set var="domain" value='<%=PortalConstants.DOMAIN%>'/>
+
 
 <table class="table edit-table three-columns" id="ProjectBasicInfo">
     <thead>

--- a/frontend/sw360-portlet/src/main/resources/sw360.properties
+++ b/frontend/sw360-portlet/src/main/resources/sw360.properties
@@ -210,6 +210,9 @@ portlets.activate= \
 
 logout.redirect.url=
 
+#list of predefined tags
+project.tag=[]
+
 # Possible values are "ADMIN", "SW360_ADMIN", "CLEARING_ADMIN", "CLEARING_EXPERT", "ECC_ADMIN", "SECURITY_ADMIN", "USER"
 # ADMIN by default has merge/split access
 # Access follows isUserAtLeast(ROLE)


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
     - created the new predefined tags for the Tag field in the Projects.

> * Which issue is this pull request belonging to and how is it solving it? (#1141 )
> * Did you add or update any new dependencies that are required for your change? No

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
  - Add a project in SW360 and select the tag from the auto-populated tag values.
  -  we can also write our own tag as per the group if the tag is not present in the sw360.properties.
  
![image](https://user-images.githubusercontent.com/56516845/111175105-1363d900-85ce-11eb-9076-20774e8878ad.png)

> Have you implemented any additional tests? 
No

### Checklist
Must:
- [] All related issues are referenced in commit messages and in PR

Signed-off-by: Ravindra Kumar kumar.ravindra@siemens.com