### PR TITLE
fix(moderation): Moderator can get moderation request

### DIFF
--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -327,6 +327,7 @@ public class ModerationDatabaseHandler {
         // Define moderators
         Set<String> moderators = new HashSet<>();
         CommonUtils.add(moderators, dbcomponent.getCreatedBy());
+        CommonUtils.addAll(moderators, dbcomponent.getModerators());
         CommonUtils.addAll(moderators, getUsersAtLeast(UserGroup.CLEARING_ADMIN));
 
         ModerationRequest request = createStubRequest(user, isDeleteRequest, component.getId(), moderators);


### PR DESCRIPTION
Signed-off-by: Kouki Hama <kouki1.hama@toshiba.co.jp>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue:   #1145 
I checked code and it seem that only adding 1 line , "add  CommonUtils.addAll(moderators, dbcomponent.getModerators());", is OK for solving them. 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
(Follow https://github.com/eclipse/sw360/issues/1145#issue-832508974)
Making 3 user who are not admin. (User1, User2, User3)
User1 make component_A and set User2 as moderator.
User3 login / change Component and send a moderate request.
User2 login. **User2 get moderation request about component_A from User3.**

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
