### PR TITLE
feat(ui): sort the additional data of Project/Component/Release follow alphabet order

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -690,6 +690,8 @@ public class ComponentPortlet extends FossologyAwarePortlet {
             try {
                 ComponentService.Iface client = thriftClients.makeComponentClient();
                 Component component = client.getComponentByIdForEdit(id, user);
+                Map<String, String> sortedAdditionalData = getSortedMap(component.getAdditionalData(), true);
+                component.setAdditionalData(sortedAdditionalData);
 
                 PortletUtils.setCustomFieldsEdit(request, user, component);
 
@@ -739,6 +741,8 @@ public class ComponentPortlet extends FossologyAwarePortlet {
 
             if (!isNullOrEmpty(releaseId)) {
                 release = client.getReleaseByIdForEdit(releaseId, user);
+                Map<String, String> sortedAdditionalData = getSortedMap(release.getAdditionalData(), true);
+                release.setAdditionalData(sortedAdditionalData);
                 request.setAttribute(RELEASE, release);
                 request.setAttribute(DOCUMENT_ID, releaseId);
                 setAttachmentsInRequest(request, release);
@@ -814,6 +818,8 @@ public class ComponentPortlet extends FossologyAwarePortlet {
             String emailFromRequest = LifeRayUserSession.getEmailFromRequest(request);
 
             Release release = PortletUtils.cloneRelease(emailFromRequest, client.getReleaseById(releaseId, user));
+            Map<String, String> sortedAdditionalData = getSortedMap(release.getAdditionalData(), true);
+            release.setAdditionalData(sortedAdditionalData);
 
             PortletUtils.setCustomFieldsEdit(request, user, release);
 
@@ -1290,6 +1296,8 @@ public class ComponentPortlet extends FossologyAwarePortlet {
             try {
                 ComponentService.Iface client = thriftClients.makeComponentClient();
                 Component component = client.getComponentById(id, user);
+                Map<String, String> sortedAdditionalData = getSortedMap(component.getAdditionalData(), true);
+                component.setAdditionalData(sortedAdditionalData);
 
                 PortletUtils.setCustomFieldsDisplay(request, user, component);
                 request.setAttribute(COMPONENT, component);
@@ -1357,6 +1365,8 @@ public class ComponentPortlet extends FossologyAwarePortlet {
 
             if (!isNullOrEmpty(releaseId)) {
                 release = client.getReleaseById(releaseId, user);
+                Map<String, String> sortedAdditionalData = getSortedMap(release.getAdditionalData(), true);
+                release.setAdditionalData(sortedAdditionalData);
 
                 ExternalToolProcessStep processStep = SW360Utils.getExternalToolProcessStepOfFirstProcessForTool(
                         release, ExternalTool.FOSSOLOGY, FossologyUtils.FOSSOLOGY_STEP_NAME_UPLOAD);

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -1328,6 +1328,8 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 ProjectService.Iface client = thriftClients.makeProjectClient();
                 Project project = client.getProjectById(id, user);
                 project = getWithFilledClearingStateSummary(project, user);
+                Map<String, String> sortedAdditionalData = getSortedMap(project.getAdditionalData(), true);
+                project.setAdditionalData(sortedAdditionalData);
                 request.setAttribute(PROJECT, project);
                 request.setAttribute(PARENT_PROJECT_PATH, project.getId());
                 setAttachmentsInRequest(request, project);
@@ -1945,6 +1947,8 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             try {
                 ProjectService.Iface client = thriftClients.makeProjectClient();
                 project = client.getProjectByIdForEdit(id, user);
+                Map<String, String> sortedAdditionalData = getSortedMap(project.getAdditionalData(), true);
+                project.setAdditionalData(sortedAdditionalData);
                 usingProjects = client.searchLinkingProjects(id, user);
                 allUsingProjectCount = client.getCountByProjectId(id);
             } catch (SW360Exception sw360Exp) {
@@ -2009,6 +2013,8 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 String department = user.getDepartment();
 
                 Project newProject = PortletUtils.cloneProject(emailFromRequest, department, client.getProjectById(id, user));
+                Map<String, String> sortedAdditionalData = getSortedMap(newProject.getAdditionalData(), true);
+                newProject.setAdditionalData(sortedAdditionalData);
                 setAttachmentsInRequest(request, newProject);
                 PortletUtils.setCustomFieldsEdit(request, user, newProject);
                 request.setAttribute(PROJECT, newProject);

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/mergeComponent.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/mergeComponent.jsp
@@ -220,7 +220,7 @@
             $stepElement.append(wizard.createSingleMergeLine('<liferay-ui:message key="mailing.list" />', data.componentTarget.mailinglist, data.componentSource.mailinglist));
             $stepElement.append(wizard.createSingleMergeLine('<liferay-ui:message key="description" />', data.componentTarget.description, data.componentSource.description));
             $stepElement.append(wizard.createMapMergeLine('<liferay-ui:message key="external.ids" />', data.componentTarget.externalIds, data.componentSource.externalIds));
-            $stepElement.append(wizard.createMapMergeLine('<liferay-ui:message key="additional.data" />', data.componentTarget.additionalData, data.componentSource.additionalData));
+            $stepElement.append(wizard.createMapMergeLine('<liferay-ui:message key="additional.data" />', wizard.convertObjectToSortedMap(data.componentTarget.additionalData), wizard.convertObjectToSortedMap(data.componentSource.additionalData)));
 
             $stepElement.append(wizard.createCategoryLine('<liferay-ui:message key="roles" />'));
             $stepElement.append(wizard.createSingleMergeLine('<liferay-ui:message key="component.owner" />', data.componentTarget.componentOwner, data.componentSource.componentOwner));
@@ -356,7 +356,7 @@
             $stepElement.append(wizard.createSingleDisplayLine('<liferay-ui:message key="mailing.list" />', data.componentSelection.mailinglist));
             $stepElement.append(wizard.createSingleDisplayLine('<liferay-ui:message key="description" />', data.componentSelection.description));
             $stepElement.append(wizard.createMapDisplayLine('<liferay-ui:message key="external.ids" />', data.componentSelection.externalIds));
-            $stepElement.append(wizard.createMapDisplayLine('<liferay-ui:message key="additional.data" />', data.componentSelection.additionalData));
+            $stepElement.append(wizard.createMapDisplayLine('<liferay-ui:message key="additional.data" />', wizard.convertObjectToSortedMap(data.componentSelection.additionalData)));
 
             $stepElement.append(wizard.createCategoryLine('<liferay-ui:message key="roles" />'));
             $stepElement.append(wizard.createSingleDisplayLine('<liferay-ui:message key="component.owner" />', data.componentSelection.componentOwner));

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/mergeRelease.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/mergeRelease.jsp
@@ -228,7 +228,7 @@
             $stepElement.append(wizard.createSingleMergeLine('<liferay-ui:message key="repository" />', data.releaseTarget.repository, data.releaseSource.repository, repositoryFormatter(data.displayInformation)));
             $stepElement.append(wizard.createMultiMapMergeLine('<liferay-ui:message key="additional.roles" />', data.releaseTarget.roles, data.releaseSource.roles));
             $stepElement.append(wizard.createMapMergeLine('<liferay-ui:message key="external.ids" />', data.releaseTarget.externalIds, data.releaseSource.externalIds));
-            $stepElement.append(wizard.createMapMergeLine('<liferay-ui:message key="additional.data" />', data.releaseTarget.additionalData, data.releaseSource.additionalData));
+            $stepElement.append(wizard.createMapMergeLine('<liferay-ui:message key="additional.data" />', wizard.convertObjectToSortedMap(data.releaseTarget.additionalData), wizard.convertObjectToSortedMap(data.releaseSource.additionalData)));
             
             $stepElement.append(wizard.createCategoryLine('<liferay-ui:message key="linked.releases" />'));
             $stepElement.append(wizard.createMultiMergeLine('<liferay-ui:message key="linked.releases" />', Object.keys(data.releaseTarget.releaseIdToRelationship || {}), Object.keys(data.releaseSource.releaseIdToRelationship || {}), mapFormatter(data.displayInformation, 'release')));
@@ -501,7 +501,7 @@
             $stepElement.append(wizard.createSingleDisplayLine('<liferay-ui:message key="repository" />', data.releaseSelection.repository, repositoryFormatter(displayInformation)));
             $stepElement.append(wizard.createMultiMapDisplayLine('<liferay-ui:message key="additional.roles" />', data.releaseSelection.roles));
             $stepElement.append(wizard.createMapDisplayLine('<liferay-ui:message key="external.ids" />', data.releaseSelection.externalIds));
-            $stepElement.append(wizard.createMapDisplayLine('<liferay-ui:message key="additional.data" />', data.releaseSelection.additionalData));
+            $stepElement.append(wizard.createMapDisplayLine('<liferay-ui:message key="additional.data" />', wizard.convertObjectToSortedMap(data.releaseSelection.additionalData)));
             
             $stepElement.append(wizard.createCategoryLine('<liferay-ui:message key="linked.releases" />'));
             $stepElement.append(wizard.createMultiDisplayLine('<liferay-ui:message key="linked.releases" />', Object.keys(data.releaseSelection.releaseIdToRelationship), mapFormatter(displayInformation, 'release')));

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/modules/mergeWizard.js
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/modules/mergeWizard.js
@@ -120,28 +120,37 @@ define('modules/mergeWizard', [ 'jquery', 'modules/sw360Wizard' ], function($, s
             keys = [],
             existInBoth = [];
 
-        target = target == null ? {} : target;
-        source = source == null ? {} : source;
+        if (target == null) {
+            target = new Map();
+        } else {
+            target = target instanceof Map ? target : new Map(Object.entries(target));
+        }
+        if (source == null) {
+            source = new Map();
+        } else {
+            source = source instanceof Map ? source : new Map(Object.entries(source));
+        }
         detailFormatter = detailFormatter || function(element) { return element; };
 
         result = $($.parseHTML('<fieldset id="' + normalizePropName(propName) + '" class="merge block">' +
                                '    <h4>' + propName + '</h4>' +
                                '</fieldset>'));
 
-        $.each(target, function(key, value) {
-            if (!source[key]) {
+        target.forEach((value, key) => {
+            if(!source.get(key)) {
                 let lineSrcEmpty = mergeWizard.createSingleMergeLine(key, value, '', detailFormatter);
                 $(lineSrcEmpty).attr("id", normalizePropName(propName+key));
                 result.append(lineSrcEmpty);
             } else {
-                let lineSrcNotEmpty = mergeWizard.createSingleMergeLine(key, value, source[key], detailFormatter);
+                let lineSrcNotEmpty = mergeWizard.createSingleMergeLine(key, value, source.get(key), detailFormatter);
                 $(lineSrcNotEmpty).attr("id", normalizePropName(propName+key));
                 result.append(lineSrcNotEmpty);
                 existInBoth.push(key);
             }
             keys.push(key);
         });
-        $.each(source, function(key, value) {
+
+        source.forEach((value, key) => {
             if ($.inArray(key, existInBoth) === -1) {
                 let lineNotExistInBoth = mergeWizard.createSingleMergeLine(key, '', value, detailFormatter);
                 $(lineNotExistInBoth).attr("id", normalizePropName(propName+key))
@@ -316,14 +325,18 @@ define('modules/mergeWizard', [ 'jquery', 'modules/sw360Wizard' ], function($, s
     mergeWizard.createMapDisplayLine = function createMapDisplayLine(propName, values, detailFormatter) {
         var result;
 
-        values = values == null ? {} : values;
+        if (values == null) {
+            values = new Map();
+        } else {
+            values = values instanceof Map ? values : new Map(Object.entries(values));
+        }
         detailFormatter = detailFormatter || function(element) { return element; };
 
         result = $($.parseHTML('<fieldset id="' + normalizePropName(propName) + '" class="display block">' +
                                '    <h4>' + propName + '</h4>' +
                                '</fieldset>'));
 
-        $.each(values, function(key, value) {
+        values.forEach((value, key) => {
             result.append(mergeWizard.createSingleDisplayLine(key, value, detailFormatter));
         });
 
@@ -584,6 +597,11 @@ define('modules/mergeWizard', [ 'jquery', 'modules/sw360Wizard' ], function($, s
 
         return result;
     };
+
+    mergeWizard.convertObjectToSortedMap = function convertObjectToSortedMap(obj) {
+        let unsortedMap = new Map(Object.entries(obj));
+        return new Map([...unsortedMap.entries()].sort());
+    }
 
     // private
 

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/modules/mergeWizard.js
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/modules/mergeWizard.js
@@ -137,7 +137,7 @@ define('modules/mergeWizard', [ 'jquery', 'modules/sw360Wizard' ], function($, s
                                '</fieldset>'));
 
         target.forEach((value, key) => {
-            if(!source.get(key)) {
+            if (!source.get(key)) {
                 let lineSrcEmpty = mergeWizard.createSingleMergeLine(key, value, '', detailFormatter);
                 $(lineSrcEmpty).attr("id", normalizePropName(propName+key));
                 result.append(lineSrcEmpty);

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
@@ -97,6 +97,24 @@ public class CommonUtils {
         return collection != null ? CASE_INSENSITIVE_ORDERING.immutableSortedCopy(collection) : ImmutableList.<String>of();
     }
 
+    /**
+     * Returns a sorted map containing the elements of the given unsorted map.
+     * The map is sorted follow the order.
+     */
+    public static Map<String, String> getSortedMap(Map<String, String> unsortedMap, boolean isAscending) {
+        if(unsortedMap == null && unsortedMap.size() <= 1) {
+            return unsortedMap;
+        }
+        Map<String, String> sortedMap;
+        if(isAscending) {
+            sortedMap = new TreeMap<String, String>(unsortedMap);
+        } else {
+            sortedMap = new TreeMap<String, String>(Collections.reverseOrder());
+            sortedMap.putAll(unsortedMap);
+        }
+        return sortedMap;
+    }
+
     public static String joinStrings(Iterable<String> strings) {
         return strings != null ? COMMA_JOINER.join(strings) : "";
     }

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/CommonUtils.java
@@ -102,11 +102,11 @@ public class CommonUtils {
      * The map is sorted follow the order.
      */
     public static Map<String, String> getSortedMap(Map<String, String> unsortedMap, boolean isAscending) {
-        if(unsortedMap == null && unsortedMap.size() <= 1) {
+        if (unsortedMap == null && unsortedMap.size() <= 1) {
             return unsortedMap;
         }
         Map<String, String> sortedMap;
-        if(isAscending) {
+        if (isAscending) {
             sortedMap = new TreeMap<String, String>(unsortedMap);
         } else {
             sortedMap = new TreeMap<String, String>(Collections.reverseOrder());

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -42,6 +42,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.eclipse.sw360.datahandler.common.CommonUtils.getSortedMap;
+
 @Service
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class Sw360ComponentService implements AwareOfRestServices<Component> {
@@ -62,7 +64,10 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
     public Release getReleaseById(String id, User sw360User) {
         try {
             ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-            return sw360ComponentClient.getReleaseById(id, sw360User);
+            Release release = sw360ComponentClient.getReleaseById(id, sw360User);
+            Map<String, String> sortedAdditionalData = getSortedMap(release.getAdditionalData(), true);
+            release.setAdditionalData(sortedAdditionalData);
+            return release;
         } catch (TException e) {
             throw new RuntimeException(e);
         }
@@ -70,7 +75,10 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
 
     public Component getComponentForUserById(String componentId, User sw360User) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-        return sw360ComponentClient.getComponentById(componentId, sw360User);
+        Component component = sw360ComponentClient.getComponentById(componentId, sw360User);
+        Map<String, String> sortedAdditionalData = getSortedMap(component.getAdditionalData(), true);
+        component.setAdditionalData(sortedAdditionalData);
+        return component;
     }
 
     public Set<Project> getProjectsByComponentId(String componentId, User sw360User) throws TException {
@@ -105,6 +113,8 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
         if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.SUCCESS) {
             component.setId(documentRequestSummary.getId());
             component.setCreatedBy(sw360User.getEmail());
+            Map<String, String> sortedAdditionalData = getSortedMap(component.getAdditionalData(), true);
+            component.setAdditionalData(sortedAdditionalData);
             return component;
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.DUPLICATE) {
             throw new DataIntegrityViolationException("sw360 component with name '" + component.getName() + "' already exists.");

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -90,6 +90,7 @@ import java.util.stream.Collectors;
 import javax.annotation.PreDestroy;
 
 import static org.eclipse.sw360.datahandler.common.CommonUtils.isNullEmptyOrWhitespace;
+import static org.eclipse.sw360.datahandler.common.CommonUtils.getSortedMap;
 
 @Service
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -113,7 +114,10 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
     public Project getProjectForUserById(String projectId, User sw360User) throws TException {
         ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
         try {
-            return sw360ProjectClient.getProjectById(projectId, sw360User);
+            Project project = sw360ProjectClient.getProjectById(projectId, sw360User);
+            Map<String, String> sortedAdditionalData = getSortedMap(project.getAdditionalData(), true);
+            project.setAdditionalData(sortedAdditionalData);
+            return project;
         } catch (SW360Exception sw360Exp) {
             if (sw360Exp.getErrorCode() == 404) {
                 throw new ResourceNotFoundException("Requested Project Not Found");
@@ -150,6 +154,8 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
         if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.SUCCESS) {
             project.setId(documentRequestSummary.getId());
             project.setCreatedBy(sw360User.getEmail());
+            Map<String, String> sortedAdditionalData = getSortedMap(project.getAdditionalData(), true);
+            project.setAdditionalData(sortedAdditionalData);
             return project;
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.DUPLICATE) {
             throw new DataIntegrityViolationException("sw360 project with name '" + project.getName() + "' already exists.");

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -101,6 +101,8 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         Release releaseById = null;
         try {
             releaseById = sw360ComponentClient.getReleaseById(releaseId, sw360User);
+            Map<String, String> sortedAdditionalData = CommonUtils.getSortedMap(releaseById.getAdditionalData(), true);
+            releaseById.setAdditionalData(sortedAdditionalData);
         } catch (SW360Exception sw360Exp) {
             if (sw360Exp.getErrorCode() == 404) {
                 throw new ResourceNotFoundException("Release does not exists! id=" + releaseId);
@@ -130,6 +132,8 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         AddDocumentRequestSummary documentRequestSummary = sw360ComponentClient.addRelease(release, sw360User);
         if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.SUCCESS) {
             release.setId(documentRequestSummary.getId());
+            Map<String, String> sortedAdditionalData = CommonUtils.getSortedMap(release.getAdditionalData(), true);
+            release.setAdditionalData(sortedAdditionalData);
             return release;
         } else if (documentRequestSummary.getRequestStatus() == AddDocumentRequestStatus.DUPLICATE) {
             throw new DataIntegrityViolationException("sw360 release with name '" + SW360Utils.printName(release) + "' already exists.");


### PR DESCRIPTION
Signed-off-by: Tran Vu Quan <quan1.tranvu@toshiba.co.jp>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> * Issue: Additional data of Project/Component/Release are sorted by unclear algorithm
> * Solution: Sort the additional data of Project/Component/Release follow alphabet order (based on key values)

Issue: #1096 

### How To Test?
> 1. Project:
> - Add new or edit existing Project, change the Additional data
> ![image](https://user-images.githubusercontent.com/85483077/124575711-d326b000-de75-11eb-964b-803ba71279d0.png)
> - After finish adding/editing, Additional data is sorted follow alphabet order (based on key values)
> ![image](https://user-images.githubusercontent.com/85483077/124575952-0cf7b680-de76-11eb-98de-97ac95ddeab9.png)
> 2. Component, Release: steps are similar with Project, Addition data should be sorted follow alphabet order
> ![image](https://user-images.githubusercontent.com/85483077/124576194-47615380-de76-11eb-9ec0-4a0d9fc555f0.png)
> ![image](https://user-images.githubusercontent.com/85483077/124576326-64962200-de76-11eb-8d02-f9a67c89d818.png)
 

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
