### PR TITLE
fix(ui): Link to main license detail page

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -572,6 +572,7 @@ public class PortalConstants {
     public static final String FRIENDLY_URL_PREFIX = "friendlyUrl";
     public static final String FRIENDLY_URL_PLACEHOLDER_PAGENAME = FRIENDLY_URL_PREFIX + "Pagename";
     public static final String FRIENDLY_URL_PLACEHOLDER_ID = FRIENDLY_URL_PREFIX + "Id";
+    public static final String FRIENDLY_URL_PLACEHOLDER_LICENSE_ID = FRIENDLY_URL_PREFIX + "license.Id";
 
     // datatables attributes for pagination
     public static final String DATATABLE_DISPLAY_DATA = "aaData";

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/view.jsp
@@ -61,7 +61,7 @@
 
 <liferay-portlet:renderURL var="friendlyLicenseURL" portletName="sw360_portlet_licenses">
     <portlet:param name="<%=PortalConstants.PAGENAME%>" value="<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_PAGENAME%>"/>
-    <portlet:param name="<%=PortalConstants.LICENSE_ID%>" value="<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_ID%>"/>
+    <portlet:param name="<%=PortalConstants.LICENSE_ID%>" value="<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_LICENSE_ID%>"/>
 </liferay-portlet:renderURL>
 
 <div class="container" style="display: none;">
@@ -280,6 +280,12 @@
                     .replace('<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_ID%>', id);
             }
 
+            function replaceLicenseUrlParameter(portletUrl, id, page) {
+                return portletUrl
+                    .replace('<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_PAGENAME%>', page)
+                    .replace('<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_LICENSE_ID%>', id);
+	        }
+
             // create and render data table
             function createComponentsTable() {
                 let columns = [
@@ -347,7 +353,7 @@
                     .replace(/components/g, "licenses");// DIRTY WORKAROUND
 
                 for (var i = 0; i < lics.length; i++) {
-                    links[i] = render.linkTo(replaceFriendlyUrlParameter(licensePortletURL.toString(), lics[i], '<%=PortalConstants.PAGENAME_DETAIL%>'), lics[i]);
+                    links[i] = replaceLicenseUrlParameter(render.linkTo(licensePortletURL.toString(), lics[i]), encodeURIComponent(lics[i]), '<%=PortalConstants.PAGENAME_DETAIL%>');
                 }
 
                 if(type == 'display') {


### PR DESCRIPTION
Signed-off-by: Tran Vu Quan <quan1.tranvu@toshiba.co.jp>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> - Update private pages to fix friendly license url
> - Update generate main license url function

Issue: #1130 #1164 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> Add Main Licenses to Component and click the License links
> ![image](https://user-images.githubusercontent.com/85483077/121880751-949b4b00-cd38-11eb-88c1-e45ae55a652d.png)


### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
