### PR TITLE
feat(ObligationHelpTextforProject): Provide the different obligation help text from the Projects Screen under Obligations tab.

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligations.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligations.jspf
@@ -40,7 +40,9 @@
                 <th class="more-info">
                     <span title="<liferay-ui:message key="expand.all" />" data-show="false">&#x25BA</span>
                 </th>
-                <th><liferay-ui:message key="license.obligation" /></th>
+                <th>
+                    <span title="<liferay-ui:message key="ObligationLevel-LICENSE_OBLIGATION" />"><liferay-ui:message key="license.obligation" /></span>
+                </th>
                 <th><liferay-ui:message key="licenses" /></th>
                 <th><liferay-ui:message key="releases" /></th>
                 <th><liferay-ui:message key="status" /></th>
@@ -73,7 +75,9 @@
                 <th class="comp-more-info">
                     <span title="<liferay-ui:message key="expand.all" />" data-show="false">&#x25BA</span>
                 </th>
-                <th><liferay-ui:message key="component.obligation" /></th>
+                <th>
+                    <span title="<liferay-ui:message key="ObligationLevel-COMPONENT_OBLIGATION" />"><liferay-ui:message key="component.obligation" /></span>
+                </th>
                 <th><liferay-ui:message key="status" /></th>
                 <th><liferay-ui:message key="type" /></th>
                 <th><liferay-ui:message key="id" /></th>
@@ -102,7 +106,9 @@
                 <th class="project-more-info">
                     <span title="<liferay-ui:message key="expand.all" />" data-show="false">&#x25BA</span>
                 </th>
-                <th><liferay-ui:message key="project.obligation" /></th>
+                <th>
+                    <span title="<liferay-ui:message key="ObligationLevel-PROJECT_OBLIGATION" />"><liferay-ui:message key="project.obligation" /></span>
+                </th>
                 <th><liferay-ui:message key="status" /></th>
                 <th><liferay-ui:message key="type" /></th>
                 <th><liferay-ui:message key="id" /></th>
@@ -131,7 +137,9 @@
                 <th class="org-more-info">
                     <span title="<liferay-ui:message key="expand.all" />" data-show="false">&#x25BA</span>
                 </th>
-                <th><liferay-ui:message key="organisation.obligation" /></th>
+                <th>
+                    <span title="<liferay-ui:message key="ObligationLevel-ORGANISATION_OBLIGATION" />"><liferay-ui:message key="organisation.obligation" /></span>
+                </th>
                 <th><liferay-ui:message key="status" /></th>
                 <th><liferay-ui:message key="type" /></th>
                 <th><liferay-ui:message key="id" /></th>


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (#1237)
> * Did you add or update any new dependencies that are required for your change? No

Issue: closes #1237 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer? 

- To Test this go to Projects->Obligations 
- Validate the different help text for the License Obligation, Project obligation, Component obligation, Organistion Obligation.
![image](https://user-images.githubusercontent.com/56516845/120313978-56de0180-c2f8-11eb-9ef6-e9408c256a00.png)

> Have you implemented any additional tests? NA

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: ravi110336 <kumar.ravindra@siemens.com>
