### PR TITLE
fix(script): Build failure of compileWithDocker.sh #1230

### DIFF
--- a/scripts/compileWithDocker.sh
+++ b/scripts/compileWithDocker.sh
@@ -25,6 +25,8 @@ docker run -i \
     -v "$DIR":/sw360portal \
     -w /sw360portal \
     --net=host \
+    -u $(id -u):$(id -g) \
+    --env MAVEN_CONFIG="/sw360portal/.m2" \
+    --env MAVEN_OPTS="$MAVEN_OPTS -Duser.home=/sw360portal" \
     sw360/sw360dev \
-    su-exec $(id -u):$(id -g) \
     mvn package -DskipTests

--- a/sw360dev.Dockerfile
+++ b/sw360dev.Dockerfile
@@ -9,15 +9,18 @@
 
 # This can be used to compile SW360 via:
 # $ docker build -f sw360dev.Dockerfile -t sw360/sw360dev --rm=true --force-rm=true .
-# $ docker run -i -v $(pwd):/sw360portal -w /sw360portal --net=host sw360/sw360dev su-exec $(id -u):$(id -g) mvn package -DskipTests
+# $ docker run -i -v $(pwd):/sw360portal -w /sw360portal --net=host -u $(id -u):$(id -g) sw360/sw360dev mvn package -DskipTests
 
-FROM maven:3.5.0-jdk-8-alpine
+FROM maven:3.6.3-openjdk-11-slim
 MAINTAINER Maximilian Huber <maximilian.huber@tngtech.com>
 
 ADD scripts/install-thrift.sh /install-thrift.sh
 RUN set -x \
- &&  apk --update add su-exec git \
+ && apt-get update && apt-get install -y --no-install-recommends git \
  && /install-thrift.sh \
- && rm -rf /var/cache/apk/*
+ && apt-get purge -y --auto-remove build-essential libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev \
+ && apt-get install -y --no-install-recommends libfl2 \
+ && apt-get -y clean \
+ && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*
 
 CMD /bin/bash


### PR DESCRIPTION
> Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)

Issue: 
Build failure of sw360dev.Dockerfile and compileWithDocker.sh #1230 

- Use maven:3.6.3-openjdk-11-slim. It’s the same base image version of Dockerfile.

- Use "-u" option for docker run
su-exec command is not available for Debian based maven image. Instead of it, "-u $(id -u):$(id -g)" option can be used for docker run command. For reference, please see https://hub.docker.com/_/maven

- Pass user.home directory and maven config directory for docker run
Otherwise, the following error is displayed and build failed.
[ERROR] Failed to execute goal com.liferay:com.liferay.portal.tools.theme.builder:1.1.8:build (default) on project liferay-theme: URI has a query component -> [Help 1]

- Remove development tools and cache of package manager after building thrift

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Did you add or update any new dependencies that are required for your change? - No

### How To Test?
> How should these changes be tested by the reviewer?

Execute ./scripts/compileWithDocker.sh and check if there is no error.

> Have you implemented any additional tests? - No

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
