### PR TITLE
feat(obligationlevelhelptext):Provide info text for different obligation Level.

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/components/_tooltips.scss
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/components/_tooltips.scss
@@ -805,3 +805,28 @@
     content: "";
     display: none;
 }
+
+/** ObligationLevel **/
+.sw360-tt-ObligationLevel:hover:after {
+	content: attr(data-content);
+	position: absolute;
+	z-index: 1;
+	bottom: 100%;
+	right: 50%;
+}
+
+.sw360-tt-ObligationLevel-ORGANISATION_OBLIGATION:hover:after {
+    content: attr(data-content);
+}
+
+.sw360-tt-ObligationLevel-PROJECT_OBLIGATION:hover:after {
+    content: attr(data-content);
+}
+
+.sw360-tt-ObligationLevel-COMPONENT_OBLIGATION:hover:after {
+    content: attr(data-content);
+}
+
+.sw360-tt-ObligationLevel-LICENSE_OBLIGATION:hover:after {
+    content: attr(data-content);
+}

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/obligations/add.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/obligations/add.jsp
@@ -90,6 +90,10 @@
                                         <select class="form-control" id="obligationLevel" name="<portlet:namespace/><%=Obligation._Fields.OBLIGATION_LEVEL%>">
                                             <sw360:DisplayEnumOptions type="<%=ObligationLevel.class%>" selected="${todo.obligationLevel}"/>
                                         </select>
+                                        <small class="form-text">
+                                             <sw360:DisplayEnumInfo type="<%=ObligationLevel.class%>"/>
+                                              <liferay-ui:message key="learn.more.about.obligation.level"/>
+                                        </small>
                                      </div>
                                     </td>
                                 </tr>

--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -1354,6 +1354,12 @@ license.obligation=License Obligation
 obligation.title= Obligation Title
 obligation.text=Obligation Text
 linked.obligations=Linked Obligations
+learn.more.about.obligation.level=Learn more about obligation level
+ObligationLevel=Organisation Obligation: Organisation Obligations are general rules or mandatory steps to made sure before conveying software. &#10An example would be to add the OSS contact e-mail address in case of questions to the project, software or to the organisation &#10at all instances of conveyed software. &#10Component Obligation: Component obligations are obligations for a specific component or release only. &#10For example, special measure or actions to be carried out could result from trade compliance or IP issues with the component. &#10License Obligation: License obligation are task to be carried out or risks to be considered from the use of software under a particular license. &#10Project Obligation: Project obligations are specific to the projects or products nature and are also requires steps or tasks to be made sure before &#10conveying the software. &#10An example could be tiny hardware with limited printed documentation. In this case open source license information would required special handling, &#10for example print instructions how to obtain OSS license information on the packaging.
+ObligationLevel-ORGANISATION_OBLIGATION=Organisation Obligations are general rules or mandatory steps to made sure before conveying software. &#10An example would be to add the OSS contact e-mail address in case of questions to the project, software &#10or to the organisation at all instances of conveyed software.
+ObligationLevel-COMPONENT_OBLIGATION=Component obligations are obligations for a specific component or release only. &#10For example, special measure or actions to be carried out could result from trade compliance &#10or IP issues with the component.
+ObligationLevel-LICENSE_OBLIGATION=License obligation are task to be carried out or risks to be considered from the use of &#10software under a particular license.
+ObligationLevel-PROJECT_OBLIGATION=Project obligations are specific to the projects or products nature and are also requires steps or tasks &#10to be made sure before conveying the software. &#10An example could be tiny hardware with limited printed documentation. In this case open source license &#10information would required special handling, &#10for example print instructions how to obtain OSS license information on the packaging.
 id=Id
 templates=Templates
 

--- a/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
@@ -1355,6 +1355,12 @@ license.obligation=License Obligation
 obligation.title=Obligation Title
 obligation.text=Obligation Text
 linked.obligations=Linked Obligations
+learn.more.about.obligation.level=Learn more about obligation level
+ObligationLevel=Organisation Obligation: Organisation Obligations are general rules or mandatory steps to made sure before conveying software. &#10An example would be to add the OSS contact e-mail address in case of questions to the project, software or to the organisation &#10at all instances of conveyed software. &#10Component Obligation: Component obligations are obligations for a specific component or release only. &#10For example, special measure or actions to be carried out could result from trade compliance or IP issues with the component. &#10License Obligation: License obligation are task to be carried out or risks to be considered from the use of software under a particular license. &#10Project Obligation: Project obligations are specific to the projects or products nature and are also requires steps or tasks to be made sure before &#10conveying the software. &#10An example could be tiny hardware with limited printed documentation. In this case open source license information would required special handling, &#10for example print instructions how to obtain OSS license information on the packaging.
+ObligationLevel-ORGANISATION_OBLIGATION=Organisation Obligations are general rules or mandatory steps to made sure before conveying software. &#10An example would be to add the OSS contact e-mail address in case of questions to the project, software &#10or to the organisation at all instances of conveyed software.
+ObligationLevel-COMPONENT_OBLIGATION=Component obligations are obligations for a specific component or release only. &#10For example, special measure or actions to be carried out could result from trade compliance &#10or IP issues with the component.
+ObligationLevel-LICENSE_OBLIGATION=License obligation are task to be carried out or risks to be considered from the use of &#10software under a particular license.
+ObligationLevel-PROJECT_OBLIGATION=Project obligations are specific to the projects or products nature and are also requires steps or tasks &#10to be made sure before conveying the software. &#10An example could be tiny hardware with limited printed documentation. In this case open source license &#10information would required special handling, &#10for example print instructions how to obtain OSS license information on the packaging.
 id=Id
 templates=Templates
 

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -1357,6 +1357,12 @@ license.obligation=License Obligation
 obligation.title= Obligation Title
 obligation.text=Obligation Text
 linked.obligations=Linked Obligations
+learn.more.about.obligation.level=Learn more about obligation level
+ObligationLevel=Organisation Obligation: Organisation Obligations are general rules or mandatory steps to made sure before conveying software. &#10An example would be to add the OSS contact e-mail address in case of questions to the project, software or to the organisation &#10at all instances of conveyed software. &#10Component Obligation: Component obligations are obligations for a specific component or release only. &#10For example, special measure or actions to be carried out could result from trade compliance or IP issues with the component. &#10License Obligation: License obligation are task to be carried out or risks to be considered from the use of software under a particular license. &#10Project Obligation: Project obligations are specific to the projects or products nature and are also requires steps or tasks to be made sure before &#10conveying the software. &#10An example could be tiny hardware with limited printed documentation. In this case open source license information would required special handling, &#10for example print instructions how to obtain OSS license information on the packaging.
+ObligationLevel-ORGANISATION_OBLIGATION=Organisation Obligations are general rules or mandatory steps to made sure before conveying software. &#10An example would be to add the OSS contact e-mail address in case of questions to the project, software &#10or to the organisation at all instances of conveyed software.
+ObligationLevel-COMPONENT_OBLIGATION=Component obligations are obligations for a specific component or release only. &#10For example, special measure or actions to be carried out could result from trade compliance &#10or IP issues with the component.
+ObligationLevel-LICENSE_OBLIGATION=License obligation are task to be carried out or risks to be considered from the use of &#10software under a particular license.
+ObligationLevel-PROJECT_OBLIGATION=Project obligations are specific to the projects or products nature and are also requires steps or tasks &#10to be made sure before conveying the software. &#10An example could be tiny hardware with limited printed documentation. In this case open source license &#10information would required special handling, &#10for example print instructions how to obtain OSS license information on the packaging.
 id=Id
 templates=Templates
 


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

>   Added a help text for the obligation level in admin obligations tab for the user.
> * Which issue is this pull request belonging to and how is it solving it? (#1226 )
> * Did you add or update any new dependencies that are required for your change? NA

Issue: closes #1226 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
  - To Test this go to Admin->Obligations->Add obligation
  - Validate the different help text for the Obligation Level.
![image](https://user-images.githubusercontent.com/56516845/119156076-7f9d0600-ba71-11eb-922e-ff6d4c3d7342.png)

> Have you implemented any additional tests? No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: ravi110336 <kumar.ravindra@siemens.com>
