### PR TITLE
feat(moderations): Paginated view for requests tab for moderations

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ModerationSearchHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ModerationSearchHandler.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Siemens AG, 2021. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.couchdb.lucene.LuceneAwareDatabaseConnector;
+import org.eclipse.sw360.datahandler.couchdb.lucene.LuceneSearchView;
+import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
+import org.ektorp.http.HttpClient;
+
+import com.cloudant.client.api.CloudantClient;
+
+public class ModerationSearchHandler {
+    private static final LuceneSearchView luceneSearchView = new LuceneSearchView("lucene", "moderations",
+            "function(doc) {" +
+                    "    var ret = new Document();" +
+                    "    if(!doc.type) return ret;" +
+                    "    if(doc.type != 'moderation') return ret;" +
+                    "    function idx(obj) {" +
+                    "        for (var key in obj) {" +
+                    "            switch (typeof obj[key]) {" +
+                    "                case 'object':" +
+                    "                    idx(obj[key]);" +
+                    "                    break;" +
+                    "                case 'function':" +
+                    "                    break;" +
+                    "                default:" +
+                    "                    ret.add(obj[key]);" +
+                    "                    break;" +
+                    "            }" +
+                    "        }" +
+                    "    };" +
+                    "    idx(doc);" +
+                    "    for(var i in doc.moderators) {  "+
+                    "      ret.add(doc.moderators[i], {\"field\": \"moderators\"} );" +
+                    "    }" +
+                    "    if(doc.documentName) {  "+
+                    "      ret.add(doc.documentName, {\"field\": \"documentName\"} );" +
+                    "    }" +
+                    "    if(doc.componentType) {  "+
+                    "      ret.add(doc.componentType, {\"field\": \"componentType\"} );" +
+                    "    }" +
+                    "    if(doc.requestingUser) {  "+
+                    "      ret.add(doc.requestingUser, {\"field\": \"requestingUser\"} );" +
+                    "    }" +
+                    "    if(doc.requestingUserDepartment) {  "+
+                    "      ret.add(doc.requestingUserDepartment, {\"field\": \"requestingUserDepartment\"} );" +
+                    "    }" +
+                    "    if(doc.moderationState) {  "+
+                    "      ret.add(doc.moderationState, {\"field\": \"moderationState\"} );" +
+                    "    }" +
+                    "    if(doc.timestamp) {  "+
+                    "      var dt = new Date(doc.timestamp); "+
+                    "      var formattedDt = dt.getFullYear()+'-'+(dt.getMonth()+1)+'-'+dt.getDate(); "+
+                    "      ret.add(formattedDt, {\"field\": \"timestamp\", \"type\": \"date\"} );" +
+                    "    }" +
+                    "    return ret;" +
+                    "}");
+    private final LuceneAwareDatabaseConnector connector;
+
+    public ModerationSearchHandler(Supplier<HttpClient> httpClient, Supplier<CloudantClient> cClient, String dbName) throws IOException {
+        connector = new LuceneAwareDatabaseConnector(httpClient, cClient, dbName);
+        connector.addView(luceneSearchView);
+        connector.setResultLimit(DatabaseSettings.LUCENE_SEARCH_LIMIT);
+    }
+
+    public List<ModerationRequest> search(String text, final Map<String , Set<String > > subQueryRestrictions ) {
+        return connector.searchViewWithRestrictions(ModerationRequest.class, luceneSearchView, text, subQueryRestrictions);
+    }
+}

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/ModerationServlet.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/ModerationServlet.java
@@ -14,8 +14,7 @@ import org.eclipse.sw360.datahandler.thrift.moderation.ModerationService;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.eclipse.sw360.projects.Sw360ThriftServlet;
 
-import java.net.MalformedURLException;
-
+import java.io.IOException;
 /**
  * Thrift Servlet instantiation
  *
@@ -25,7 +24,7 @@ import java.net.MalformedURLException;
  */
 public class ModerationServlet extends Sw360ThriftServlet {
 
-    public ModerationServlet() throws MalformedURLException {
+    public ModerationServlet() throws IOException {
         // Create a service processor using the provided handler
         super(new ModerationService.Processor<ModerationHandler>(new ModerationHandler()), new TCompactProtocol.Factory());
     }

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -29,6 +29,7 @@ import org.eclipse.sw360.datahandler.thrift.ClearingRequestEmailTemplate;
 import org.eclipse.sw360.datahandler.thrift.ClearingRequestState;
 import org.eclipse.sw360.datahandler.thrift.Comment;
 import org.eclipse.sw360.datahandler.thrift.ModerationState;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.ThriftClients;
@@ -112,6 +113,10 @@ public class ModerationDatabaseHandler {
 
     public List<ModerationRequest> getRequestsByModerator(String moderator) {
         return repository.getRequestsByModerator(moderator);
+    }
+
+    public Map<PaginationData, List<ModerationRequest>> getRequestsByModerator(String moderator, PaginationData pageData, boolean open) {
+        return repository.getRequestsByModerator(moderator, pageData, open);
     }
 
     public List<ModerationRequest> getRequestsByRequestingUser(String user) {
@@ -619,6 +624,14 @@ public class ModerationDatabaseHandler {
 
         return request;
 
+    }
+
+    public Map<String, Long> getCountByModerationState() {
+        return repository.getCountByModerationState();
+    }
+
+    public Set<String> getRequestingUserDepts() {
+        return repository.getRequestingUserDepts();
     }
 
     private void sendMailForNewCommentInCR(ClearingRequest cr, Comment comment, User user) throws SW360Exception {

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationRequestRepository.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationRequestRepository.java
@@ -13,14 +13,28 @@ package org.eclipse.sw360.moderation.db;
 import org.eclipse.sw360.components.summary.ModerationRequestSummary;
 import org.eclipse.sw360.components.summary.SummaryType;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.couchdb.SummaryAwareRepository;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.moderation.ModerationRequest;
 
 import com.cloudant.client.api.model.DesignDocument.MapReduce;
+import com.cloudant.client.api.views.Key;
+import com.cloudant.client.api.views.ViewRequest;
+import com.cloudant.client.api.views.ViewRequestBuilder;
+import com.cloudant.client.api.views.ViewResponse;
+import com.cloudant.client.api.views.ViewResponse.Row;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * CRUD access for the ModerationRequest class
@@ -30,6 +44,8 @@ import java.util.Map;
  */
 public class ModerationRequestRepository extends SummaryAwareRepository<ModerationRequest> {
     private static final String ALL = "function(doc) { if (doc.type == 'moderation') emit(null, doc._id) }";
+    private static final String ALL_OPEN = "function(doc) { if (doc.type == 'moderation' && (doc.moderationState === 'INPROGRESS' || doc.moderationState === 'PENDING')) emit(null, doc._id) }";
+    private static final String ALL_CLOSED = "function(doc) { if (doc.type == 'moderation' && (doc.moderationState === 'APPROVED' || doc.moderationState === 'REJECTED')) emit(null, doc._id) }";
 
     private static final String DOCUMENTS_VIEW = "function(doc) { " +
             "  if (doc.type == 'moderation') {" +
@@ -37,8 +53,26 @@ public class ModerationRequestRepository extends SummaryAwareRepository<Moderati
             "  }" +
             "}";
 
+    private static final String REQUESTING_USERS_VIEW = "function(doc) { " +
+            "  if (doc.type == 'moderation') {" +
+            "    emit(doc.requestingUserDepartment, null);" +
+            "  }" +
+            "}";
+
     private static final String USERS_VIEW = "function(doc) { " +
             "  if (doc.type == 'moderation') {" +
+            "    emit(doc.requestingUser, doc);" +
+            "    }" +
+            "}";
+
+    private static final String USERS_VIEW_OPEN = "function(doc) { " +
+            "  if (doc.type == 'moderation' && (doc.moderationState === 'INPROGRESS' || doc.moderationState === 'PENDING')) {" +
+            "    emit(doc.requestingUser, doc);" +
+            "    }" +
+            "}";
+
+    private static final String USERS_VIEW_CLOSED = "function(doc) { " +
+            "  if (doc.type == 'moderation' && (doc.moderationState === 'APPROVED' || doc.moderationState === 'REJECTED')) {" +
             "    emit(doc.requestingUser, doc);" +
             "    }" +
             "}";
@@ -51,13 +85,122 @@ public class ModerationRequestRepository extends SummaryAwareRepository<Moderati
             "  }" +
             "}";
 
+    private static final String MODERATORS_VIEW_FOR_SORTING_OPEN = "function(doc) {" +
+            "  if (doc.type == 'moderation' && (doc.moderationState === 'INPROGRESS' || doc.moderationState === 'PENDING')) {" +
+            "      if(doc.moderators) {" +
+            "            emit(doc.moderators.join(), doc);" +
+            "      } else {" +
+            "            emit('', doc);" +
+            "      }" +
+            "  }" +
+            "}";
+
+    private static final String MODERATORS_VIEW_FOR_SORTING_CLOSED = "function(doc) {" +
+            "  if (doc.type == 'moderation' && (doc.moderationState === 'APPROVED' || doc.moderationState === 'REJECTED')) {" +
+            "      if(doc.moderators) {" +
+            "            emit(doc.moderators.join(), doc);" +
+            "      } else {" +
+            "            emit('', doc);" +
+            "      }" +
+            "  }" +
+            "}";
+
+    private static final String BYDATE_OPEN = "function(doc) { " +
+            "  if (doc.type == 'moderation' && (doc.moderationState === 'INPROGRESS' || doc.moderationState === 'PENDING')) {" +
+            "    emit(new Date(doc.timestamp), doc);" +
+            "    }" +
+            "}";
+
+    private static final String BYDATE_CLOSED = "function(doc) { " +
+            "  if (doc.type == 'moderation'  && (doc.moderationState === 'APPROVED' || doc.moderationState === 'REJECTED')) {" +
+            "    emit(new Date(doc.timestamp), doc);" +
+            "    }" +
+            "}";
+
+    private static final String BYDOCUMENTNAME_OPEN = "function(doc) { " +
+            "  if (doc.type == 'moderation' && (doc.moderationState === 'INPROGRESS' || doc.moderationState === 'PENDING')) {" +
+            "    emit(doc.documentName, doc);" +
+            "    }" +
+            "}";
+
+    private static final String BYDOCUMENTNAME_CLOSED = "function(doc) { " +
+            "  if (doc.type == 'moderation' && (doc.moderationState === 'APPROVED' || doc.moderationState === 'REJECTED')) {" +
+            "    emit(doc.documentName, doc);" +
+            "    }" +
+            "}";
+
+    private static final String BYMODERATIONTATE_OPEN = "function(doc) { " +
+            "  if (doc.type == 'moderation' && (doc.moderationState === 'INPROGRESS' || doc.moderationState === 'PENDING')) {" +
+            "    emit(doc.moderationState, doc);" +
+            "    }" +
+            "}";
+
+    private static final String BYMODERATIONTATE_CLOSED = "function(doc) { " +
+            "  if (doc.type == 'moderation' && (doc.moderationState === 'APPROVED' || doc.moderationState === 'REJECTED')) {" +
+            "    emit(doc.moderationState, doc);" +
+            "    }" +
+            "}";
+
+    private static final String BYCOMPONENTTYPE_OPEN = "function(doc) { " +
+            "  if (doc.type == 'moderation' && (doc.moderationState === 'INPROGRESS' || doc.moderationState === 'PENDING')) {" +
+            "    emit(doc.componentType, doc);" +
+            "    }" +
+            "}";
+
+    private static final String BYCOMPONENTTYPE_CLOSED = "function(doc) { " +
+            "  if (doc.type == 'moderation' && (doc.moderationState === 'APPROVED' || doc.moderationState === 'REJECTED')) {" +
+            "    emit(doc.componentType, doc);" +
+            "    }" +
+            "}";
+
+    private static final String BYREQUESTINGUSERDEPRTMENT_OPEN = "function(doc) { " +
+            "  if (doc.type == 'moderation' && (doc.moderationState === 'INPROGRESS' || doc.moderationState === 'PENDING')) {" +
+            "    emit(doc.requestingUserDepartment, doc);" +
+            "    }" +
+            "}";
+
+    private static final String BYREQUESTINGUSERDEPRTMENT_CLOSED = "function(doc) { " +
+            "  if (doc.type == 'moderation' && (doc.moderationState === 'APPROVED' || doc.moderationState === 'REJECTED')) {" +
+            "    emit(doc.requestingUserDepartment, doc);" +
+            "    }" +
+            "}";
+
+    private static final String COUNTBYMODERATIONSTATE = "function(doc) {" +
+            "  if (doc.type == 'moderation') {" +
+            "    var moderationState = doc.moderationState;" +
+            "    if(moderationState === \"INPROGRESS\" || moderationState === \"PENDING\") {" +
+            "      emit(\"OPEN\", null);" +
+            "    } else {" +
+            "      emit(\"CLOSED\", null);" +
+            "    }" +
+            "  }" +
+            "}";
+
     public ModerationRequestRepository(DatabaseConnectorCloudant db) {
         super(ModerationRequest.class, db, new ModerationRequestSummary());
         Map<String, MapReduce> views = new HashMap<String, MapReduce>();
         views.put("all", createMapReduce(ALL, null));
+        views.put("allOpenRequests", createMapReduce(ALL_OPEN, null));
+        views.put("allClosedRequests", createMapReduce(ALL_CLOSED, null));
         views.put("documents", createMapReduce(DOCUMENTS_VIEW, null));
         views.put("moderators", createMapReduce(MODERATORS_VIEW, null));
         views.put("users", createMapReduce(USERS_VIEW, null));
+        views.put("openRequestsUsers", createMapReduce(USERS_VIEW_OPEN, null));
+        views.put("closedRequestsUsers", createMapReduce(USERS_VIEW_CLOSED, null));
+        views.put("openRequestsBydate", createMapReduce(BYDATE_OPEN, null));
+        views.put("closedRequestsBydate", createMapReduce(BYDATE_CLOSED, null));
+        views.put("openRequestsBydocumentname", createMapReduce(BYDOCUMENTNAME_OPEN, null));
+        views.put("closedRequestsBydocumentname", createMapReduce(BYDOCUMENTNAME_CLOSED, null));
+        views.put("openRequestsBymoderationstate", createMapReduce(BYMODERATIONTATE_OPEN, null));
+        views.put("closedRequestsBymoderationstate", createMapReduce(BYMODERATIONTATE_CLOSED, null));
+        views.put("openRequestsBycomponenttype", createMapReduce(BYCOMPONENTTYPE_OPEN, null));
+        views.put("closedRequestsBycomponenttype", createMapReduce(BYCOMPONENTTYPE_CLOSED, null));
+        views.put("openRequestsbyrequestinguserdept", createMapReduce(BYREQUESTINGUSERDEPRTMENT_OPEN, null));
+        views.put("closedRequestsbyrequestinguserdept", createMapReduce(BYREQUESTINGUSERDEPRTMENT_CLOSED, null));
+        views.put("openRequestsBymoderators", createMapReduce(MODERATORS_VIEW_FOR_SORTING_OPEN, null));
+        views.put("closedRequestsBymoderators", createMapReduce(MODERATORS_VIEW_FOR_SORTING_CLOSED, null));
+        views.put("byRequestingUsersDeptView", createMapReduce(REQUESTING_USERS_VIEW, null));
+        views.put("countByModerationState", createMapReduce(COUNTBYMODERATIONSTATE, "_count"));
         initStandardDesignDocument(views, db);
     }
 
@@ -69,8 +212,118 @@ public class ModerationRequestRepository extends SummaryAwareRepository<Moderati
         return makeSummaryFromFullDocs(SummaryType.SHORT, queryView("moderators", moderator));
     }
 
+    public Map<PaginationData, List<ModerationRequest>> getRequestsByModerator(String moderator, PaginationData pageData, boolean open) {
+        Map<PaginationData, List<ModerationRequest>> paginatedModerations = queryViewWithPagination(moderator, pageData, open);
+        List<ModerationRequest> moderationList = paginatedModerations.values().iterator().next();
+        moderationList = makeSummaryFromFullDocs(SummaryType.SHORT, moderationList);
+        paginatedModerations.put(pageData, moderationList);
+        return paginatedModerations;
+    }
+
+    private Map<PaginationData, List<ModerationRequest>> queryViewWithPagination(String moderator, PaginationData pageData, boolean open) {
+        final int rowsPerPage = pageData.getRowsPerPage();
+        Map<PaginationData, List<ModerationRequest>> result = Maps.newHashMap();
+        List<ModerationRequest> modReqs = Lists.newArrayList();
+        final boolean ascending = pageData.isAscending();
+        final int sortColumnNo = pageData.getSortColumnNumber();
+        ViewRequestBuilder query;
+        switch (sortColumnNo) {
+        case -1:
+            query = getConnector().createQuery(ModerationRequest.class,
+                    open ? "openRequestsBymoderators" : "closedRequestsBymoderators");
+            break;
+        case 0:
+            query = getConnector().createQuery(ModerationRequest.class,
+                    open ? "openRequestsBydate" : "closedRequestsBydate");
+            break;
+        case 1:
+            query = getConnector().createQuery(ModerationRequest.class,
+                    open ? "openRequestsBycomponenttype" : "closedRequestsBycomponenttype");
+            break;
+        case 2:
+            query = getConnector().createQuery(ModerationRequest.class,
+                    open ? "openRequestsBydocumentname" : "closedRequestsBydocumentname");
+            break;
+        case 3:
+            query = getConnector().createQuery(ModerationRequest.class,
+                    open ? "openRequestsUsers" : "closedRequestsUsers");
+            break;
+        case 4:
+            query = getConnector().createQuery(ModerationRequest.class,
+                    open ? "openRequestsbyrequestinguserdept" : "closedRequestsbyrequestinguserdept");
+            break;
+        case 5:
+            query = getConnector().createQuery(ModerationRequest.class,
+                    open ? "openRequestsBymoderators" : "closedRequestsBymoderators");
+            break;
+        case 6:
+            query = getConnector().createQuery(ModerationRequest.class,
+                    open ? "openRequestsBymoderationstate" : "closedRequestsBymoderationstate");
+            break;
+        default:
+            query = getConnector().createQuery(ModerationRequest.class, open ? "allOpenRequests" : "allClosedRequests");
+            break;
+        }
+        ViewRequest<String, Object> request = null;
+        if (rowsPerPage == -1) {
+            request = query.newRequest(Key.Type.STRING, Object.class).descending(!ascending).includeDocs(true).build();
+        } else {
+            request = query.newPaginatedRequest(Key.Type.STRING, Object.class).rowsPerPage(rowsPerPage)
+                    .descending(!ascending).includeDocs(true).build();
+        }
+
+        ViewResponse<String, Object> response = null;
+        try {
+            response = request.getResponse();
+            int pageNo = pageData.getDisplayStart() / rowsPerPage;
+            int i = 1;
+            while (i <= pageNo) {
+                response = response.nextPage();
+                i++;
+            }
+            modReqs = response.getDocsAs(ModerationRequest.class);
+        } catch (Exception e) {
+            log.error("Error getting recent components", e);
+        }
+        pageData.setTotalRowCount(response.getTotalRowCount());
+        result.put(pageData, modReqs);
+        return result;
+    }
+
     public List<ModerationRequest> getRequestsByRequestingUser(String user) {
         return makeSummaryFromFullDocs(SummaryType.SHORT, queryView("users", user));
     }
 
+    public Map<String, Long> getCountByModerationState() {
+        Map<String, Long> countByModerationState = Maps.newHashMap();
+        ViewRequest<String, Long> countReq = getConnector()
+                .createQuery(ModerationRequest.class, "countByModerationState").newRequest(Key.Type.STRING, Long.class)
+                .group(true).reduce(true).build();
+        List<Row<String, Long>> rows;
+        try {
+            if (countReq.getResponse() != null) {
+                rows = countReq.getResponse().getRows();
+                for (Row<String, Long> row : rows) {
+                    countByModerationState.put(row.getKey(), row.getValue());
+                }
+            }
+        } catch (IOException e) {
+            log.error("Error getting count of moderation requests based on moderation state", e);
+        }
+        return countByModerationState;
+    }
+
+    public Set<String> getRequestingUserDepts() {
+        Set<String> requestingUserDepts = Sets.newHashSet();
+        ViewRequest<String, Object> query = getConnector()
+                .createQuery(ModerationRequest.class, "byRequestingUsersDeptView")
+                .newRequest(Key.Type.STRING, Object.class).includeDocs(false).build();
+        try {
+            requestingUserDepts = Sets.newTreeSet(CommonUtils.nullToEmptyList(query.getResponse().getKeys()).stream()
+                    .filter(Objects::nonNull).collect(Collectors.toList()));
+        } catch (IOException e) {
+            log.error("Error getting requesting users", e);
+        }
+        return requestingUserDepts;
+    }
 }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -46,6 +46,8 @@ public class PortalConstants {
     public static final UserGroup USER_ROLE_ALLOWED_TO_MERGE_OR_SPLIT_COMPONENT;
     public static final String CLEARING_REPORT_TEMPLATE_TO_FILENAMEMAPPING;
     public static final String CLEARING_REPORT_TEMPLATE_FORMAT;
+    public static final String LOAD_OPEN_MODERATION_REQUEST = "loadOpenModerationRequest";
+    public static final String LOAD_CLOSED_MODERATION_REQUEST = "loadClosedModerationRequest";
 
     // DO NOT CHANGE THIS UNLESS YOU KNOW WHAT YOU ARE DOING !!!
     // - friendly url mapping files must be changed
@@ -120,6 +122,7 @@ public class PortalConstants {
     public static final String CLOSED_MODERATION_REQUESTS = "closedModerationRequests";
     public static final String DELETE_MODERATION_REQUEST = "deleteModerationRequest";
     public static final String MODERATION_ACTIONS_ALLOWED = "moderationAllowed";
+    public static final String MODERATION_REQUESTING_USER_DEPARTMENTS = "requestingUserDepartments";
 
     //! Specialized keys for clearing
     public static final String CLEARING_REQUEST = "clearingRequest";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
@@ -433,11 +433,11 @@ public class PortletUtils {
     }
 
     public static void handlePaginationSortOrder(ResourceRequest request, PaginationParameters paginationParameters,
-            final ImmutableList<Project._Fields> projectFilteredFields, final int projectNoSort) {
+            final ImmutableList<? extends TFieldIdEnum> entityilteredFields, final int entityNoSort) {
         if (!paginationParameters.getSortingColumn().isPresent()) {
-            for (Project._Fields filteredField : projectFilteredFields) {
+            for (TFieldIdEnum filteredField : entityilteredFields) {
                 if (!isNullOrEmpty(request.getParameter(filteredField.toString()))) {
-                    paginationParameters.setSortingColumn(Optional.of(projectNoSort));
+                    paginationParameters.setSortingColumn(Optional.of(entityNoSort));
                     break;
                 }
             }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
@@ -9,10 +9,14 @@
  */
 package org.eclipse.sw360.portal.portlets.moderation;
 
-import com.fasterxml.jackson.core.JsonFactory;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Organization;
@@ -20,11 +24,16 @@ import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
+import org.eclipse.sw360.commonIO.SampleOptions;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Constants;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
+import org.eclipse.sw360.datahandler.common.ThriftEnumUtils;
+import org.eclipse.sw360.datahandler.couchdb.lucene.LuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.permissions.PermissionUtils;
+import org.eclipse.sw360.datahandler.thrift.DateRange;
 import org.eclipse.sw360.datahandler.thrift.ModerationState;
+import org.eclipse.sw360.datahandler.thrift.PaginationData;
 import org.eclipse.sw360.datahandler.thrift.RemoveModeratorRequestStatus;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
@@ -55,11 +64,14 @@ import org.eclipse.sw360.portal.common.PortalConstants;
 import org.eclipse.sw360.portal.common.PortletUtils;
 import org.eclipse.sw360.portal.common.ThriftJsonSerializer;
 import org.eclipse.sw360.portal.common.UsedAsLiferayAction;
+import org.eclipse.sw360.portal.common.datatables.PaginationParser;
+import org.eclipse.sw360.portal.common.datatables.data.PaginationParameters;
 import org.eclipse.sw360.portal.portlets.FossologyAwarePortlet;
 import org.eclipse.sw360.portal.users.UserCacheHolder;
 import org.eclipse.sw360.portal.users.UserUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.thrift.TEnum;
 import org.apache.thrift.TException;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -68,11 +80,16 @@ import javax.portlet.*;
 import javax.servlet.http.HttpServletRequest;
 
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Strings.nullToEmpty;
 import static com.liferay.portal.kernel.json.JSONFactoryUtil.createJSONArray;
 import static com.liferay.portal.kernel.json.JSONFactoryUtil.createJSONObject;
+import static org.eclipse.sw360.datahandler.common.CommonUtils.isNotNullEmptyOrWhitespace;
+import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhitespace;
 import static org.eclipse.sw360.datahandler.common.CommonUtils.nullToEmptySet;
 import static org.eclipse.sw360.datahandler.permissions.PermissionUtils.makePermission;
 import static org.eclipse.sw360.portal.common.PortalConstants.*;
@@ -98,7 +115,16 @@ import static org.eclipse.sw360.portal.common.PortalConstants.*;
 public class ModerationPortlet extends FossologyAwarePortlet {
 
     private static final Logger log = LogManager.getLogger(ModerationPortlet.class);
-    private static final JsonFactory JSON_FACTORY = new JsonFactory();
+    private static final ImmutableList<ModerationRequest._Fields> MODERATION_FILTERED_FIELDS = ImmutableList.of(
+            ModerationRequest._Fields.TIMESTAMP,
+            ModerationRequest._Fields.COMPONENT_TYPE,
+            ModerationRequest._Fields.DOCUMENT_NAME,
+            ModerationRequest._Fields.REQUESTING_USER,
+            ModerationRequest._Fields.REQUESTING_USER_DEPARTMENT,
+            ModerationRequest._Fields.MODERATORS,
+            ModerationRequest._Fields.MODERATION_STATE);
+
+    private static final int MODERATION_NO_SORT = -1;
 
     @Override
     public void serveResource(ResourceRequest request, ResourceResponse response) throws IOException, PortletException {
@@ -119,7 +145,158 @@ public class ModerationPortlet extends FossologyAwarePortlet {
             JSONObject dataForChangeLogs = changeLogsPortletUtilsPortletUtils.serveResourceForChangeLogs(request,
                     response, action);
             writeJSON(request, response, dataForChangeLogs);
+        } else if (PortalConstants.LOAD_OPEN_MODERATION_REQUEST.equals(action)) {
+            serveModerationList(request, response, true);
+        } else if (PortalConstants.LOAD_CLOSED_MODERATION_REQUEST.equals(action)) {
+            serveModerationList(request, response, false);
         }
+    }
+
+    private void serveModerationList(ResourceRequest request, ResourceResponse response, boolean open) {
+        HttpServletRequest originalServletRequest = PortalUtil
+                .getOriginalServletRequest(PortalUtil.getHttpServletRequest(request));
+        PaginationParameters paginationParameters = PaginationParser.parametersFrom(originalServletRequest);
+        PortletUtils.handlePaginationSortOrder(request, paginationParameters, MODERATION_FILTERED_FIELDS,
+                MODERATION_NO_SORT);
+        PaginationData pageData = new PaginationData();
+        pageData.setRowsPerPage(paginationParameters.getDisplayLength());
+        pageData.setDisplayStart(paginationParameters.getDisplayStart());
+        pageData.setAscending(paginationParameters.isAscending().get());
+        if(paginationParameters.getSortingColumn().isPresent()) {
+            int sortParam = paginationParameters.getSortingColumn().get();
+            if(sortParam == 0 &&  Integer.valueOf(paginationParameters.getEcho()) == 1) {
+                pageData.setSortColumnNumber(-1);
+            } else {
+                pageData.setSortColumnNumber(paginationParameters.getSortingColumn().get());
+            }
+        } else {
+            pageData.setSortColumnNumber(-1);
+        }
+        Map<PaginationData, List<ModerationRequest>> modRequestsWithPageData = getFilteredModerationList(request,
+                pageData, open);
+        List<ModerationRequest> moderations = new ArrayList<>();
+        PaginationData pgDt = new PaginationData();
+        if (!CommonUtils.isNullOrEmptyMap(modRequestsWithPageData)) {
+            moderations = modRequestsWithPageData.values().iterator().next();
+            pgDt = modRequestsWithPageData.keySet().iterator().next();
+        }
+        JSONArray jsonOpenModerations = getModerationData(moderations, paginationParameters, request, open);
+        JSONObject jsonResult = createJSONObject();
+        jsonResult.put(DATATABLE_RECORDS_TOTAL, pgDt.getTotalRowCount());
+        jsonResult.put(DATATABLE_RECORDS_FILTERED, pgDt.getTotalRowCount());
+        jsonResult.put(DATATABLE_DISPLAY_DATA, jsonOpenModerations);
+        final Map<String, Long> countByModerationState = getCountByModerationState();
+        long totalNoOfRequests = countByModerationState.values().stream().mapToLong(Long::longValue).sum();
+        long closedModRequestCount = countByModerationState.get("CLOSED") == null ? 0
+                : countByModerationState.get("CLOSED");
+        jsonResult.put(MODERATION_REQUESTS, totalNoOfRequests);
+        jsonResult.put(CLOSED_MODERATION_REQUESTS, closedModRequestCount);
+        jsonResult.put(MODERATION_REQUESTING_USER_DEPARTMENTS, getRequestingUserDepts());
+        try {
+            writeJSON(request, response, jsonResult);
+        } catch (IOException e) {
+            log.error("Problem rendering list of open moderation", e);
+        }
+    }
+
+    private Map<String, Long> getCountByModerationState() {
+        Map<String, Long> countByModerationState = Maps.newHashMap();
+        ModerationService.Iface client = thriftClients.makeModerationClient();
+        try {
+            countByModerationState = client.getCountByModerationState();
+        } catch (TException e) {
+            log.error("Error geeting moderation requests count", e);
+        }
+        return countByModerationState;
+    }
+
+    private Set<String> getRequestingUserDepts() {
+        Set<String> requestingUserDepts = Sets.newHashSet();
+        ModerationService.Iface client = thriftClients.makeModerationClient();
+        try {
+            requestingUserDepts = client.getRequestingUserDepts();
+        } catch (TException e) {
+            log.error("Error geeting requesting user departments", e);
+        }
+        return requestingUserDepts;
+    }
+
+    private JSONArray getModerationData(List<ModerationRequest> moderationList,
+            PaginationParameters paginationParameters, ResourceRequest request, boolean open) {
+        Map<String, Set<String>> filterMap = getModerationFilterMap(request);
+        int count = PortletUtils.getProjectDataCount(paginationParameters, moderationList.size());
+        User user = UserCacheHolder.getUserFromRequest(request);
+        boolean isClearingAdmin = PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user);
+        JSONArray moderationRequestData = createJSONArray();
+        final int start = filterMap.isEmpty() ? 0 : paginationParameters.getDisplayStart();
+        for (int i = start; i < count; i++) {
+            JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
+            ModerationRequest modreq = moderationList.get(i);
+            jsonObject.put("id", modreq.getId());
+            jsonObject.put("renderTimestamp", modreq.getTimestamp() + "");
+            jsonObject.put("componentType", printEnumValueWithTooltip(request, modreq.getComponentType()));
+            jsonObject.put("documentName", modreq.getDocumentName());
+            jsonObject.put("requestingUser", UserUtils.displayUser(modreq.getRequestingUser(), null));
+            jsonObject.put("requestingUserDepartment", modreq.getRequestingUserDepartment());
+            jsonObject.put("moderators", displayUserCollection(modreq.getModerators()));
+            jsonObject.put("moderationState", printEnumValueWithTooltip(request, modreq.getModerationState()));
+            if (!open) {
+                jsonObject.put("isClearingAdmin", isClearingAdmin);
+            }
+            moderationRequestData.put(jsonObject);
+        }
+
+        return moderationRequestData;
+    }
+
+    private String displayUserCollection(Set<String> values) {
+        if (!CommonUtils.isNotEmpty(values)) {
+            return "";
+        }
+        List<String> valueList = new ArrayList<String>(values);
+        Collections.sort(valueList, String.CASE_INSENSITIVE_ORDER);
+        List<String> resultList = new ArrayList<>();
+
+        for (String email : valueList) {
+            if (!Strings.isNullOrEmpty(email)) {
+                resultList.add(UserUtils.displayUser(email, null));
+            }
+        }
+        return CommonUtils.COMMA_JOINER.join(resultList);
+    }
+
+    private String printEnumValueWithTooltip(ResourceRequest request, TEnum value) {
+        if (value == null) {
+            return "";
+        }
+        ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content.Language", request.getLocale(),
+                getClass());
+        return "<span class='" + PortalConstants.TOOLTIP_CLASS__CSS + " " + PortalConstants.TOOLTIP_CLASS__CSS + "-"
+                + value.getClass().getSimpleName() + "-" + value.toString() + "' data-content='"
+                + LanguageUtil.get(resourceBundle, value.getClass().getSimpleName() + "-" + value.toString()) + "'>"
+                + LanguageUtil.get(resourceBundle, ThriftEnumUtils.enumToString(value).replace(' ', '.').toLowerCase())
+                + "</span>";
+    }
+
+    private Map<PaginationData, List<ModerationRequest>> getFilteredModerationList(PortletRequest request, PaginationData pageData, boolean open) {
+        ModerationService.Iface client = thriftClients.makeModerationClient();
+        Map<String, Set<String>> filterMap = getModerationFilterMap(request);
+        User user = UserCacheHolder.getUserFromRequest(request);
+        Map<PaginationData, List<ModerationRequest>> moderationRequestsWithPageData = Maps.newHashMap();
+        try {
+            if (filterMap.isEmpty()) {
+                moderationRequestsWithPageData = client.getRequestsByModeratorWithPagination(user, pageData, open);
+            } else {
+                List<ModerationRequest> moderations = client.refineSearch(null, filterMap);
+                Map<Boolean, List<ModerationRequest>> partitionedModerationRequests = moderations.stream()
+                        .collect(Collectors.groupingBy(ModerationPortletUtils::isOpenModerationRequest));
+                List<ModerationRequest> requests = CommonUtils.nullToEmptyList(partitionedModerationRequests.get(open));
+                moderationRequestsWithPageData.put(pageData.setTotalRowCount(requests.size()), requests);
+            }
+        } catch (TException e) {
+            log.error("Could not fetch moderation requests from backend!", e);
+        }
+        return moderationRequestsWithPageData;
     }
 
     private void serveDeleteModerationRequest(ResourceRequest request, ResourceResponse response) throws IOException {
@@ -448,26 +625,9 @@ public class ModerationPortlet extends FossologyAwarePortlet {
         HttpServletRequest httpServletRequest = PortalUtil.getOriginalServletRequest(PortalUtil.getHttpServletRequest(request));
         String selectedTab = httpServletRequest.getParameter(SELECTED_TAB);
 
-        List<ModerationRequest> openModerationRequests = null;
-        List<ModerationRequest> closedModerationRequests = null;
         List<ClearingRequest> openClearingRequests = null;
         List<ClearingRequest> closedClearingRequests = null;
         ModerationService.Iface client = thriftClients.makeModerationClient();
-
-        try {
-            List<ModerationRequest> moderationRequests = client.getRequestsByModerator(user);
-            Map<Boolean, List<ModerationRequest>> partitionedModerationRequests = moderationRequests
-                    .stream()
-                    .collect(Collectors.groupingBy(ModerationPortletUtils::isOpenModerationRequest));
-            openModerationRequests = partitionedModerationRequests.get(true);
-            closedModerationRequests = partitionedModerationRequests.get(false);
-        } catch (TException e) {
-            log.error("Could not fetch moderation requests from backend!", e);
-        }
-
-        request.setAttribute(MODERATION_REQUESTS, CommonUtils.nullToEmptyList(openModerationRequests));
-        request.setAttribute(CLOSED_MODERATION_REQUESTS, CommonUtils.nullToEmptyList(closedModerationRequests));
-        request.setAttribute(IS_USER_AT_LEAST_CLEARING_ADMIN, PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user) ? "Yes" : "No");
 
         try {
             Set<ClearingRequest> clearingRequestsSet = client.getMyClearingRequests(user);
@@ -490,6 +650,12 @@ public class ModerationPortlet extends FossologyAwarePortlet {
         if (CommonUtils.isNotNullEmptyOrWhitespace(selectedTab)) {
             request.setAttribute(SELECTED_TAB, selectedTab);
         }
+        for (ModerationRequest._Fields moderationFilteredField : MODERATION_FILTERED_FIELDS) {
+            request.setAttribute(moderationFilteredField.getFieldName(),
+                    nullToEmpty(request.getParameter(moderationFilteredField.toString())));
+        }
+        request.setAttribute(PortalConstants.DATE_RANGE, nullToEmpty(request.getParameter(PortalConstants.DATE_RANGE)));
+        request.setAttribute(PortalConstants.END_DATE, nullToEmpty(request.getParameter(PortalConstants.END_DATE)));
         super.doView(request, response);
     }
 
@@ -777,6 +943,60 @@ public class ModerationPortlet extends FossologyAwarePortlet {
         request.setAttribute(PortalConstants.ORGANIZATIONS, organizations);
 
         include("/html/moderation/users/merge.jsp", request, response);
+    }
+
+    @UsedAsLiferayAction
+    public void applyFilters(ActionRequest request, ActionResponse response) throws PortletException, IOException {
+        for (ModerationRequest._Fields moderationFilteredField : MODERATION_FILTERED_FIELDS) {
+            response.setRenderParameter(moderationFilteredField.toString(),
+                    nullToEmpty(request.getParameter(moderationFilteredField.toString())));
+        }
+        response.setRenderParameter(PortalConstants.DATE_RANGE, nullToEmpty(request.getParameter(PortalConstants.DATE_RANGE)));
+        response.setRenderParameter(PortalConstants.END_DATE, nullToEmpty(request.getParameter(PortalConstants.END_DATE)));
+    }
+
+    private Map<String, Set<String>> getModerationFilterMap(PortletRequest request) {
+        Map<String, Set<String>> filterMap = new HashMap<>();
+        for (ModerationRequest._Fields filteredField : MODERATION_FILTERED_FIELDS) {
+            String parameter = request.getParameter(filteredField.toString());
+            if (!isNullOrEmpty(parameter) && !((filteredField.equals(ModerationRequest._Fields.COMPONENT_TYPE)
+                    || filteredField.equals(ModerationRequest._Fields.MODERATION_STATE))
+                    && parameter.equals(PortalConstants.NO_FILTER))) {
+                if (filteredField.equals(ModerationRequest._Fields.TIMESTAMP) && isNotNullEmptyOrWhitespace(request.getParameter(PortalConstants.DATE_RANGE))) {
+                    Date date = new Date();
+                    String upperLimit = new SimpleDateFormat(SampleOptions.DATE_OPTION).format(date);
+                    String dateRange = request.getParameter(PortalConstants.DATE_RANGE);
+                    String query = new StringBuilder("[%s ").append(PortalConstants.TO).append(" %s]").toString();
+                    DateRange range = ThriftEnumUtils.stringToEnum(dateRange, DateRange.class);
+                    switch (range) {
+                    case EQUAL:
+                        break;
+                    case LESS_THAN_OR_EQUAL_TO:
+                        parameter = String.format(query, PortalConstants.EPOCH_DATE, parameter);
+                        break;
+                    case GREATER_THAN_OR_EQUAL_TO:
+                        parameter = String.format(query, parameter, upperLimit);
+                        break;
+                    case BETWEEN:
+                        String endDate = request.getParameter(PortalConstants.END_DATE);
+                        if (isNullEmptyOrWhitespace(endDate)) {
+                            endDate = upperLimit;
+                        }
+                        parameter = String.format(query, parameter, endDate);
+                        break;
+                    }
+                }
+                Set<String> values = CommonUtils.splitToSet(parameter);
+                if (filteredField.equals(ModerationRequest._Fields.DOCUMENT_NAME)
+                        || filteredField.equals(ModerationRequest._Fields.REQUESTING_USER)
+                        || filteredField.equals(ModerationRequest._Fields.REQUESTING_USER_DEPARTMENT)) {
+                    values = values.stream().map(LuceneAwareDatabaseConnector::prepareWildcardQuery)
+                            .collect(Collectors.toSet());
+                }
+                filterMap.put(filteredField.getFieldName(), values);
+            }
+        }
+        return filterMap;
     }
 
     private UnsupportedOperationException unsupportedActionException() {

--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -1027,6 +1027,7 @@ request.information=Request Information
 request.status=Request Status
 request.created.on=Request Created On
 requesting.user=Requesting User
+requesting.user.email=Requesting User (Email)
 reset=Reset
 responsible=Responsible
 rest.api.token=REST API Token

--- a/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
@@ -1027,6 +1027,7 @@ request.information=リクエスト情報
 request.status=リクエスト状況
 request.created.on=リクエスト作成
 requesting.user=リクエストユーザー
+requesting.user.email=Requesting User (Email)
 reset=リセット
 responsible=責任
 rest.api.token=REST API トークン

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -1025,6 +1025,7 @@ request.information=Yêu cầu thông tin
 request.status=Request Status
 request.created.on=Request Created On
 requesting.user=Yêu cầu người dùng
+requesting.user.email=Requesting User (Email)
 reset=Cài lại
 responsible=Trách nhiệm
 rest.api.token=Mã truy cập REST API

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/LuceneAwareDatabaseConnector.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/couchdb/lucene/LuceneAwareDatabaseConnector.java
@@ -244,7 +244,7 @@ public class LuceneAwareDatabaseConnector extends LuceneAwareCouchDbConnector {
         final Function<String, String> addType = input -> {
             if (fieldName.equals("businessUnit") || fieldName.equals("tag") || fieldName.equals("projectResponsible") || fieldName.equals("createdBy")) {
                 return fieldName + ":\"" + input + "\"";
-            } if (fieldName.equals("createdOn")) {
+            } if (fieldName.equals("createdOn") || fieldName.equals("timestamp")) {
                 return fieldName + "<date>:" + input;
             } else {
                 return fieldName + ":" + input;

--- a/libraries/lib-datahandler/src/main/thrift/moderation.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/moderation.thrift
@@ -22,6 +22,7 @@ typedef sw360.RequestStatus RequestStatus
 typedef sw360.RemoveModeratorRequestStatus RemoveModeratorStatus
 typedef sw360.ModerationState ModerationState
 typedef sw360.Comment Comment
+typedef sw360.PaginationData PaginationData
 typedef components.Component Component
 typedef components.Release Release
 typedef projects.Project Project
@@ -193,6 +194,11 @@ service ModerationService {
     list<ModerationRequest> getRequestsByModerator(1: User user);
 
     /**
+     * get list of moderation requests based on moderation state(open/closed) where user is one of the moderators, with pagination
+     **/
+    map<PaginationData, list<ModerationRequest>> getRequestsByModeratorWithPagination(1: User user, 2: PaginationData pageData, 3: bool open);
+
+    /**
      * get list of moderation requests where user is requesting user
      **/
     list<ModerationRequest> getRequestsByRequestingUser(1: User user);
@@ -246,4 +252,19 @@ service ModerationService {
      * add comment to clearing request
      **/
     RequestStatus addCommentToClearingRequest(1: string id, 2: Comment comment, 3: User user);
+
+    /**
+     * search moderation requests in database that match subQueryRestrictions
+     **/
+    list<ModerationRequest> refineSearch(1: string text, 2: map<string, set<string>> subQueryRestrictions);
+
+    /**
+     * get count of moderation requests by moderation state
+     **/
+    map<string, i64> getCountByModerationState();
+
+    /**
+     * get requesting users departments
+     **/
+    set<string> getRequestingUserDepts();
 }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)

Issue: 

It is observed the "Requests" tab taking longer time to load if the number of requests are higher.  This changes adds the paginated view response for loading moderation requests instead off getting all the moderations on a single hit upon clicking on "Requests" tab which might decrease the loading time. 

Note: 
- Had to remove the data table quick filter and add the advanced search as it is there in Components and Projects tab to make the search work properly. 
- Paginated response for clearing requests are not taken care of as part of it as per now.

> * Did you add or update any new dependencies that are required for your change?


### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?

Need to test the moderation functionality. 

> Have you implemented any additional tests? No

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR

Signed-off-by: Smruti Prakash Sahoo <smruti.sahoo@siemens.com>
