### PR TITLE
fix(search): Removing support for `_fti` hook based lucene search for couchdb 1.x

### DIFF
--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/LuceneAwareDatabaseConnector.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/LuceneAwareDatabaseConnector.java
@@ -117,24 +117,13 @@ public class LuceneAwareDatabaseConnector extends LuceneAwareCouchDbConnector {
             return null;
         }
 
-        LuceneQuery query = new LuceneQuery(function.searchView, function.searchFunction);
-        query.setQuery(queryString);
-        query.setIncludeDocs(includeDocs);
-        setQueryLimit(query);
-
         try {
-            return queryLucene(query);
-        } catch (DbAccessException e) {
-            log.error("Error querying database using _fti hook." + e.getMessage());
-            log.info("Trying to call lucene directly");
-            try {
-                LuceneResult callLuceneDirectly = callLuceneDirectly(function, queryString, includeDocs);
-                return callLuceneDirectly;
-            } catch (Exception exp) {
-                log.error("Error querying Lucene directly.", exp);
-            }
-            return null;
+            LuceneResult callLuceneDirectly = callLuceneDirectly(function, queryString, includeDocs);
+            return callLuceneDirectly;
+        } catch (Exception exp) {
+            log.error("Error querying Lucene directly.", exp);
         }
+        return null;
     }
 
     private LuceneResult callLuceneDirectly(LuceneSearchView function, String queryString, boolean includeDocs)


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change? 

For couchdb 2.x users there will always be an exception while searching which is using `_fti` which consumes some resource. Hence removed support for `_fti` hook based lucene search for couchdb 1.x or earlier version. Ref: #926 



Issue: 

### Suggest Reviewer

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR

Signed-off-by: Smruti Prakash Sahoo <smruti.sahoo@siemens.com>
