### PR TITLE
fix(rest): Auto-set release clearing state

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -393,9 +393,9 @@ public class RestControllerHelper<T> {
     }
 
     public Release updateRelease(Release releaseToUpdate, Release requestBodyRelease) {
-        for(Release._Fields field:Release._Fields.values()) {
+        for (Release._Fields field : Release._Fields.values()) {
             Object fieldValue = requestBodyRelease.getFieldValue(field);
-            if(fieldValue != null) {
+            if (fieldValue != null) {
                 releaseToUpdate.setFieldValue(field, fieldValue);
             }
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -27,6 +27,7 @@ import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
+import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ExternalToolProcess;
 import org.eclipse.sw360.datahandler.thrift.users.User;
@@ -238,6 +239,7 @@ public class ReleaseController implements ResourceProcessor<RepositoryLinksResou
         User user = restControllerHelper.getSw360UserFromAuthentication();
         Release sw360Release = releaseService.getReleaseForUserById(id, user);
         Release updateRelease = setBackwardCompatibleFieldsInRelease(reqBodyMap);
+        updateRelease.setClearingState(sw360Release.getClearingState());
         sw360Release = this.restControllerHelper.updateRelease(sw360Release, updateRelease);
         releaseService.setComponentNameAsReleaseName(sw360Release, user);
         RequestStatus updateReleaseStatus = releaseService.updateRelease(sw360Release, user);
@@ -279,6 +281,7 @@ public class ReleaseController implements ResourceProcessor<RepositoryLinksResou
             release.setMainLicenseIds(mainLicenseIds);
         }
 
+        release.unsetClearingState();
         Release sw360Release = releaseService.createRelease(release, sw360User);
         HalResource<Release> halResource = createHalReleaseResource(sw360Release, true);
 


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Issue: 

Release clearing state should be automatically set based on attachments and it's type in release, which is working fine in UI, however from REST it can be set manually.

> Please provide a summary of your changes here.

This change is to ignore clearing state value while creating or updating release via REST, which is handled automatically in backend([here](https://github.com/eclipse/sw360/blob/8f7caf8aa02a0b7a28dcb23863eb52116466da4b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java#L923) and [here](https://github.com/eclipse/sw360/blob/8f7caf8aa02a0b7a28dcb23863eb52116466da4b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java#L422))

> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change? - No

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
- Need to verify creating and updating release by setting `clearingState` field in request payload. It should ignore the clearing state value set in the REST request. 

> Have you implemented any additional tests? - No

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR

Signed-off-by: Smruti Prakash Sahoo <smruti.sahoo@siemens.com>