### PR TITLE
fix(ui): Vulnerabilities relevance rating (tooltip) is not shown properly

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/CommonVulnerabilityPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/CommonVulnerabilityPortletUtils.java
@@ -47,7 +47,7 @@ public class CommonVulnerabilityPortletUtils {
                         "<span class=\"" + htmlClassPrefix + "Head\"><b>" + valueGetter.apply(historyElement) +
                         "</b> <span class=\"" + htmlClassPrefix + "Date\">(" + dateGetter.apply(historyElement) +
                         ")</span></span><br/><span class=\"" + htmlClassPrefix + "CheckedBy\"><b>" + authorGetter.apply(historyElement) +
-                        "</b></span><br/><span class=\"" + htmlClassPrefix + "Comment\">" + commentGetter.apply(historyElement) +
+                        "</b></span><br/><span class=\"" + htmlClassPrefix + "Comment\">" + commentGetter.apply(historyElement).replace("<", "&lt;").replace(">", "&gt;") +
                         "</span></li>"));
         sb.append("</ol>");
         return sb.toString();

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/components/_tooltips.scss
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/components/_tooltips.scss
@@ -14,10 +14,10 @@
 
 .info-text {
     ol.formatedMessageForVul {
-        list-style: none;
+        list-style-type: decimal;
+        margin-left: -0.6rem;
 
         li:before {
-            content: "- ";
             margin-left: -0.6rem;
         }
 
@@ -46,6 +46,13 @@
             font-style: italic;
         }
     }
+}
+
+.info-text.ui-widget.ui-widget-content {
+    max-width: 500px;
+    max-height: 300px;
+    overflow-x: auto;
+    overflow-y: auto;
 }
 
 .sw360-tt:hover:after {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/vulnerabilities.jspf
@@ -91,6 +91,16 @@
             $('#vulnerabilityTable th [data-action="select-all"]').prop('checked', !($('#vulnerabilityTable td :checkbox:not(:checked)').length > 0));
         });
 
+        vulnerabilityTable.on('preDraw', function() {
+            $('[role="tooltip"]').css("display", "none");
+            $('#vulnerabilityTable .info-text').tooltip("close");
+        });
+
+        vulnerabilityTable.on('draw', function() {
+            $('[role="tooltip"]').css("display", "none");
+            $('#vulnerabilityTable .info-text').tooltip("close");
+        });
+
         var viewSize = $('#vulnerabilityTable').data().viewSize;
         $('#btnShowVulnerabilityCount [data-name="count"]').text(viewSize > 0 ? '<liferay-ui:message key="latest" /> ' + viewSize : '<liferay-ui:message key="all" />');
         $('#btnShowVulnerabilityCount + div > a').on('click', function(event) {
@@ -179,18 +189,6 @@
                     datatable.enableCheckboxForSelection(table, 0);
                 });
             }
-
-            $('#vulnerabilityTable .info-text').tooltip({
-                delay: 0,
-                track: true,
-                fade: 250,
-                classes: {
-                     "ui-tooltip": "ui-corner-all ui-widget-shadow info-text"
-                },
-                content: function () {
-                    return $('<textarea/>').html($(this).prop('title')).val();
-                }
-            });
 
             return table;
         }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/vulnerabilities.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/vulnerabilities.jspf
@@ -127,6 +127,16 @@
             $('#vulnerabilityTable th [data-action="select-all"]').prop('checked', !($('#vulnerabilityTable td :checkbox:not(:checked)').length > 0));
         });
 
+        vulnerabilityTable.on('preDraw', function() {
+            $('[role="tooltip"]').css("display", "none");
+            $('#vulnerabilityTable .info-text').tooltip("close");
+        });
+
+        vulnerabilityTable.on('draw', function() {
+            $('[role="tooltip"]').css("display", "none");
+            $('#vulnerabilityTable .info-text').tooltip("close");
+        });
+
         var viewSize = $('#vulnerabilityTable').data() ? $('#vulnerabilityTable').data().viewSize : 0;
         $('#btnShowVulnerabilityCount [data-name="count"]').text(viewSize > 0 ? '<liferay-ui:message key="latest" /> ' + viewSize : '<liferay-ui:message key="all" />');
         $('#btnShowVulnerabilityCount + div > a').on('click', function(event) {
@@ -210,18 +220,6 @@
                    datatable.enableCheckboxForSelection(table, 0);
                 });
             }
-
-            $('#vulnerabilityTable .info-text').tooltip({
-                delay: 0,
-                track: true,
-                fade: 250,
-                classes: {
-                     "ui-tooltip": "ui-corner-all ui-widget-shadow info-text"
-                },
-                content: function () {
-                    return $('<textarea/>').html($(this).prop('title')).val();
-                }
-            });
 
             return table;
         }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/vulnerabilities/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/vulnerabilities/view.jsp
@@ -108,6 +108,16 @@
             vulnerabilityTable = createVulnerabilityTable();
             quickfilter.addTable(vulnerabilityTable);
 
+            vulnerabilityTable.on('preDraw', function() {
+                $('[role="tooltip"]').css("display", "none");
+                $('#vulnerabilitiesTable .info-text').tooltip("close");
+            });
+
+            vulnerabilityTable.on('draw', function() {
+                $('[role="tooltip"]').css("display", "none");
+                $('#vulnerabilitiesTable .info-text').tooltip("close");
+            });
+
             var viewSize = $('#vulnerabilitiesTable').data().viewSize;
             $('#viewSizeBtn [data-name="count"]').text(viewSize > 0 ? '<liferay-ui:message key="latest" /> ' + viewSize : '<liferay-ui:message key="all" />');
             $('#viewSizeBtn + div > a').on('click', function(event) {
@@ -215,18 +225,6 @@
                     },
                     initComplete: datatables.showPageContainer
                 }, [0, 1, 2, 3, 4]);
-
-                $('#vulnerabilitiesTable .info-text').tooltip({
-                    delay: 0,
-                    track: true,
-                    fade: 250,
-                    classes: {
-                        "ui-tooltip": "ui-corner-all ui-widget-shadow info-text"
-                    },
-                    content: function () {
-                        return $('<textarea/>').html($(this).prop('title')).val();
-                    }
-                });
 
                 return table;
             }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/bridges/datatables.js
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/bridges/datatables.js
@@ -115,6 +115,29 @@ define('bridges/datatables', [
 					"<'row'<'col-auto'i><'col'p>>"; // line below table
 			}
 
+			config.drawCallback = function () {
+				$('.info-text').tooltip({
+					track: true,
+					classes: {
+						"ui-tooltip": "ui-corner-all ui-widget-shadow info-text"
+					},
+					content: function () {
+						return $('<textarea/>').html($(this).prop('title')).val();
+					},
+					'data-html': 'true',
+					close: function (event, ui) {
+						ui.tooltip.hover(function () {
+							$(this).stop(true).fadeTo(100, 1);
+						},
+						function () {
+							$(this).fadeOut('100', function () {
+								$(this).remove();
+							});
+						});
+					}
+				});
+			}
+
 			return $(selector).DataTable(config);
 		},
 		destroy: function(selector) {


### PR DESCRIPTION
Signed-off-by: Tran Vu Quan <quan1.tranvu@toshiba.co.jp>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Issue: After changing the relevance of a CVE within the project's vulnerability view, the relevance rating in the pop-up box is not displayed properly.
>
> Solution: Correct the mechanism how relevance rating (DataTable tooltip) is rendered and displayed.

Issue:  #1042 

### How To Test?
> 1. Setup CVE Search server follow the installation manual: [SW360-CVE-mannual-20210621.md](https://github.com/eclipse/sw360/files/6698844/SW360-CVE-mannual-20210621.md)
> 2. Update SW360 configuration file with the CVE Search server address (default value: https://cve.circl.lu)
> https://github.com/toshiba/sw360/blob/4ff31a1bbd5234683ed5b553947eb5b063215ed1/backend/src/src-cvesearch/src/main/resources/cvesearch.properties#L10
> 3. (Optional) Update SW360 configuration file with the interval of querying data from CVE Search server (default value: 86400 seconds)
> https://github.com/toshiba/sw360/blob/4ff31a1bbd5234683ed5b553947eb5b063215ed1/backend/src/src-schedule/src/main/resources/sw360.properties#L13~L14
> 4. Re-build SW360
> 5. Open Admin Schedule page, and click button 'Schedule CVE service'
> ![image](https://user-images.githubusercontent.com/85483077/123036760-c33fb280-d417-11eb-98cf-3a8715d43961.png)
> ![image](https://user-images.githubusercontent.com/85483077/123036778-ccc91a80-d417-11eb-9501-a732e2284e34.png)
> 6. Wait for data synchronization from CVE Search server (depends on the interval you set at step 3)
> 7. Create a new component and with a new release. The new release should have CPE ID
> ![image](https://user-images.githubusercontent.com/85483077/123036880-f08c6080-d417-11eb-842f-b1b6a1bb9654.png)
> 8. After data synchronization completed, you should see vulnerability data in page 'Vulnerabilities'
> ![image](https://user-images.githubusercontent.com/85483077/123036854-e702f880-d417-11eb-80e4-c4aa2f83f6da.png)
> 9. Vulnerabilities should be displayed in release 'Vulnerabilities' tab.
> ![image](https://user-images.githubusercontent.com/85483077/123036912-feda7c80-d417-11eb-9871-8f4c387119bd.png)
> 10. Change the Verification
> 11. Reload the page and hover mouse over Verification value for 'Vulnerabilities relevance rating' history
> ![image](https://user-images.githubusercontent.com/85483077/123037000-25001c80-d418-11eb-8651-13095b3c9827.png)
>
> Note: step 7 and step 8 were swapped.


### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
