### PR TITLE
fix(readmeossdownload): Null pointer while downloading readme_oss

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -367,7 +367,7 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
 
         if (CommonUtils.isNotNullEmptyOrWhitespace(project.getLinkedObligationId())) {
             ObligationList obligation = projectDatabaseHandler.getLinkedObligations(project.getLinkedObligationId(), user);
-            obligationStatusMap = obligation.getLinkedObligationStatus();
+            obligationStatusMap = CommonUtils.nullToEmptyMap(obligation.getLinkedObligationStatus());
             releaseIdToAcceptedCLI.putAll(SW360Utils.getReleaseIdtoAcceptedCLIMappings(obligationStatusMap));
         }
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -290,7 +290,11 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             final ProjectService.Iface client = thriftClients.makeProjectClient();
             final User user = UserCacheHolder.getUserFromRequest(request);
             obligation = client.getLinkedObligations(obligationId, user);
-            obligation.getLinkedObligationStatus().remove(topic);
+            Map<java.lang.String, ObligationStatusInfo> obligationStatusInfo = obligation.getLinkedObligationStatus();
+            if (null == obligationStatusInfo) {
+                return;
+            }
+            obligationStatusInfo.remove(topic);
             status = client.updateLinkedObligations(obligation, user);
         } catch (TException exception) {
             log.error("Failed to delete obligation: "+ obligationId +" with topic: " + topic, exception);
@@ -2318,7 +2322,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             releases = getLinkedReleases(CommonUtils.getNullToEmptyKeyset(project.getReleaseIdToUsage()), user);
                 if (CommonUtils.isNotNullEmptyOrWhitespace(project.getLinkedObligationId())) {
                     obligation = projectClient.getLinkedObligations(project.getLinkedObligationId(), user);
-                    obligationStatusMap = obligation.getLinkedObligationStatus();
+                    obligationStatusMap = CommonUtils.nullToEmptyMap(obligation.getLinkedObligationStatus());
                     setObligationsFromAdminSection(obligationStatusMap, request, project);
                     if (!CommonUtils.isNotEmpty(releases)) {
                         return null;

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -223,6 +223,9 @@ public class SW360Utils {
     }
 
     public static Map<String, String> getReleaseIdtoAcceptedCLIMappings(Map<String, ObligationStatusInfo> obligationStatusMap) {
+        if (null == obligationStatusMap) {
+            return Maps.newHashMap();
+        }
         return obligationStatusMap.values().stream().flatMap(e -> (e.getReleaseIdToAcceptedCLI() != null ? e.getReleaseIdToAcceptedCLI() : new HashMap<String,String>()).entrySet().stream())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (oldValue, newValue) -> oldValue));
     }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

**Issue:** 

It is observed some of the project documents having linked obligation (with field `linkedObligationId` in database). However without any any proper linked obligation status(field: `linkedObligationStatus`) in the corresponding linked  document(reason unknow).
like

`{
  "_id": "4ac36b2711dd4d63a7fc7fcb967bd2b2",
  "_rev": "19-c1c61973923d83ea3732ee77fcff8804",
  "type": "obligationList",
  "projectId": "4a0860307fae44a18bbc978042cf8fd1"
}`

which causes the null pointer downloading readme_oss and it breaks the obligations view for individual project in UI.


> Please provide a summary of your changes here.

This change is to mitigate the null pointer as mentioned in the issue section.

> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change? - No

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?

- Add a CLI file with obligations to release, link it to project . Go to obligations view of the project. Edit any field like comment and update the project which will create the linked obligation and link it to project.
- Go to the linked obligation in DB and delete the field `linkedObligationStatus` with contents and try to download the readme_oss and check the obligations view as well.
  
> Have you implemented any additional tests? - No

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR

Signed-off-by: Smruti Prakash Sahoo <smruti.sahoo@siemens.com>
