### PR TITLE
fix REST: Wrong error handling when deleting multiple components #851

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -1507,8 +1507,13 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
 
 
     public RequestStatus deleteComponent(String id, User user) throws SW360Exception {
-        Component component = componentRepository.get(id);
-        assertNotNull(component);
+        Component component = new Component();
+        try {
+            component = componentRepository.get(id);
+            assertNotNull(component);
+        } catch (Exception e) {
+            return RequestStatus.INVALID_INPUT;
+        }
 
         final Set<String> releaseIds = component.getReleaseIds();
         if (releaseIds!=null && releaseIds.size()>0) return RequestStatus.IN_USE;


### PR DESCRIPTION
Signed-off-by: Nguyen Phuong Nam <nam1.nguyenphuong@toshiba.co.jp>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Add 
`return RequestStatus.INVALID_INPUT`

when call to 
`deleteComponent`

Issue: #851 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
![image](https://user-images.githubusercontent.com/41797157/119919444-a8069200-bf94-11eb-9c7d-47808c4c27d4.png)


### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
