### PR TITLE
fix(ui/rest): Issue fetching releases by external ids from REST and null value in external id breaks the release view

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayMapOfExternalIdsString.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/tags/DisplayMapOfExternalIdsString.java
@@ -18,6 +18,8 @@ import javax.servlet.jsp.tagext.SimpleTagSupport;
 import java.io.IOException;
 import java.util.*;
 
+import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
+
 /**
  * This displays a map
  *
@@ -25,6 +27,7 @@ import java.util.*;
  */
 public class DisplayMapOfExternalIdsString extends SimpleTagSupport {
 
+    private static final String NULL_STRING = "null";
     private Map<String, String> value;
     private Map<String, String> autoFillValue;
 
@@ -64,11 +67,15 @@ public class DisplayMapOfExternalIdsString extends SimpleTagSupport {
         ObjectMapper mapper = new ObjectMapper();
         Set<String> externalIdValueSet = new TreeSet<>();
         try {
-            externalIdValueSet = mapper.readValue(externalIdValues, Set.class);
+            if(externalIdValues.equals(NULL_STRING)) {
+                externalIdValueSet.add(NULL_STRING);
+            } else {
+                externalIdValueSet = mapper.readValue(externalIdValues, Set.class);
+            }
         } catch (IOException e) {
             externalIdValueSet.add(externalIdValues);
         }
-        externalIdValueSet.forEach( e ->
+        nullToEmptySet(externalIdValueSet).forEach( e ->
                 sb.append("<li><span class=\"mapDisplayChildItemLeft\">")
                   .append(StringEscapeUtils.escapeXml(externalIdKey))
                   .append("</span><span class=\"mapDisplayChildItemRight\"> ")

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClient.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/cloudantclient/DatabaseRepositoryCloudantClient.java
@@ -202,8 +202,14 @@ public class DatabaseRepositoryCloudantClient<T> {
         Set<String[]> complexKeys = keys.entrySet().stream().map(DatabaseRepositoryCloudantClient::createComplexKeys)
                 .flatMap(Collection::stream).collect(Collectors.toSet());
         ViewRequestBuilder query = connector.createQuery(type, queryName);
+        Key.ComplexKey[] complexKys = new Key.ComplexKey[complexKeys.size()];
+        int index = 0;
+        for (String[] keyArr : complexKeys) {
+            Key.ComplexKey key = Key.complex(keyArr);
+            complexKys[index++] = key;
+        }
         UnpaginatedRequestBuilder reqBuild = query.newRequest(Key.Type.COMPLEX, Object.class)
-                .keys((com.cloudant.client.api.views.Key.ComplexKey[]) complexKeys.toArray());
+                .keys(complexKys);
         return queryForIds(reqBuild);
     }
 
@@ -308,7 +314,7 @@ public class DatabaseRepositoryCloudantClient<T> {
     }
 
     public ViewResponse<ComplexKey, Object> queryViewForComplexKeys(
-            UnpaginatedRequestBuilder<com.cloudant.client.api.views.Key.ComplexKey, Object> req) {
+            UnpaginatedRequestBuilder<Key.ComplexKey, Object> req) {
         ViewResponse<ComplexKey, Object> responses = null;
         try {
             responses = req.build().getResponse();


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Issue: 

500 Error fetching releases by external id with value from rest. If the release contains any external id with value null, then it breaks the release view.


> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change? - No


### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
* Need to test the endpoint `/api/releases/searchByExternalIds?externalId=XXX`
* Put null as external Id value in release and verify if the release should open without any error.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
Signed-off-by: Smruti Prakash Sahoo <smruti.sahoo@siemens.com>