### PR TITLE
feat(AttachmentVirusScan): Store the attachments to local file system for the virus scan.

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -515,6 +515,8 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         // Get actual document for members that should not change
         Component actual = componentRepository.get(component.getId());
         assertNotNull(actual, "Could not find component to update!");
+        DatabaseHandlerUtil.saveAttachmentInFileSystem(attachmentConnector, actual.getAttachments(),
+                component.getAttachments(), user.getEmail(), component.getId());
         if (changeWouldResultInDuplicate(actual, component)) {
             return RequestStatus.DUPLICATE;
         } else if (duplicateAttachmentExist(component)) {
@@ -880,7 +882,8 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         // Get actual document for members that should no change
         Release actual = releaseRepository.get(release.getId());
         assertNotNull(actual, "Could not find release to update");
-
+        DatabaseHandlerUtil.saveAttachmentInFileSystem(attachmentConnector, actual.getAttachments(),
+                release.getAttachments(), user.getEmail(), release.getId());
         if (actual.equals(release)) {
             return RequestStatus.SUCCESS;
         } else if (duplicateAttachmentExist(release)) {

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -369,6 +369,8 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
         assertNotNull(project);
 
+        DatabaseHandlerUtil.saveAttachmentInFileSystem(attachmentConnector, actual.getAttachments(),
+                project.getAttachments(), user.getEmail(), project.getId());
         if (changeWouldResultInDuplicate(actual, project)) {
             return RequestStatus.DUPLICATE;
         } else if (duplicateAttachmentExist(project)) {

--- a/backend/src-common/src/main/resources/sw360.properties
+++ b/backend/src-common/src/main/resources/sw360.properties
@@ -69,3 +69,6 @@ textForNewProject= a new project %s %s, in which you take part, has been created
 textForUpdateProject= the project %s %s, in which you take part, has been updated.\n\n
 textForClosedClearingRequest= your clearing request with id: %s for the project %s has been closed by the clearing team.\n\n
 textForRejectedClearingRequest= your clearing request with id: %s for the project %s has been rejected by the clearing team.\n\n
+#attachment.store.file.system.location=/opt/sw360tempattachments
+#enable.attachment.store.to.file.system=false
+#attachment.store.file.system.permission=rwx------

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/AttachmentPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/AttachmentPortletUtils.java
@@ -185,26 +185,17 @@ public class AttachmentPortletUtils extends AttachmentFrontendUtils {
     private boolean uploadAttachmentPartFromRequest(PortletRequest request, String fileUploadName) throws IOException, TException {
         final UploadPortletRequest uploadPortletRequest = PortalUtil.getUploadPortletRequest(request);
         final InputStream stream = uploadPortletRequest.getFileAsStream(fileUploadName);
-        final InputStream attachmentStream = uploadPortletRequest.getFileAsStream(fileUploadName);
 
         final ResumableUpload resumableUpload = ResumableUpload.from(uploadPortletRequest);
         AttachmentContent attachment = null;
 
-        final User user = UserCacheHolder.getUserFromRequest(request);
-        String docId = request.getParameter(PortalConstants.DOCUMENT_ID);
-        String userEmail = user.getEmail();
-        String filename = null;
-
         if (resumableUpload.isValid()) {
             final AttachmentStreamConnector attachmentStreamConnector = getConnector();
-
             attachment = getAttachmentContent(resumableUpload, stream);
 
             if (attachment != null) {
                 try {
-                    filename = attachment.getFilename();
                     attachmentStreamConnector.uploadAttachmentPart(attachment, resumableUpload.getChunkNumber(), stream);
-                    attachmentStreamConnector.saveAttachmentToFileSystem(docId, userEmail, attachmentStream, filename);
                 } catch (TException e) {
                     log.error("Error saving attachment part", e);
                     return false;

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -65,6 +65,7 @@ public class SW360Constants {
     public static final String TYPE_CLEARING = "clearing";
     public static final String TYPE_SEARCHRESULT = "searchResult";
     public static final String TYPE_CHANGELOG = "changeLog";
+    public static final String DEFAULT_PATH = "/opt/sw360tempattachments";
 
     /**
      * Hashmap containing the name field for each type.
@@ -150,5 +151,4 @@ public class SW360Constants {
     private static Map.Entry<String, String> pair(TFieldIdEnum field, String displayName){
         return new AbstractMap.SimpleImmutableEntry<>(field.toString(), displayName);
     }
-
 }

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -65,7 +65,6 @@ public class SW360Constants {
     public static final String TYPE_CLEARING = "clearing";
     public static final String TYPE_SEARCHRESULT = "searchResult";
     public static final String TYPE_CHANGELOG = "changeLog";
-    public static final String DEFAULT_PATH = "/opt/sw360tempattachments";
 
     /**
      * Hashmap containing the name field for each type.

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentStreamConnector.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentStreamConnector.java
@@ -39,6 +39,14 @@ import java.util.zip.ZipOutputStream;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.getExtensionFromFileName;
 import static org.eclipse.sw360.datahandler.common.SW360Assert.assertNotNull;
 
+import org.eclipse.sw360.datahandler.common.SW360Constants;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.nio.file.Paths;
+
+import org.eclipse.sw360.datahandler.thrift.ThriftClients;
+
 /**
  * Created by bodet on 03/02/15.
  *
@@ -269,5 +277,36 @@ public class AttachmentStreamConnector {
 
     private String getPartFileName(AttachmentContent attachment, int part) {
         return attachment.getFilename() + "_part" + part;
+    }
+
+    public void saveAttachmentToFileSystem(String Id, String user, InputStream stream, String filename) throws SW360Exception {
+        try {
+            OutputStream out =null;
+            final int BUFFER_SIZE = 1024;
+            String PATH = SW360Constants.DEFAULT_PATH;
+            String directoryName = PATH.concat("/"+user+"/"+Id);
+            File dir = new File(directoryName);
+            if(!dir.exists())
+            {
+                dir.mkdirs();
+            }
+            Paths.get(directoryName + File.separatorChar + filename);
+            File file = new File(directoryName + "/" +filename);
+            if(file != null) {
+                out = new FileOutputStream(file);
+            }
+            byte[] buf = new byte[BUFFER_SIZE];
+            int len;
+            while((len = stream.read(buf)) > 0) {
+                out.write(buf, 0, len);
+            }
+            stream.close();
+            out.close();
+
+        }catch(IOException ioe) {
+            String message = "Exception while saving the attachment in local file system.";
+            log.error(message, ioe);
+            throw new SW360Exception(message);
+        }
     }
 }

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentStreamConnector.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/AttachmentStreamConnector.java
@@ -39,14 +39,6 @@ import java.util.zip.ZipOutputStream;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.getExtensionFromFileName;
 import static org.eclipse.sw360.datahandler.common.SW360Assert.assertNotNull;
 
-import org.eclipse.sw360.datahandler.common.SW360Constants;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.OutputStream;
-import java.nio.file.Paths;
-
-import org.eclipse.sw360.datahandler.thrift.ThriftClients;
-
 /**
  * Created by bodet on 03/02/15.
  *
@@ -194,7 +186,7 @@ public class AttachmentStreamConnector {
         return attachmentContent;
     }
 
-    protected InputStream readAttachmentStream(AttachmentContent attachment) {
+    public InputStream readAttachmentStream(AttachmentContent attachment) {
         int partsCount = -1;
 
         if (attachment.isSetPartsCount()) {
@@ -277,36 +269,5 @@ public class AttachmentStreamConnector {
 
     private String getPartFileName(AttachmentContent attachment, int part) {
         return attachment.getFilename() + "_part" + part;
-    }
-
-    public void saveAttachmentToFileSystem(String Id, String user, InputStream stream, String filename) throws SW360Exception {
-        try {
-            OutputStream out =null;
-            final int BUFFER_SIZE = 1024;
-            String PATH = SW360Constants.DEFAULT_PATH;
-            String directoryName = PATH.concat("/"+user+"/"+Id);
-            File dir = new File(directoryName);
-            if(!dir.exists())
-            {
-                dir.mkdirs();
-            }
-            Paths.get(directoryName + File.separatorChar + filename);
-            File file = new File(directoryName + "/" +filename);
-            if(file != null) {
-                out = new FileOutputStream(file);
-            }
-            byte[] buf = new byte[BUFFER_SIZE];
-            int len;
-            while((len = stream.read(buf)) > 0) {
-                out.write(buf, 0, len);
-            }
-            stream.close();
-            out.close();
-
-        }catch(IOException ioe) {
-            String message = "Exception while saving the attachment in local file system.";
-            log.error(message, ioe);
-            throw new SW360Exception(message);
-        }
     }
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/ComponentController.java
@@ -12,7 +12,9 @@
 
 package org.eclipse.sw360.rest.resourceserver.component;
 
+import org.eclipse.sw360.commonIO.AttachmentFrontendUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
+import org.eclipse.sw360.datahandler.couchdb.AttachmentStreamConnector;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
 import org.eclipse.sw360.datahandler.resourcelists.ResourceClassNotFoundException;
@@ -63,6 +65,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
@@ -252,8 +255,17 @@ public class ComponentController implements ResourceProcessor<RepositoryLinksRes
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
 
         Attachment attachment;
+        AttachmentStreamConnector attachmentStreamConnector = null;
+        String attachmentContentId = null;
+        String userEmail = null;
+
         try {
+            AttachmentFrontendUtils attachmentFrontendUtils = new AttachmentFrontendUtils();
+            attachmentStreamConnector = attachmentFrontendUtils.getConnector();
+            String fileName = newAttachment.getFilename();
+            userEmail = sw360User.getEmail();
             attachment = attachmentService.uploadAttachment(file, newAttachment, sw360User);
+            attachmentStreamConnector.saveAttachmentToFileSystem(componentId, userEmail, file.getInputStream(), fileName);
         } catch (IOException e) {
             log.error("failed to upload attachment", e);
             throw new RuntimeException("failed to upload attachment", e);

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/ProjectController.java
@@ -20,14 +20,12 @@ import org.apache.thrift.TException;
 import org.apache.thrift.TSerializer;
 import org.springframework.data.domain.Pageable;
 import org.apache.thrift.protocol.TSimpleJSONProtocol;
-import org.eclipse.sw360.commonIO.AttachmentFrontendUtils;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationParameterException;
 import org.eclipse.sw360.datahandler.resourcelists.PaginationResult;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.common.ThriftEnumUtils;
-import org.eclipse.sw360.datahandler.couchdb.AttachmentStreamConnector;
 import org.eclipse.sw360.datahandler.thrift.MainlineState;
 import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
@@ -687,25 +685,15 @@ public class ProjectController implements ResourceProcessor<RepositoryLinksResou
                                                               @RequestPart("file") MultipartFile file,
                                                               @RequestPart("attachment") Attachment newAttachment) throws TException {
         final User sw360User = restControllerHelper.getSw360UserFromAuthentication();
-
-        Attachment attachment;
-        AttachmentStreamConnector attachmentStreamConnector = null;
-        String attachmentContentId = null;
-        String userEmail = null;
-
+        final Project project = projectService.getProjectForUserById(projectId, sw360User);
+        Attachment attachment = null;
         try {
-            AttachmentFrontendUtils attachmentFrontendUtils = new AttachmentFrontendUtils();
-            attachmentStreamConnector = attachmentFrontendUtils.getConnector();
-            String fileName = newAttachment.getFilename();
-            userEmail = sw360User.getEmail();
             attachment = attachmentService.uploadAttachment(file, newAttachment, sw360User);
-            attachmentStreamConnector.saveAttachmentToFileSystem(projectId, userEmail, file.getInputStream(), fileName);
         } catch (IOException e) {
-            log.error(e.getMessage());
-            throw new RuntimeException(e);
+            log.error("failed to upload attachment", e);
+            throw new RuntimeException("failed to upload attachment", e);
         }
 
-        final Project project = projectService.getProjectForUserById(projectId, sw360User);
         project.addToAttachments(attachment);
         RequestStatus updateProjectStatus = projectService.updateProject(project, sw360User);
         HttpStatus status = HttpStatus.OK;

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -252,6 +252,8 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                 new Release("Test Release", "1.0", component.getId())
                         .setId("1234567890"));
 
+        given(this.userServiceMock.getUserByEmailOrExternalId("admin@sw360.org")).willReturn(
+                new User("admin@sw360.org", "sw360").setId("123456789"));
         given(this.userServiceMock.getUserByEmail("admin@sw360.org")).willReturn(
                 new User("admin@sw360.org", "sw360").setId("123456789"));
         given(this.userServiceMock.getUserByEmail("jane@sw360.org")).willReturn(


### PR DESCRIPTION
> Store the attachments to local file system for the virus scan.
> * Which issue is this pull request belonging to and how is it solving it? (#1173 )
> * Did you add or update any new dependencies that are required for your change? - No

Issue: Closes #1173 

### How To Test?
> How should these changes be tested by the reviewer?

- We need to test this from the sw360 UI when we upload a attachment for a Project, Component or Release. 
- We need to test this from the Rest API as well for the below:
Add Attachment To Project
POST - http://localhost:8080/resource/api/projects/{ProjectId}/attachments
Add Attachment To Component
POST - http://localhost:8080/resource/api/components/{componentId}/attachments
Add Attachment To Release
POST - http://localhost:8080/resource/api/releases/{releaseId}/attachments

- Set properties in `/etc/sw360/sw360.properties`: 
- `attachment.store.file.system.location` - location where to store attachments by default. Default location is `/opt/sw360tempattachments/userEmail/documentId_{docId}/attachmentId_{attachmentId}/AttachmentFile`
- `enable.attachment.store.to.file.system` - to enable this feature

> Have you implemented any additional tests? - No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: ravi110336 <kumar.ravindra@siemens.com>
Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>