### PR TITLE
feat(rest): Support map of release id to usage as request body in addition to previous array of release id for - Link/Patch Releases to a Project API

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -376,24 +376,48 @@ include::{snippets}/should_document_update_project/http-response.adoc[]
 [[resources-project-link-releases]]
 ==== Link Releases to the project
 
-A `POST` request is used to link releases to the project. Please pass an array of release ids to be linked as request body.
+A `POST` request is used to link releases to the project. Please pass an array of release ids or a map of release id to usage to be linked as request body.
 
-===== Example request
+===== Request structure 1
+Pass an array of release ids to be linked as request body.
+
+===== Example request 1
 include::{snippets}/should_document_link_releases/curl-request.adoc[]
 
-===== Example response
+===== Example response 1
 include::{snippets}/should_document_link_releases/http-response.adoc[]
+
+===== Request structure 2
+Pass a map of release id to usage to be linked as request body.
+
+===== Example request 2
+include::{snippets}/should_document_link_releases_with_project_release_relation/curl-request.adoc[]
+
+===== Example response 2
+include::{snippets}/should_document_link_releases_with_project_release_relation/http-response.adoc[]
 
 [[resources-project-patch-releases]]
 ==== Patch Releases to the project
 
-A `PATCH` request to append new releases to existing releases in a project
+A `PATCH` request to append new releases to existing releases in a project. Please pass an array of release ids or a map of release id to usage to be linked as request body.
 
-===== Example request
+===== Request structure 1
+Pass an array of release ids to be linked as request body.
+
+===== Example request 1
 include::{snippets}/should_document_patch_releases/curl-request.adoc[]
 
-===== Example response
+===== Example response 1
 include::{snippets}/should_document_patch_releases/http-response.adoc[]
+
+===== Request structure 2
+Pass a map of release id to usage to be linked as request body.
+
+===== Example request 2
+include::{snippets}/should_document_patch_releases_with_project_release_relation/curl-request.adoc[]
+
+===== Example response 2
+include::{snippets}/should_document_patch_releases_with_project_release_relation/http-response.adoc[]
 
 [[resources-project-patch-release-usage]]
 ==== Update Project Release Relationship

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -62,6 +62,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
@@ -1226,9 +1227,21 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
     }
 
     @Test
+    public void should_document_link_releases_with_project_release_relation() throws Exception {
+        MockHttpServletRequestBuilder requestBuilder = post("/api/projects/" + project.getId() + "/releases");
+        add_patch_releases_with_project_release_relation(requestBuilder);
+    }
+
+    @Test
     public void should_document_patch_releases() throws Exception {
         MockHttpServletRequestBuilder requestBuilder = patch("/api/projects/" + project.getId() + "/releases");
         add_patch_releases(requestBuilder);
+    }
+
+    @Test
+    public void should_document_patch_releases_with_project_release_relation() throws Exception {
+        MockHttpServletRequestBuilder requestBuilder = patch("/api/projects/" + project.getId() + "/releases");
+        add_patch_releases_with_project_release_relation(requestBuilder);
     }
 
     @Test
@@ -1337,6 +1350,22 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
         this.mockMvc.perform(requestBuilder.contentType(MediaTypes.HAL_JSON)
                 .content(this.objectMapper.writeValueAsString(releaseIds))
+                .header("Authorization", "Bearer " + accessToken)).andExpect(status().isCreated());
+    }
+
+    private void add_patch_releases_with_project_release_relation(MockHttpServletRequestBuilder requestBuilder)
+            throws Exception {
+        ProjectReleaseRelationship projectReleaseRelationship1 = new ProjectReleaseRelationship(
+                ReleaseRelationship.REFERRED, MAINLINE);
+        ProjectReleaseRelationship projectReleaseRelationship2 = new ProjectReleaseRelationship(
+                ReleaseRelationship.STANDALONE, MainlineState.SPECIFIC).setComment("Test Comment 2");
+
+        ImmutableMap<String, ProjectReleaseRelationship> releaseIdToUsage = ImmutableMap
+                .<String, ProjectReleaseRelationship>builder().put("12345", projectReleaseRelationship1)
+                .put("54321", projectReleaseRelationship2).build();
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        this.mockMvc.perform(requestBuilder.contentType(MediaTypes.HAL_JSON)
+                .content(this.objectMapper.writeValueAsString(releaseIdToUsage))
                 .header("Authorization", "Bearer " + accessToken)).andExpect(status().isCreated());
     }
 }


### PR DESCRIPTION
> Support map of release id to usage as request body in addition to previous array of release id for - Link/Patch Releases to a Project API.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change? - No

Issue: closes: 


### How To Test? Refer Sw360 Rest Documentation
- **3.3.19. Link Releases to the project**
   - Doc - http://localhost:8080/resource/docs/api-guide.html#resources-project-link-releases
   - Request structure 1 - Array of Release Ids (Existing)
     ```
       curl 'https://sw360.org/api/projects/376576/releases' -i -X POST 
       -H 'Content-Type: application/hal+json'  -H 'Authorization: Bearer ************' 
       -d '[ "3765276512", "5578999", "3765276513" ]'
     ```

  - Request structure 2 - Map of Release Ids to usage (New)
     ```
      curl 'https://sw360.org/api/projects/376576/releases' -i -X POST 
      -H 'Content-Type: application/hal+json'  -H 'Authorization: Bearer ************' 
      -d '{
            "12345" : {
                            "releaseRelation" : "REFERRED",
                            "mainlineState" : "MAINLINE"
                           },
           "54321" : {
                          "releaseRelation" : "STANDALONE",
                           "mainlineState" : "SPECIFIC",
                           "comment" : "Test Comment 2"
                           }
           }'
       ```

- **3.3.20. Patch Releases to the project**
   - Doc - http://localhost:8080/resource/docs/api-guide.html#resources-project-patch-releases
   - Request structure 1 - Array of Release Ids (Existing)
      ```
      curl 'https://sw360.org/api/projects/376576/releases' -i -X PATCH
      -H 'Content-Type: application/hal+json' -H 'Authorization: 
      Bearer *********' -d '[ "3765276512", "5578999", "3765276513" ]'
      ```

  - Request structure 2 - Map of Release Ids to usage (New)
     ```
      curl 'https://sw360.org/api/projects/376576/releases' -i -X PATCH 
      -H 'Content-Type: application/hal+json'  -H 'Authorization: Bearer ************' 
      -d '{
            "12345" : {
                            "releaseRelation" : "REFERRED",
                            "mainlineState" : "MAINLINE"
                           },
           "54321" : {
                          "releaseRelation" : "STANDALONE",
                           "mainlineState" : "SPECIFIC",
                           "comment" : "Test Comment 2"
                           }
           }'
      ```
> Have you implemented any additional tests? - No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>