### PR TITLE
Fix(REST): not check licenseId when create and edit release

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -242,6 +242,7 @@ public class ReleaseController implements ResourceProcessor<RepositoryLinksResou
         updateRelease.setClearingState(sw360Release.getClearingState());
         sw360Release = this.restControllerHelper.updateRelease(sw360Release, updateRelease);
         releaseService.setComponentNameAsReleaseName(sw360Release, user);
+        releaseService.checkLicenseId(sw360Release);
         RequestStatus updateReleaseStatus = releaseService.updateRelease(sw360Release, user);
         HalResource<Release> halRelease = createHalReleaseResource(sw360Release, true);
         if (updateReleaseStatus == RequestStatus.SENT_TO_MODERATOR) {
@@ -270,6 +271,7 @@ public class ReleaseController implements ResourceProcessor<RepositoryLinksResou
         }
 
         if (release.getMainLicenseIds() != null) {
+            releaseService.checkLicenseId(release);
             Set<String> mainLicenseIds = new HashSet<>();
             Set<String> mainLicenseUris = release.getMainLicenseIds();
             for (String licenseURIString : mainLicenseUris.toArray(new String[mainLicenseUris.size()])) {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -162,20 +162,6 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
         rch.checkForCyclicOrInvalidDependencies(sw360ComponentClient, release, sw360User);
 
-        List <String> licenseIncorrect = new ArrayList<>();
-        if (!release.getMainLicenseIds().isEmpty()) {
-            for (String licenseId : release.getMainLicenseIds()) {
-                try {
-                    licenseService.getLicenseById(licenseId);
-                } catch (Exception e) {
-                    licenseIncorrect.add(licenseId);
-                }
-            }
-        }
-        if (!licenseIncorrect.isEmpty()) {
-            throw new HttpMessageNotReadableException("License with ids " + licenseIncorrect + " not existed.");
-        }
-
         RequestStatus requestStatus = sw360ComponentClient.updateRelease(release, sw360User);
         if (requestStatus == RequestStatus.INVALID_INPUT) {
             throw new HttpMessageNotReadableException("Dependent document Id/ids not valid.");
@@ -586,6 +572,22 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         }
 
         return RequestStatus.PROCESSING;
+    }
+
+    public void checkLicenseId(Release release) {
+        List <String> licenseIncorrect = new ArrayList<>();
+        if (!release.getMainLicenseIds().isEmpty()) {
+            for (String licenseId : release.getMainLicenseIds()) {
+                try {
+                    licenseService.getLicenseById(licenseId);
+                } catch (Exception e) {
+                    licenseIncorrect.add(licenseId);
+                }
+            }
+        }
+        if (!licenseIncorrect.isEmpty()) {
+            throw new HttpMessageNotReadableException("License with ids " + licenseIncorrect + " not existed.");
+        }
     }
 
     private Object[] checkScanCompletedSuccessfully(FossologyService.Iface sw360FossologyClient, String scanJobId,


### PR DESCRIPTION
Signed-off-by: Nguyen Phuong Nam <nam1.nguyenphuong@toshiba.co.jp>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

- Update function for checking licenseId when create/edit release

Issue: #534 

Refer: 
#1273 

#1234 

### Suggest Reviewer
### How To Test?
Create release:
![image](https://user-images.githubusercontent.com/41797157/122526316-59ed2780-d044-11eb-94b2-237e612d5037.png)

Edit release:
![image](https://user-images.githubusercontent.com/41797157/122526510-94ef5b00-d044-11eb-8a2b-91cdf0b17d8e.png)


### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
