### PR TITLE
fix(test): Use test databases in maven test phase

### DIFF
--- a/backend/src-common/src/test/java/org/eclipse/sw360/datahandler/db/AttachmentDatabaseHandlerTest.java
+++ b/backend/src-common/src/test/java/org/eclipse/sw360/datahandler/db/AttachmentDatabaseHandlerTest.java
@@ -12,6 +12,7 @@ package org.eclipse.sw360.datahandler.db;
 import com.google.common.collect.Sets;
 
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.attachments.*;
 
@@ -28,8 +29,8 @@ import static org.junit.Assert.assertTrue;
 
 public class AttachmentDatabaseHandlerTest {
 
-    private static final String dbName = DatabaseSettings.COUCH_DB_DATABASE;
-    private static final String attachmentsDbName = DatabaseSettings.COUCH_DB_ATTACHMENTS;
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_DATABASE;
+    private static final String attachmentsDbName = DatabaseSettingsTest.COUCH_DB_ATTACHMENTS;
 
     private AttachmentDatabaseHandler uut;
 
@@ -42,7 +43,7 @@ public class AttachmentDatabaseHandlerTest {
         // only need the parameters to call the constructor
         // when this changes, the database has to be created before and deleted
         // afterwards - see e.g. ProjectDatabaseHandlerTest
-        uut = new AttachmentDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), dbName, attachmentsDbName);
+        uut = new AttachmentDatabaseHandler(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, attachmentsDbName);
     }
 
     @Test

--- a/backend/src-common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerTest.java
+++ b/backend/src-common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerTest.java
@@ -14,7 +14,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.SetMultimap;
 
 import org.eclipse.sw360.datahandler.TestUtils;
-import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.entitlement.ProjectModerator;
 import org.eclipse.sw360.datahandler.thrift.*;
@@ -45,9 +45,9 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ProjectDatabaseHandlerTest {
 
-    private static final String dbName = DatabaseSettings.COUCH_DB_DATABASE;
-    private static final String attachmentDbName = DatabaseSettings.COUCH_DB_ATTACHMENTS;
-    private static final String attachmentsDbName = DatabaseSettings.COUCH_DB_ATTACHMENTS;
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_DATABASE;
+    private static final String attachmentDbName = DatabaseSettingsTest.COUCH_DB_ATTACHMENTS;
+    private static final String attachmentsDbName = DatabaseSettingsTest.COUCH_DB_ATTACHMENTS;
 
     private static final User user1 = new User().setEmail("user1").setDepartment("AB CD EF");
     private static final User user2 = new User().setEmail("user2").setDepartment("AB CD FE");
@@ -104,10 +104,10 @@ public class ProjectDatabaseHandlerTest {
         releases.add(new Release().setId("r6").setComponentId("c1"));
 
         // Create the database
-        TestUtils.createDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
 
         // Prepare the database
-        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
         for (Project project : projects) {
             databaseConnector.add(project);
         }
@@ -118,15 +118,15 @@ public class ProjectDatabaseHandlerTest {
 
         databaseConnector.add(new Component("comp1").setId("c1"));
 
-        componentHandler = new ComponentDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), dbName, attachmentsDbName);
-        attachmentDatabaseHandler = new AttachmentDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), dbName, attachmentsDbName);
-        handler = new ProjectDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), dbName, attachmentDbName, moderator, componentHandler, attachmentDatabaseHandler);
+        componentHandler = new ComponentDatabaseHandler(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, attachmentsDbName);
+        attachmentDatabaseHandler = new AttachmentDatabaseHandler(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, attachmentsDbName);
+        handler = new ProjectDatabaseHandler(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, attachmentDbName, moderator, componentHandler, attachmentDatabaseHandler);
     }
 
     @After
     public void tearDown() throws Exception {
         // Delete the database
-        TestUtils.deleteDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
     }
 
 

--- a/backend/src/src-attachments/src/main/java/org/eclipse/sw360/attachments/AttachmentHandler.java
+++ b/backend/src/src-attachments/src/main/java/org/eclipse/sw360/attachments/AttachmentHandler.java
@@ -18,6 +18,7 @@ import org.eclipse.sw360.datahandler.thrift.RequestSummary;
 import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.attachments.*;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.ektorp.http.HttpClient;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 
 import java.net.MalformedURLException;
@@ -25,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.eclipse.sw360.datahandler.common.SW360Assert.*;
@@ -42,6 +44,10 @@ public class AttachmentHandler implements AttachmentService.Iface {
 
     public AttachmentHandler() throws MalformedURLException {
         handler = new AttachmentDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE, DatabaseSettings.COUCH_DB_ATTACHMENTS);
+    }
+
+    public AttachmentHandler(Supplier<HttpClient> httpClient, String dbName, String attachmentDbName) throws MalformedURLException {
+        handler = new AttachmentDatabaseHandler(httpClient, dbName, attachmentDbName);
     }
 
     @Override

--- a/backend/src/src-attachments/src/test/java/org/eclipse/sw360/attachments/AttachmentHandlerTest.java
+++ b/backend/src/src-attachments/src/test/java/org/eclipse/sw360/attachments/AttachmentHandlerTest.java
@@ -16,6 +16,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.eclipse.sw360.datahandler.TestUtils;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestSummary;
@@ -41,7 +42,7 @@ import static org.junit.Assert.assertThat;
 
 public class AttachmentHandlerTest {
 
-    private static final String dbName = DatabaseSettings.COUCH_DB_ATTACHMENTS;
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_ATTACHMENTS;
 
     private AttachmentHandler handler;
 
@@ -52,21 +53,21 @@ public class AttachmentHandlerTest {
     @Before
     public void setUp() throws Exception {
         // Create the database
-        TestUtils.createDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
-        TestUtils.createDatabase(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE);
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), DatabaseSettingsTest.COUCH_DB_DATABASE);
 
-        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
         databaseConnector.add(new AttachmentContent().setId("A1").setFilename("a.txt").setContentType("text"));
         databaseConnector.add(new AttachmentContent().setId("A2").setFilename("b.jpg").setContentType("image"));
 
-        handler = new AttachmentHandler();
+        handler = new AttachmentHandler(DatabaseSettingsTest.getConfiguredHttpClient(), DatabaseSettingsTest.COUCH_DB_DATABASE, dbName);
     }
 
     @After
     public void tearDown() throws Exception {
         // Delete the database
-        TestUtils.deleteDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
-        TestUtils.deleteDatabase(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE);
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), DatabaseSettingsTest.COUCH_DB_DATABASE);
     }
 
     @Test

--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -58,7 +58,7 @@ public class ComponentHandler implements ComponentService.Iface {
         this(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE, DatabaseSettings.COUCH_DB_ATTACHMENTS, thriftClients);
     }
 
-    ComponentHandler(Supplier<HttpClient> httpClient, String dbName, String attachmentDbName, ThriftClients thriftClients) throws IOException {
+    public ComponentHandler(Supplier<HttpClient> httpClient, String dbName, String attachmentDbName, ThriftClients thriftClients) throws IOException {
         handler = new ComponentDatabaseHandler(httpClient, dbName, attachmentDbName, thriftClients);
         componentSearchHandler = new ComponentSearchHandler(httpClient, dbName);
         releaseSearchHandler = new ReleaseSearchHandler(httpClient, dbName);

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -14,7 +14,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import org.eclipse.sw360.datahandler.TestUtils;
-import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.db.ComponentDatabaseHandler;
 import org.eclipse.sw360.datahandler.entitlement.ComponentModerator;
@@ -53,8 +53,8 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ComponentDatabaseHandlerTest {
 
-    private static final String dbName = DatabaseSettings.COUCH_DB_DATABASE;
-    private static final String attachmentsDbName = DatabaseSettings.COUCH_DB_ATTACHMENTS;
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_DATABASE;
+    private static final String attachmentsDbName = DatabaseSettingsTest.COUCH_DB_ATTACHMENTS;
 
     private static final String email1 = "cedric.bodet@tngtech.com";
     private static final String email2 = "johannes.najjar@tngtech.com";
@@ -129,10 +129,10 @@ public class ComponentDatabaseHandlerTest {
         releases.add(release2c);
 
         // Create the database
-        TestUtils.createDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
 
         // Prepare the database
-        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
 
         for (Vendor vendor : vendors.values()) {
             databaseConnector.add(vendor);
@@ -147,12 +147,12 @@ public class ComponentDatabaseHandlerTest {
         componentMap= ThriftUtils.getIdMap(components);
 
         // Prepare the handler
-        handler = new ComponentDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), dbName, attachmentsDbName, moderator, releaseModerator, projectModerator);
+        handler = new ComponentDatabaseHandler(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, attachmentsDbName, moderator, releaseModerator, projectModerator);
     }
 
     @After
     public void tearDown() throws Exception {
-        TestUtils.deleteDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
     }
 
     @Test

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentSearchHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentSearchHandlerTest.java
@@ -12,7 +12,7 @@ package org.eclipse.sw360.components.db;
 
 import com.google.common.collect.ImmutableSet;
 import org.eclipse.sw360.datahandler.TestUtils;
-import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseInstance;
 import org.eclipse.sw360.datahandler.db.ComponentSearchHandler;
@@ -32,8 +32,8 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.Is.is;
 
 public class ComponentSearchHandlerTest {
-    private static final String url = DatabaseSettings.COUCH_DB_URL;
-    private static final String dbName = DatabaseSettings.COUCH_DB_DATABASE;
+    private static final String url = DatabaseSettingsTest.COUCH_DB_URL;
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_DATABASE;
 
     private static final String email1 = "cedric.bodet@tngtech.com";
     private static final String email2 = "johannes.najjar@tngtech.com";
@@ -74,22 +74,22 @@ public class ComponentSearchHandlerTest {
         components.add(component3);
 
         // Create the database
-        TestUtils.createDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
 
         // Prepare the database
-        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
 
         for (Component component : components) {
             databaseConnector.add(component);
         }
 
         // Prepare the handler
-        searchHandler = new ComponentSearchHandler(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        searchHandler = new ComponentSearchHandler(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
     }
 
     @After
     public void tearDown() throws Exception {
-        TestUtils.deleteDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
     }
 
     @Test

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ProjectDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ProjectDatabaseHandlerTest.java
@@ -12,7 +12,7 @@ package org.eclipse.sw360.components.db;
 
 import com.google.common.collect.ImmutableMap;
 import org.eclipse.sw360.datahandler.TestUtils;
-import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.db.AttachmentDatabaseHandler;
 import org.eclipse.sw360.datahandler.db.ComponentDatabaseHandler;
@@ -56,8 +56,8 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ProjectDatabaseHandlerTest {
 
-    private static final String dbName = DatabaseSettings.COUCH_DB_DATABASE;
-    private static final String attachmentsDbName = DatabaseSettings.COUCH_DB_ATTACHMENTS;
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_DATABASE;
+    private static final String attachmentsDbName = DatabaseSettingsTest.COUCH_DB_ATTACHMENTS;
 
     @Rule
     public final ExpectedException exception = ExpectedException.none();
@@ -115,10 +115,10 @@ public class ProjectDatabaseHandlerTest {
         projects.add(project7);
 
         // Create the database
-        TestUtils.createDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
 
         // Prepare the database
-        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
 
         for (Vendor vendor : vendors) {
             databaseConnector.add(vendor);
@@ -133,9 +133,9 @@ public class ProjectDatabaseHandlerTest {
             databaseConnector.add(project);
         }
 
-        ComponentDatabaseHandler componentHandler = new ComponentDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), dbName, attachmentsDbName);
-        AttachmentDatabaseHandler attachmentDatabaseHandler = new AttachmentDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), dbName, attachmentsDbName);
-        handler = new ProjectDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), dbName, attachmentsDbName, moderator, componentHandler, attachmentDatabaseHandler);
+        ComponentDatabaseHandler componentHandler = new ComponentDatabaseHandler(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, attachmentsDbName);
+        AttachmentDatabaseHandler attachmentDatabaseHandler = new AttachmentDatabaseHandler(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, attachmentsDbName);
+        handler = new ProjectDatabaseHandler(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, attachmentsDbName, moderator, componentHandler, attachmentDatabaseHandler);
     }
 
     private ProjectReleaseRelationship newDefaultProjectReleaseRelationship() {
@@ -144,7 +144,7 @@ public class ProjectDatabaseHandlerTest {
 
     @After
     public void tearDown() throws Exception {
-        TestUtils.deleteDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
     }
 
     @Test

--- a/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/FossologyHandlerLocalhostIntegrationTest.java
+++ b/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/FossologyHandlerLocalhostIntegrationTest.java
@@ -41,8 +41,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.eclipse.sw360.datahandler.common.DatabaseSettings.COUCH_DB_CONFIG;
-import static org.eclipse.sw360.datahandler.common.DatabaseSettings.getConfiguredHttpClient;
+import static org.eclipse.sw360.datahandler.common.DatabaseSettingsTest.COUCH_DB_CONFIG;
+import static org.eclipse.sw360.datahandler.common.DatabaseSettingsTest.getConfiguredHttpClient;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;

--- a/backend/src/src-health/src/main/java/org/eclipse/sw360/health/HealthHandler.java
+++ b/backend/src/src-health/src/main/java/org/eclipse/sw360/health/HealthHandler.java
@@ -13,8 +13,11 @@ import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.thrift.health.Health;
 import org.eclipse.sw360.datahandler.thrift.health.HealthService;
 import org.eclipse.sw360.health.db.HealthDatabaseHandler;
+import org.ektorp.http.HttpClient;
 
 import java.net.MalformedURLException;
+import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Implementation of the thrift service "Health"
@@ -27,8 +30,17 @@ public class HealthHandler implements HealthService.Iface {
         handler = new HealthDatabaseHandler(DatabaseSettings.getConfiguredHttpClient());
     }
 
+    HealthHandler(Supplier<HttpClient> httpClient) throws MalformedURLException {
+        handler = new HealthDatabaseHandler(httpClient);
+    }
+
     @Override
     public Health getHealth() {
         return handler.getHealth();
+    }
+
+    @Override
+    public Health getHealthOfSpecificDbs(Set<String> dbsToCheck){
+        return handler.getHealthOfSpecificDbs(dbsToCheck);
     }
 }

--- a/backend/src/src-health/src/main/java/org/eclipse/sw360/health/db/HealthDatabaseHandler.java
+++ b/backend/src/src-health/src/main/java/org/eclipse/sw360/health/db/HealthDatabaseHandler.java
@@ -36,9 +36,13 @@ public class HealthDatabaseHandler {
     }
 
     public Health getHealth() {
+        return getHealthOfDbs(DATABASES_TO_CHECK);
+    }
+
+    private Health getHealthOfDbs(Set<String> dbsTocheck) {
         final Health health = new Health().setDetails(new HashMap<>());
 
-        for (String database : DATABASES_TO_CHECK) {
+        for (String database : dbsTocheck) {
             try {
                 if (!db.checkIfDbExists(database)) {
                     health.getDetails().put(database, String.format("The database '%s' does not exist.", database));
@@ -51,9 +55,13 @@ public class HealthDatabaseHandler {
         if (health.getDetails().isEmpty()) {
             return health.setStatus(Status.UP);
         } else {
-            return health.getDetails().size() == DATABASES_TO_CHECK.size() ?
+            return health.getDetails().size() == dbsTocheck.size() ?
                     health.setStatus(Status.DOWN) :
                     health.setStatus(Status.ERROR);
         }
+    }
+
+    public Health getHealthOfSpecificDbs(Set<String> dbsToCheck) {
+        return getHealthOfDbs(dbsToCheck);
     }
 }

--- a/backend/src/src-health/src/test/java/org/eclipse/sw360/health/HealthHandlerTest.java
+++ b/backend/src/src-health/src/test/java/org/eclipse/sw360/health/HealthHandlerTest.java
@@ -11,52 +11,60 @@ package org.eclipse.sw360.health;
 
 import org.eclipse.sw360.datahandler.TestUtils;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.thrift.health.Health;
 import org.eclipse.sw360.datahandler.thrift.health.Status;
 import org.eclipse.sw360.health.db.HealthDatabaseHandler;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.net.MalformedURLException;
 import java.util.HashMap;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 
 public class HealthHandlerTest {
+    public static final Set<String> DATABASES_TO_CHECK = ImmutableSet.of(
+            DatabaseSettingsTest.COUCH_DB_ATTACHMENTS,
+            DatabaseSettingsTest.COUCH_DB_DATABASE,
+            DatabaseSettingsTest.COUCH_DB_USERS);
     @Test
     public void testGetHealthFailsUponMissingDB() throws MalformedURLException {
         TestUtils.deleteAllDatabases();
-        HealthHandler healthHandler = new HealthHandler();
-        final Health health = healthHandler.getHealth();
+        HealthHandler healthHandler = new HealthHandler(DatabaseSettingsTest.getConfiguredHttpClient());
+        final Health health = healthHandler.getHealthOfSpecificDbs(DATABASES_TO_CHECK);
         assertEquals(Status.DOWN, health.status);
-        assertEquals(HealthDatabaseHandler.DATABASES_TO_CHECK.size(), health.getDetails().size());
+        assertEquals(DATABASES_TO_CHECK.size(), health.getDetails().size());
     }
 
     @Test
     public void testGetHealth() throws MalformedURLException {
-        for (String database : HealthDatabaseHandler.DATABASES_TO_CHECK) {
-            TestUtils.createDatabase(DatabaseSettings.getConfiguredHttpClient(), database);
+        for (String database : DATABASES_TO_CHECK) {
+            TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), database);
         }
 
-        HealthHandler healthHandler = new HealthHandler();
+        HealthHandler healthHandler = new HealthHandler(DatabaseSettingsTest.getConfiguredHttpClient());
         final Health health = healthHandler.getHealth();
         assertEquals(Status.UP, health.status);
         assertEquals(new HashMap<>(), health.getDetails());
 
-        for (String database : HealthDatabaseHandler.DATABASES_TO_CHECK) {
-            TestUtils.deleteDatabase(DatabaseSettings.getConfiguredHttpClient(), database);
+        for (String database : DATABASES_TO_CHECK) {
+            TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), database);
         }
     }
 
     @Test
     public void testGetHealthWithPartialDBMissing() throws MalformedURLException {
-        final String couchDbDatabase = DatabaseSettings.COUCH_DB_DATABASE;
-        TestUtils.createDatabase(DatabaseSettings.getConfiguredHttpClient(), couchDbDatabase);
+        final String couchDbDatabase = DatabaseSettingsTest.COUCH_DB_DATABASE;
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), couchDbDatabase);
 
-        HealthHandler healthHandler = new HealthHandler();
-        final Health health = healthHandler.getHealth();
+        HealthHandler healthHandler = new HealthHandler(DatabaseSettingsTest.getConfiguredHttpClient());
+        final Health health = healthHandler.getHealthOfSpecificDbs(DATABASES_TO_CHECK);
         assertEquals(Status.ERROR, health.getStatus());
-        assertEquals(HealthDatabaseHandler.DATABASES_TO_CHECK.size() -1, health.getDetails().size());
+        assertEquals(DATABASES_TO_CHECK.size() -1, health.getDetails().size());
 
-        TestUtils.deleteDatabase(DatabaseSettings.getConfiguredHttpClient(), couchDbDatabase);
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), couchDbDatabase);
     }
 }

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/LicenseHandler.java
@@ -20,11 +20,13 @@ import org.eclipse.sw360.datahandler.thrift.CustomProperties;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.licenses.db.LicenseDatabaseHandler;
+import org.ektorp.http.HttpClient;
 import org.apache.thrift.TException;
 
 import java.net.MalformedURLException;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.eclipse.sw360.datahandler.common.SW360Assert.*;
 
@@ -39,6 +41,10 @@ public class LicenseHandler implements LicenseService.Iface {
 
     LicenseHandler() throws MalformedURLException {
         handler = new LicenseDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE);
+    }
+
+    LicenseHandler(Supplier<HttpClient> httpClient, String dbName) throws MalformedURLException {
+        handler = new LicenseDatabaseHandler(httpClient, dbName);
     }
 
     /////////////////////

--- a/backend/src/src-licenses/src/test/java/org/eclipse/sw360/licenses/LicenseHandlerTest.java
+++ b/backend/src/src-licenses/src/test/java/org/eclipse/sw360/licenses/LicenseHandlerTest.java
@@ -10,7 +10,7 @@
 package org.eclipse.sw360.licenses;
 
 import org.eclipse.sw360.datahandler.TestUtils;
-import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
@@ -33,7 +33,7 @@ import static org.junit.Assert.*;
  */
 public class LicenseHandlerTest {
 
-    private static final String dbName = DatabaseSettings.COUCH_DB_DATABASE;
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_DATABASE;
 
     private LicenseHandler handler;
     private User user;
@@ -54,13 +54,13 @@ public class LicenseHandlerTest {
     @Before
     public void setUp() throws Exception {
         // Create the database
-        TestUtils.createDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
 
         // Create all test entries
         createTestEntries();
 
         // Create the handler
-        handler = new LicenseHandler();
+        handler = new LicenseHandler(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
 
         // Create the user
         user = new User().setEmail("test@siemens.com").setDepartment("CT BE OP SWI OSS").setUserGroup(UserGroup.ADMIN);
@@ -69,7 +69,7 @@ public class LicenseHandlerTest {
     @After
     public void tearDown() throws Exception {
         // Delete the database
-        TestUtils.deleteDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
     }
 
     @Test
@@ -203,7 +203,7 @@ public class LicenseHandlerTest {
         obligs.put("T4", oblig4);
         obligs.put("T5", oblig5);
 
-        DatabaseConnector db = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        DatabaseConnector db = new DatabaseConnector(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
 
         // Add obligations to database
         for (Obligation oblig : obligs.values()) {

--- a/backend/src/src-moderation/src/test/java/org/eclipse/sw360/moderation/testutil/DatabaseTestSetup.java
+++ b/backend/src/src-moderation/src/test/java/org/eclipse/sw360/moderation/testutil/DatabaseTestSetup.java
@@ -10,7 +10,7 @@
 
 package org.eclipse.sw360.moderation.testutil;
 
-import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.moderation.DocumentType;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
@@ -26,7 +26,7 @@ public class DatabaseTestSetup {
 
     public static void main(String[] args) throws MalformedURLException {
 
-        DatabaseConnector db = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE);
+        DatabaseConnector db = new DatabaseConnector(DatabaseSettingsTest.getConfiguredHttpClient(), DatabaseSettingsTest.COUCH_DB_DATABASE);
 
         Project project = new Project().setName("Test Project");
         project.addToModerators("user1");

--- a/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -31,12 +31,14 @@ import org.eclipse.sw360.datahandler.thrift.projects.UsedReleaseRelations;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.LicenseInfoService;
 import org.eclipse.sw360.datahandler.thrift.users.User;
+import org.ektorp.http.HttpClient;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.eclipse.sw360.datahandler.common.SW360Assert.*;
 
@@ -57,6 +59,11 @@ public class ProjectHandler implements ProjectService.Iface {
     ProjectHandler() throws IOException {
         handler = new ProjectDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE, DatabaseSettings.COUCH_DB_ATTACHMENTS);
         searchHandler = new ProjectSearchHandler(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE);
+    }
+
+    ProjectHandler(Supplier<HttpClient> httpClient, String dbName, String attchmntDbName) throws IOException {
+        handler = new ProjectDatabaseHandler(httpClient, dbName, attchmntDbName);
+        searchHandler = new ProjectSearchHandler(httpClient, dbName);
     }
 
     /////////////////////

--- a/backend/src/src-projects/src/test/java/org/eclipse/sw360/projects/ProjectHandlerTest.java
+++ b/backend/src/src-projects/src/test/java/org/eclipse/sw360/projects/ProjectHandlerTest.java
@@ -12,7 +12,7 @@ package org.eclipse.sw360.projects;
 
 import com.google.common.collect.ImmutableMap;
 import org.eclipse.sw360.datahandler.TestUtils;
-import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.db.AttachmentDatabaseHandler;
@@ -42,8 +42,8 @@ import static org.junit.Assert.assertEquals;
 
 public class ProjectHandlerTest {
 
-    private static final String dbName = DatabaseSettings.COUCH_DB_DATABASE;
-    private static final String attachmentDbName = DatabaseSettings.COUCH_DB_ATTACHMENTS;
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_DATABASE;
+    private static final String attachmentDbName = DatabaseSettingsTest.COUCH_DB_ATTACHMENTS;
 
     private static final User user1 = new User().setEmail("user1").setDepartment("AB CD EF");
     private static final User user2 = new User().setEmail("user2").setDepartment("AB CD FE");
@@ -62,22 +62,22 @@ public class ProjectHandlerTest {
         projects.add(new Project().setId("P3").setName("Project3").setBusinessUnit("AB CD EF").setCreatedBy("user3").setReleaseIdToUsage(Collections.emptyMap()));
 
         // Create the database
-        TestUtils.createDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
 
         // Prepare the database
-        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
         for (Project project : projects) {
             databaseConnector.add(project);
         }
 
         // Create the connector
-        handler = new ProjectHandler();
+        handler = new ProjectHandler(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, attachmentDbName);
     }
 
     @After
     public void tearDown() throws Exception {
         // Delete the database
-        TestUtils.deleteDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
     }
 
     @Test
@@ -220,9 +220,9 @@ public class ProjectHandlerTest {
     public void testUpdateProject2_1() throws Exception {
         ProjectModerator moderator = Mockito.mock(ProjectModerator.class);
 
-        ProjectDatabaseHandler handler = new ProjectDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), dbName, attachmentDbName, moderator,
-                new ComponentDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), dbName, attachmentDbName),
-                new AttachmentDatabaseHandler(DatabaseSettings.getConfiguredHttpClient(), dbName, attachmentDbName));
+        ProjectDatabaseHandler handler = new ProjectDatabaseHandler(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, attachmentDbName, moderator,
+                new ComponentDatabaseHandler(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, attachmentDbName),
+                new AttachmentDatabaseHandler(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, attachmentDbName));
         Project project2 = handler.getProjectById("P2", user1);
         project2.setName("Project2new");
 

--- a/backend/src/src-users/src/test/java/org/eclipse/sw360/users/UserHandlerTest.java
+++ b/backend/src/src-users/src/test/java/org/eclipse/sw360/users/UserHandlerTest.java
@@ -10,7 +10,7 @@
 package org.eclipse.sw360.users;
 
 import org.eclipse.sw360.datahandler.TestUtils;
-import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.junit.After;
 import org.junit.Before;
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertFalse;
 
 
 public class UserHandlerTest {
-    private static final String dbName = DatabaseSettings.COUCH_DB_USERS;
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_USERS;
 
     private static final String DUMMY_EMAIL_ADDRESS_1 = "dummy.user1@dummy.domain.tld";
     private static final String DUMMY_EMAIL_ADDRESS_2 = "dummy.user2@dummy.domain.tld";
@@ -33,7 +33,7 @@ public class UserHandlerTest {
     @Before
     public void setUp() throws Exception {
         // Create the database
-        TestUtils.createDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
 
         // Create the connector
         handler = new UserHandler();
@@ -42,7 +42,7 @@ public class UserHandlerTest {
     @After
     public void tearDown() throws Exception {
         // Delete the database
-        TestUtils.deleteDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
     }
 
     @Test

--- a/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorHandler.java
+++ b/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorHandler.java
@@ -17,11 +17,13 @@ import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vendors.VendorService;
+import org.ektorp.http.HttpClient;
 
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.eclipse.sw360.datahandler.common.SW360Assert.*;
 public class VendorHandler implements VendorService.Iface {
@@ -31,6 +33,12 @@ public class VendorHandler implements VendorService.Iface {
 
     public VendorHandler() throws IOException {
         DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE);
+        vendorDatabaseHandler = new VendorDatabaseHandler(databaseConnector);
+        vendorSearchHandler = new VendorSearchHandler(databaseConnector);     // Remove release id from component
+    }
+
+    public VendorHandler(Supplier<HttpClient> httpClient, String dbName) throws IOException {
+        DatabaseConnector databaseConnector = new DatabaseConnector(httpClient, dbName);
         vendorDatabaseHandler = new VendorDatabaseHandler(databaseConnector);
         vendorSearchHandler = new VendorSearchHandler(databaseConnector);     // Remove release id from component
     }

--- a/backend/src/src-vendors/src/test/java/org/eclipse/sw360/vendors/TestVendorClient.java
+++ b/backend/src/src-vendors/src/test/java/org/eclipse/sw360/vendors/TestVendorClient.java
@@ -9,7 +9,7 @@
  */
 package org.eclipse.sw360.vendors;
 
-import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.datahandler.thrift.vendors.VendorService;
@@ -31,7 +31,7 @@ public class TestVendorClient {
 
     @SuppressWarnings("unused")
     public static void InitDatabase() throws MalformedURLException {
-        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE);
+        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettingsTest.getConfiguredHttpClient(), DatabaseSettingsTest.COUCH_DB_DATABASE);
 
         databaseConnector.add(new Vendor().setShortname("Microsoft").setFullname("Microsoft Corporation").setUrl("http://www.microsoft.com"));
         databaseConnector.add(new Vendor().setShortname("Apache").setFullname("The Apache Software Foundation").setUrl("http://www.apache.org"));

--- a/backend/src/src-vendors/src/test/java/org/eclipse/sw360/vendors/VendorHandlerTest.java
+++ b/backend/src/src-vendors/src/test/java/org/eclipse/sw360/vendors/VendorHandlerTest.java
@@ -10,7 +10,7 @@
 package org.eclipse.sw360.vendors;
 
 import org.eclipse.sw360.datahandler.TestUtils;
-import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseInstance;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertNotNull;
 
 public class VendorHandlerTest {
 
-    private static final String dbName = DatabaseSettings.COUCH_DB_DATABASE;
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_DATABASE;
 
     private VendorHandler vendorHandler;
     private List<Vendor> vendorList;
@@ -36,10 +36,10 @@ public class VendorHandlerTest {
     public void setUp() throws Exception {
 
         // Create the database
-        TestUtils.createDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        TestUtils.createDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
 
         // Prepare the database
-        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
         vendorList = new ArrayList<>();
         vendorList.add(new Vendor().setShortname("Microsoft").setFullname("Microsoft Corporation").setUrl("http://www.microsoft.com"));
         vendorList.add(new Vendor().setShortname("Apache").setFullname("The Apache Software Foundation").setUrl("http://www.apache.org"));
@@ -49,13 +49,13 @@ public class VendorHandlerTest {
             databaseConnector.add(vendor);
         }
 
-        vendorHandler = new VendorHandler();
+        vendorHandler = new VendorHandler(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
     }
 
     @After
     public void tearDown() throws Exception {
         // Delete the database
-        TestUtils.deleteDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        TestUtils.deleteDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
     }
 
 

--- a/backend/utils/src/test/java/org/eclipse/sw360/attachments/db/RemoteAttachmentDownloaderTest.java
+++ b/backend/utils/src/test/java/org/eclipse/sw360/attachments/db/RemoteAttachmentDownloaderTest.java
@@ -10,7 +10,7 @@
 package org.eclipse.sw360.attachments.db;
 
 import org.eclipse.sw360.datahandler.TestUtils;
-import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.common.Duration;
 import org.eclipse.sw360.datahandler.couchdb.AttachmentConnector;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
@@ -53,8 +53,8 @@ import static org.junit.Assume.assumeThat;
  */
 public class RemoteAttachmentDownloaderTest {
 
-    private static final String url = DatabaseSettings.COUCH_DB_URL;
-    private static final String dbName = DatabaseSettings.COUCH_DB_ATTACHMENTS;
+    private static final String url = DatabaseSettingsTest.COUCH_DB_URL;
+    private static final String dbName = DatabaseSettingsTest.COUCH_DB_ATTACHMENTS;
 
     private AttachmentConnector attachmentConnector;
     private AttachmentContentRepository repository;
@@ -67,13 +67,13 @@ public class RemoteAttachmentDownloaderTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         assertTestString(dbName);
-        deleteDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+        deleteDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
     }
 
     @Before
     public void setUp() throws Exception {
-        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), dbName);
-        attachmentConnector = new AttachmentConnector(DatabaseSettings.getConfiguredHttpClient(), dbName, downloadTimeout);
+        DatabaseConnector databaseConnector = new DatabaseConnector(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
+        attachmentConnector = new AttachmentConnector(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, downloadTimeout);
         repository = new AttachmentContentRepository(databaseConnector);
 
         garbage = new ArrayList<>();
@@ -90,7 +90,7 @@ public class RemoteAttachmentDownloaderTest {
     public void testIntegration() throws Exception {
         AttachmentContent attachmentContent = saveRemoteAttachment(url);
 
-        assertThat(retrieveRemoteAttachments(DatabaseSettings.getConfiguredHttpClient(), dbName, downloadTimeout), is(1));
+        assertThat(retrieveRemoteAttachments(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, downloadTimeout), is(1));
 
         assertThat(attachmentConnector.getAttachmentStream(attachmentContent, dummyUser,
                         new Project()
@@ -99,7 +99,7 @@ public class RemoteAttachmentDownloaderTest {
                                 .setAttachments(Collections.singleton(new Attachment().setAttachmentContentId(attachmentContent.getId())))),
                 hasLength(greaterThan(0l)));
 
-        assertThat(retrieveRemoteAttachments(DatabaseSettings.getConfiguredHttpClient(), dbName, downloadTimeout), is(0));
+        assertThat(retrieveRemoteAttachments(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, downloadTimeout), is(0));
     }
 
     @Test
@@ -115,7 +115,7 @@ public class RemoteAttachmentDownloaderTest {
             Future<Integer> future = executor.submit(new Callable<Integer>() {
                 @Override
                 public Integer call() throws Exception {
-                    return retrieveRemoteAttachments(DatabaseSettings.getConfiguredHttpClient(), dbName, downloadTimeout);
+                    return retrieveRemoteAttachments(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, downloadTimeout);
                 }
             });
 
@@ -140,7 +140,7 @@ public class RemoteAttachmentDownloaderTest {
         AttachmentContent attachmentGood = saveRemoteAttachment(url);
 
         assertThat(repository.getOnlyRemoteAttachments(), hasSize(2));
-        assertThat(retrieveRemoteAttachments(DatabaseSettings.getConfiguredHttpClient(), dbName, downloadTimeout), is(1));
+        assertThat(retrieveRemoteAttachments(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, downloadTimeout), is(1));
         assertThat(repository.getOnlyRemoteAttachments(), hasSize(1));
 
         assertThat(attachmentConnector.getAttachmentStream(attachmentGood, dummyUser,
@@ -151,7 +151,7 @@ public class RemoteAttachmentDownloaderTest {
                 hasLength(greaterThan(0l)));
 
         assertThat(repository.getOnlyRemoteAttachments(), hasSize(1));
-        assertThat(retrieveRemoteAttachments(DatabaseSettings.getConfiguredHttpClient(), dbName, downloadTimeout), is(0));
+        assertThat(retrieveRemoteAttachments(DatabaseSettingsTest.getConfiguredHttpClient(), dbName, downloadTimeout), is(0));
         assertThat(repository.getOnlyRemoteAttachments(), hasSize(1));
 
         try {

--- a/build-configuration/test-resources/couchdb-test.properties
+++ b/build-configuration/test-resources/couchdb-test.properties
@@ -11,6 +11,8 @@
 # N.B this is the build property file, copied from module build-configuration
 
 couchdb.url = http://localhost:5984
+couchdb.user =
+couchdb.password =
 couchdb.database = sw360_test_db
 couchdb.usersdb = sw360_test_users
 couchdb.attachments = sw360_test_attachments

--- a/libraries/importers/src/test/java/org/eclipse/sw360/importer/ComponentAndAttachmentAwareDBTest.java
+++ b/libraries/importers/src/test/java/org/eclipse/sw360/importer/ComponentAndAttachmentAwareDBTest.java
@@ -14,7 +14,7 @@ import com.google.common.collect.FluentIterable;
 import org.eclipse.sw360.attachments.AttachmentHandler;
 import org.eclipse.sw360.datahandler.db.AttachmentContentRepository;
 import org.eclipse.sw360.components.ComponentHandler;
-import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.common.ImportCSV;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
@@ -52,12 +52,12 @@ public class ComponentAndAttachmentAwareDBTest {
     protected User user;
 
     protected  static  DatabaseConnector getDBConnector(String couchDbDatabase) throws MalformedURLException {
-        return new DatabaseConnector(DatabaseSettings.getConfiguredHttpClient(), couchDbDatabase);
+        return new DatabaseConnector(DatabaseSettingsTest.getConfiguredHttpClient(), couchDbDatabase);
     }
 
 
     protected static AttachmentContentRepository getAttachmentContentRepository() throws MalformedURLException {
-        return new AttachmentContentRepository(getDBConnector(DatabaseSettings.COUCH_DB_ATTACHMENTS));
+        return new AttachmentContentRepository(getDBConnector(DatabaseSettingsTest.COUCH_DB_ATTACHMENTS));
     }
 
     protected static FluentIterable<ComponentCSVRecord> getCompCSVRecordsFromTestFile(String fileName) throws IOException {
@@ -77,17 +77,17 @@ public class ComponentAndAttachmentAwareDBTest {
     }
 
     protected void deleteDatabases() throws MalformedURLException {
-        deleteDatabase(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_ATTACHMENTS);
-        deleteDatabase(DatabaseSettings.getConfiguredHttpClient(), DatabaseSettings.COUCH_DB_DATABASE);
+        deleteDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), DatabaseSettingsTest.COUCH_DB_ATTACHMENTS);
+        deleteDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), DatabaseSettingsTest.COUCH_DB_DATABASE);
     }
     protected static ThriftClients getThriftClients() throws TException, IOException {
         assertTestDbNames();
 
         ThriftClients thriftClients = failingMock(ThriftClients.class);
 
-        ComponentHandler componentHandler = new ComponentHandler(thriftClients);
-        VendorHandler vendorHandler = new VendorHandler();
-        AttachmentHandler attachmentHandler = new AttachmentHandler();
+        ComponentHandler componentHandler = new ComponentHandler(DatabaseSettingsTest.getConfiguredHttpClient(),DatabaseSettingsTest.COUCH_DB_DATABASE, DatabaseSettingsTest.COUCH_DB_ATTACHMENTS, thriftClients);
+        VendorHandler vendorHandler = new VendorHandler(DatabaseSettingsTest.getConfiguredHttpClient(), DatabaseSettingsTest.COUCH_DB_DATABASE);
+        AttachmentHandler attachmentHandler = new AttachmentHandler(DatabaseSettingsTest.getConfiguredHttpClient(), DatabaseSettingsTest.COUCH_DB_DATABASE, DatabaseSettingsTest.COUCH_DB_ATTACHMENTS);
 
         ModerationService.Iface moderationService = failingMock(ModerationService.Iface.class);
 

--- a/libraries/lib-datahandler/src/main/thrift/health.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/health.thrift
@@ -30,4 +30,6 @@ service HealthService {
     * Returns a single health of the thrift service and all running thrift services
     **/
     Health getHealth();
+
+    Health getHealthOfSpecificDbs(1: set<string> dbsToCheck);
 }

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/TestUtils.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/TestUtils.java
@@ -14,6 +14,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseInstance;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseInstanceTracker;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -53,9 +54,9 @@ public class TestUtils {
     public static final String BLACK_HOLE_ADDRESS = "100::/64";
 
     private static final List<String> dbNames = ImmutableList.of(
-            DatabaseSettings.COUCH_DB_DATABASE,
-            DatabaseSettings.COUCH_DB_ATTACHMENTS,
-            DatabaseSettings.COUCH_DB_USERS);
+            DatabaseSettingsTest.COUCH_DB_DATABASE,
+            DatabaseSettingsTest.COUCH_DB_ATTACHMENTS,
+            DatabaseSettingsTest.COUCH_DB_USERS);
 
     static {
         assertTestDbNames();
@@ -70,7 +71,7 @@ public class TestUtils {
 
     public static void deleteAllDatabases() throws MalformedURLException {
         for (String dbName : dbNames) {
-            deleteDatabase(DatabaseSettings.getConfiguredHttpClient(), dbName);
+            deleteDatabase(DatabaseSettingsTest.getConfiguredHttpClient(), dbName);
         }
     }
 

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/common/DatabaseSettingsTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/common/DatabaseSettingsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Siemens AG, 2021. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.common;
+
+import org.ektorp.http.HttpClient;
+import org.ektorp.http.StdHttpClient;
+
+import java.net.MalformedURLException;
+import java.util.Properties;
+import java.util.function.Supplier;
+
+/**
+ * Constants for the database address
+ */
+public class DatabaseSettingsTest {
+
+    public static final String PROPERTIES_FILE_PATH = "/couchdb-test.properties";
+
+    public static final String COUCH_DB_URL;
+    public static final String COUCH_DB_LUCENE_URL;
+    public static final String COUCH_DB_DATABASE;
+    public static final String COUCH_DB_ATTACHMENTS;
+    public static final String COUCH_DB_CONFIG;
+    public static final String COUCH_DB_USERS;
+    public static final String COUCH_DB_VM;
+
+    private static final String COUCH_DB_USERNAME;
+    private static final String COUCH_DB_PASSWORD;
+
+    static {
+        Properties props = CommonUtils.loadProperties(DatabaseSettingsTest.class, PROPERTIES_FILE_PATH);
+
+        COUCH_DB_URL = props.getProperty("couchdb.url", "http://localhost:5984");
+        COUCH_DB_LUCENE_URL = props.getProperty("couchdb.lucene.url", "http://localhost:8080/couchdb-lucene");
+        COUCH_DB_DATABASE = props.getProperty("couchdb.database", "sw360_test_db");
+        COUCH_DB_USERNAME = props.getProperty("couchdb.user", "");
+        COUCH_DB_PASSWORD = props.getProperty("couchdb.password", "");
+        COUCH_DB_ATTACHMENTS = props.getProperty("couchdb.attachments", "sw360_test_attachments");
+        COUCH_DB_CONFIG = props.getProperty("couchdb.config", "sw360_test_config");
+        COUCH_DB_USERS = props.getProperty("couchdb.usersdb", "sw360_test_users");
+        COUCH_DB_VM = props.getProperty("couchdb.vulnerability_management", "sw360_test_vm");
+    }
+
+    public static Supplier<HttpClient> getConfiguredHttpClient() throws MalformedURLException {
+        StdHttpClient.Builder httpClientBuilder = new StdHttpClient.Builder().url(COUCH_DB_URL);
+        if(! "".equals(COUCH_DB_USERNAME)) {
+            httpClientBuilder.username(COUCH_DB_USERNAME);
+        }
+        if (! "".equals(COUCH_DB_PASSWORD)) {
+            httpClientBuilder.password(COUCH_DB_PASSWORD);
+        }
+        return httpClientBuilder::build;
+    }
+
+
+    private DatabaseSettingsTest() {
+        // Utility class with only static functions
+    }
+
+}


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Added a new `DatabaseSettingsTest` class which will be used for test cases and renamed the `couchdb.properties` to `couchdb-test.properties` in test resources of build-configuration module which is used to keep the test database names and credentials.

> * Which issue is this pull request belonging to and how is it solving it? (*#1125*)
> * Did you add or update any new dependencies that are required for your change? - No

Issue: Closes #1125 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?

Need to place `couchdb-test.properties` with test db names and credentials in /etc/sw360 and to verify if it creates and uses the databases with "test" string and uses them for unit test cases.

> Have you implemented any additional tests? - No

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
Signed-off-by: Smruti Prakash Sahoo <smruti.sahoo@siemens.com>