### PR TITLE
fix(build): Fix issue with overwriting of patchlevel variable in pom.xml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ before_install:
   - ./scripts/install-thrift.sh --no-cleanup
 
 env:
-  GIT_COMMIT_COUNT="$(git rev-list  `git rev-list --tags --no-walk --max-count=1`..HEAD --count)"
   MVN_ARGS="package"
 install:
   mvn dependency:resolve || true
@@ -45,9 +44,9 @@ script:
 
 matrix:
   include:
-    - name: mvn package -Pci -Dcount=$GIT_COMMIT_COUNT
+    - name: mvn package
       env: MVN_ARGS="package"
-    - name: mvn validate -Pci -Dcount=$GIT_COMMIT_COUNT
+    - name: mvn validate
       env: MVN_ARGS="validate"
       before_install:
     - name: mvn dependency:analyze

--- a/jenkins.eclipse/Jenkinsfile
+++ b/jenkins.eclipse/Jenkinsfile
@@ -80,9 +80,9 @@ spec:
                 container('sw360buildenv') {
                     script {
                         if (params.RELEASE) {
-                            VERSION_SUFFIX = "1.0-m1"
+                            VERSION_SUFFIX = "0-m1"
                         } else {
-                            VERSION_SUFFIX = "1.0-" + COUNT
+                            VERSION_SUFFIX = "0-" + COUNT
                         }
                     }
                     // FIXME: Removed the frontend from the build, because it does not build in the Container environment

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
         <!-- This is first of two places for changing the version of SW360 -->
         <!-- note that 6.1.0-SNAPSHOT relates to 6.0.${patchlevel} -->
         <!-- pls see also the profile cli -->
-        <revision>13.${patchlevel}</revision>
-        <patchlevel>2.0-SNAPSHOT</patchlevel>
+        <revision>13.2.${patchlevel}</revision>
+        <patchlevel>0-SNAPSHOT</patchlevel>
         <java.version>11</java.version>
         <ektorp.version>1.5.0</ektorp.version>
         <thrift.version>0.13.0</thrift.version>
@@ -690,16 +690,6 @@
                         </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <id>ci</id>
-            <properties>
-                <!-- second of two places for version setting: minor version -->
-                <patchlevel>1.${count}</patchlevel>
-            </properties>
         </profile>
         <profile>
             <activation>


### PR DESCRIPTION
Issue is that the maven flatten module is not able to handle the
double definition of variable patchlevel in the pom correctly.
The generated pom files have the wrong version.
Solution: Put the minor version in the revision variable and
reduce the standard patchlevel content to the idea from the "ci"
profile. Remove the "ci" profile and adapt the travis and jenkins
build files.

Removed the version handling from travis build because it was obsolete.
The whole mechanism was only used to define the name of the build, but not
the version of the mvn call. Since the variable did not make sense, I removed 
the whole mechanism.

Signed-off-by: Lars Geyer-Blaumeiser <lars.geyer-blaumeiser@bosch.io>

Fixes #1144 

### Suggest Reviewer
@mcjaeger 

### How To Test?
Check Travis and Eclipse build log for the right version to be build

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
