### PR TITLE
fix(ModerationRequest): Fixed Moderation Request for Project is not opening

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
@@ -934,6 +934,9 @@ public class ModerationPortlet extends FossologyAwarePortlet {
             putReleasesAndProjectIntoRequest(request, actual_project.getId(), user);
             request.setAttribute(DOCUMENT_TYPE, SW360Constants.TYPE_PROJECT);
             setAttachmentsInRequest(request, actual_project);
+            ModerationService.Iface modClient = thriftClients.makeModerationClient();
+            Integer criticalCount = modClient.getCriticalClearingRequestCount();
+            request.setAttribute(CRITICAL_CR_COUNT, criticalCount);
         } catch (TException e) {
             log.error("Error fetching project from backend!", e);
         }


### PR DESCRIPTION
> Fixed Moderation Request for Project is not opening.
>  * Optimized loading for Project/Component/Release Moderation Request Edit Page.
>  * Optimized REST API for search Project By Name, since common backend api is used.
>  * Optimized REST APIs for search Project by externalId, since common backend api is used.
>  * Optimized REST APIs "Resources using the project/release", since common backend api is used.
>  * Optimized Project/Release Details/Edit/Duplicate page to get usingProjects, since common backend api is used.
>  * Optimized merge releases which are used by some Project, since common backend api is used.

> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change? - No

Issue: 

### How To Test?
>  * Optimized loading for Project/Component/Release Moderation Request Edit Page.
>      - Create Moderation Request for Project with Linked Project, release, version (basic fields) .
>      - View/Accept/Reject Moderation Request.
>      - View Closed Moderation Request.
>  * Optimized REST API for search Project By Name, since common backend api is used.
>      - search Project By name - http://localhost:8080/resource/docs/api-guide.html#resources-projects-list-by-name
>  * Optimized REST APIs for search Project by externalId, since common backend api is used.
>      - 3.3.7. Listing by external ids - http://localhost:8080/resource/docs/api-guide.html#resources-project-get-project-by-externalids
>  * Optimized REST APIs "Resources using the project/release", since common backend api is used.
>      - 3.3.23. Resources using the project - http://localhost:8080/resource/docs/api-guide.html#resources-project-usedby-list
>      - 3.5.18. Resources using the release - http://localhost:8080/resource/docs/api-guide.html#resources-release-usedby-list
>  * Optimized Project/Release Details/Edit/Duplicate page to get usingProjects, since common backend api is used.
>      - View/Edit/Detail Page of Project/Release which is linked to some other Project i.e usedby some other project.
>  * Optimized merge releases which are used by some Project, since common backend api is used.  
>      - merge releases which are  linked to some other Project i.e usedby some other project.

> Have you implemented any additional tests?

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>