### PR TITLE
fix(RequestUi):BU & ProjectName not loading for Closed CR table

### DIFF
--- a/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -279,6 +279,7 @@ public class ProjectHandler implements ProjectService.Iface {
 
     @Override
     public List<Project> fillClearingStateSummary(List<Project> projects, User user) throws TException {
+        assertUser(user);
         return handler.fillClearingStateSummary(projects, user);
     }
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortletUtils.java
@@ -116,7 +116,7 @@ public class ModerationPortletUtils {
                     String status = request.getParameter(ClearingRequest._Fields.CLEARING_STATE.toString());
                     String priority = request.getParameter(ClearingRequest._Fields.PRIORITY.toString());
                     if (CommonUtils.isNotNullEmptyOrWhitespace(agreedDate) && !agreedDate.equals(clearingRequest.getAgreedClearingDate())
-                            && !SW360Utils.isValidDate(agreedDate, DateTimeFormatter.ISO_LOCAL_DATE, 0)) {
+                            && !SW360Utils.isValidDate(agreedDate, DateTimeFormatter.ISO_LOCAL_DATE, null)) {
                         log.warn("Invalid agreed clearing date: " + agreedDate + " is entered, by user: "+ user.getEmail());
                         return requestSummary.setMessage("Invalid agreed clearing date");
                     }
@@ -149,7 +149,7 @@ public class ModerationPortletUtils {
             String priority = (criticalCount > 1) ? "" : request.getParameter(ClearingRequest._Fields.PRIORITY.toString());
             Integer dateLimit = ModerationPortletUtils.loadPreferredClearingDateLimit(request, user);
             dateLimit = (CommonUtils.isNotNullEmptyOrWhitespace(priority) && criticalCount < 2) ? 0 : (dateLimit < 1) ? 7 : dateLimit;
-            if (!SW360Utils.isValidDate(preferredDate, DateTimeFormatter.ISO_LOCAL_DATE, dateLimit)) {
+            if (!SW360Utils.isValidDate(preferredDate, DateTimeFormatter.ISO_LOCAL_DATE, Long.valueOf(dateLimit))) {
                 log.warn("Invalid requested clearing date: " + preferredDate + " is entered, by user: "+ user.getEmail());
                 return requestSummary.setMessage("Invalid requested clearing date");
             }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -348,7 +348,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             ProjectService.Iface client = thriftClients.makeProjectClient();
             Integer dateLimit = ModerationPortletUtils.loadPreferredClearingDateLimit(request, user);
             dateLimit = (ClearingRequestPriority.CRITICAL.equals(clearingRequest.getPriority()) && criticalCount < 2) ? 0 : (dateLimit < 1) ? 7 : dateLimit;
-            if (!SW360Utils.isValidDate(clearingRequest.getRequestedClearingDate(), DateTimeFormatter.ISO_LOCAL_DATE, dateLimit)) {
+            if (!SW360Utils.isValidDate(clearingRequest.getRequestedClearingDate(), DateTimeFormatter.ISO_LOCAL_DATE, Long.valueOf(dateLimit))) {
                 log.warn("Invalid requested clearing date: " + clearingRequest.getRequestedClearingDate() + " is entered, by user: "+ user.getEmail());
                 requestSummary = new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.FAILURE).setMessage("Invalid requested clearing date");
             } else {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/clearing/clearingRequest.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/clearing/clearingRequest.jsp
@@ -437,7 +437,7 @@ require(['jquery', 'modules/dialog', 'modules/validation', 'modules/button', 'br
                 return;
             }
             $emailId.removeClass("is-invalid");
-            if ($acDate.val() && !validation.isValidDate($acDate.val(), 0)) {
+            if ($acDate.val() && !validation.isValidDate($acDate.val())) {
                 $acDate.addClass("is-invalid");
                 return;                
             }

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/view.jsp
@@ -715,7 +715,7 @@ AUI().use('liferay-portlet-url', function () {
                     crIds.push(value.DT_RowId);
                 }
             }
-            if (projectIds.length > 25) {
+            if (isOpenCrTable && projectIds.length > 25) {
                 let i, j, temp, chunk = 25;
                 setTimeout(function() {
                     for (i = 0, j = projectIds.length; i < j; i += chunk) {
@@ -729,13 +729,13 @@ AUI().use('liferay-portlet-url', function () {
         }
 
         function loadProjectDetailsAjaxCall(tableId, tableData, projectIds, isOpenCrTable, crIds) {
-            console.log("triggering the backend call: "+ isOpenCrTable);
             $.ajax({
                 type: 'POST',
                 url: '<%=loadProjectDetailsAjaxURL%>',
                 cache: false,
                 data: {
-                    "<portlet:namespace/>projectIds": projectIds
+                    "<portlet:namespace/>projectIds": projectIds,
+                    "<portlet:namespace/>isOpenCr": isOpenCrTable
                 },
                 success: function (response) {
                     function d(v) { return v == undefined ? 0 : v; }
@@ -784,14 +784,14 @@ AUI().use('liferay-portlet-url', function () {
                             projCell = table.cell('#'+crId, projectColIndex),
                             compCell = table.cell('#'+crId, componentColIndex),
                             progressCell = table.cell('#'+crId, progressColIndex),
-                            projName = response[i].name,
-                            clearing = response[i].clearing,
-                            totalCount = d(clearing.newRelease) + d(clearing.underClearing) + d(clearing.sentToClearingTool) + d(clearing.reportAvailable) + d(clearing.approved),
-                            approvedCount = d(clearing.reportAvailable) + d(clearing.approved);
+                            projName = response[i].name;
 
                         buCell.data(response[i].bu);
                         projCell.data(renderLinkToProject(response[i].id, projName));
                         if (isOpenCrTable) {
+                            let clearing = response[i].clearing,
+                                totalCount = d(clearing.newRelease) + d(clearing.underClearing) + d(clearing.sentToClearingTool) + d(clearing.reportAvailable) + d(clearing.approved),
+                                approvedCount = d(clearing.reportAvailable) + d(clearing.approved);
                             compCell.data(totalCount - approvedCount);
                             if (!totalCount || $(table.cell('#'+crId, 4).node()).find('span.sw360-tt-ClearingRequestState-NEW').text()) {
                                 progressCell.data('<liferay-ui:message key="not.available" />');

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -235,12 +235,15 @@ public class SW360Utils {
         return text.replaceAll("(?m)^#.*(?:\r?\n)?", ""); // ignore comments in template file
     }
 
-    public static boolean isValidDate(String date, DateTimeFormatter format, long greaterThanDays) {
+    public static boolean isValidDate(String date, DateTimeFormatter format, Long greaterThanDays) {
         try {
             LocalDate selectedDate = LocalDate.parse(date, format);
             LocalDate currentDate = LocalDate.now();
             long difference = ChronoUnit.DAYS.between(currentDate, selectedDate);
-            return difference >= greaterThanDays ? true : false;
+            if (null != greaterThanDays) {
+                return difference >= greaterThanDays;
+            }
+            return true;
         } catch (DateTimeParseException e) {
             return false;
         }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

> Which issue is this pull request belonging to and how is it solving it?
- #1292 

> Did you add or update any new dependencies that are required for your change?
- No.

Issue: #1292 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?

> How should these changes be tested by the reviewer?

- `Project name`, and `business unit` should load for closed clearing request tables, If there are more CR in closed state.
- `Clearing Team` should be able to update the clearing request even if `Agreed Clearing Date` is passed.

> Have you implemented any additional tests?

- No.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: Abdul Kapti <abdul.kapti@siemens-healthineers.com>
