### PR TITLE
fix(backend): Issues with boolean and timestamp field deserialization and get attachment REST

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentOwnerRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentOwnerRepository.java
@@ -14,8 +14,6 @@ import org.eclipse.sw360.datahandler.cloudantclient.DatabaseRepositoryCloudantCl
 import org.eclipse.sw360.datahandler.thrift.Source;
 
 import com.cloudant.client.api.model.DesignDocument.MapReduce;
-import com.cloudant.client.api.views.Key;
-import com.cloudant.client.api.views.UnpaginatedRequestBuilder;
 import com.cloudant.client.api.views.ViewRequestBuilder;
 
 import java.util.HashMap;
@@ -40,7 +38,6 @@ public class AttachmentOwnerRepository extends DatabaseRepositoryCloudantClient<
 
     public List<Source> getOwnersByIds(Set<String> ids) {
         ViewRequestBuilder viewQuery = getConnector().createQuery(Source.class, "attachmentOwner");
-        UnpaginatedRequestBuilder req = viewQuery.newRequest(Key.Type.STRING, Object.class).includeDocs(false).keys((String[]) ids.toArray());
-        return queryView(req);
+        return queryViewForSource(buildRequest(viewQuery, ids));
     }
 }

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentRepository.java
@@ -14,8 +14,6 @@ import org.eclipse.sw360.datahandler.cloudantclient.DatabaseRepositoryCloudantCl
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 
 import com.cloudant.client.api.model.DesignDocument.MapReduce;
-import com.cloudant.client.api.views.Key;
-import com.cloudant.client.api.views.UnpaginatedRequestBuilder;
 import com.cloudant.client.api.views.ViewRequestBuilder;
 
 import java.util.HashMap;
@@ -42,13 +40,11 @@ public class AttachmentRepository extends DatabaseRepositoryCloudantClient<Attac
 
     public List<Attachment> getAttachmentsByIds(Set<String> ids) {
         ViewRequestBuilder viewQuery = getConnector().createQuery(Attachment.class, "byid");
-        UnpaginatedRequestBuilder req = viewQuery.newRequest(Key.Type.STRING, Object.class).includeDocs(false).keys((String[]) ids.toArray());
-        return queryView(req);
+        return queryViewForAttchmnt(buildRequest(viewQuery, ids));
     }
 
     public List<Attachment> getAttachmentsBySha1s(Set<String> sha1s) {
         ViewRequestBuilder viewQuery = getConnector().createQuery(Attachment.class, "bysha1");
-        UnpaginatedRequestBuilder req = viewQuery.newRequest(Key.Type.STRING, Object.class).includeDocs(false).keys((String[]) sha1s.toArray());
-        return queryView(req);
+        return queryViewForAttchmnt(buildRequest(viewQuery, sha1s));
     }
 }

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CustomThriftDeserializer.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CustomThriftDeserializer.java
@@ -26,6 +26,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.internal.LinkedTreeMap;
 
@@ -56,6 +57,14 @@ public class CustomThriftDeserializer implements JsonDeserializer<TBase> {
     @Override
     public TBase deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
             throws JsonParseException {
+        if (json.isJsonObject()) {
+            JsonObject jObj = json.getAsJsonObject();
+            if (jObj.has("issetBitfield")) {
+                jObj.add("__isset_bitfield", jObj.get("issetBitfield"));
+            }
+            json = jObj.getAsJsonObject();
+        }
+
         Gson gson = new Gson();
         if (typeOfT.getTypeName().equals("org.eclipse.sw360.datahandler.thrift.attachments.AttachmentUsage")) {
             AttachmentUsage tbase = gson.fromJson(json, typeOfT);


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

The boolean fields and timestamp being ignored in the middle layer. Hence the values are not being rendered correctly in the UI.
> * Which issue is this pull request belonging to and how is it solving it? (*#1211*)
> * Did you add or update any new dependencies that are required for your change? - No

Issue: 

closes #1211 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
* Need to verify the dates are appearing correctly in moderations and clearing requests tab.
* Need to test the `/api/attachments?sha1=xxx` endpoint.
* Need to verify he boolean fields like enableSVM or enableVulnerabilitiesDisplay fileds are rendering correctly as per the value in DB.
> Have you implemented any additional tests? - No

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR

Signed-off-by: Smruti Prakash Sahoo <smruti.sahoo@siemens.com>
