### PR TITLE
feat(ProjectGroupFilter):Filter the projects in Advanced Search based on Projects Group.

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/view.jsp
@@ -110,9 +110,9 @@
                                     <option value=""
                                             <core_rt:if test="${empty businessUnit}"> selected="selected"</core_rt:if>></option>
                                     <core_rt:forEach items="${organizations}" var="org">
-                                        <option value="<sw360:out value="${org.name}"/>"
-                                                <core_rt:if test="${org.name == businessUnit}"> selected="selected"</core_rt:if>
-                                        ><sw360:out value="${org.name}"/></option>
+                                        <option value="<sw360:out value="${org}"/>"
+                                                <core_rt:if test="${org == businessUnit}"> selected="selected"</core_rt:if>
+                                        ><sw360:out value="${org}"/></option>
                                     </core_rt:forEach>
                                 </select>
                             </div>


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> The Filter for Group in Advanced Search should read from the Project List Group not from the user table.
> * Which issue is this pull request belonging to and how is it solving it? (#1194 )
> * Did you add or update any new dependencies that are required for your change? No

Issue: closes #1194 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?

- To Test this, go to the Projects tab Advanced Search option and select the filter by Group and search the projects.
- The values populated in the Group in Advanced Search is the distinct Group from the list of projects available in the DB not 
      from the user table.

> Have you implemented any additional tests? No

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: ravi110336 <kumar.ravindra@siemens.com>
