### PR TITLE
fix(ui): fix visibility of the group

### DIFF
--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissions.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissions.java
@@ -67,7 +67,7 @@ public class ProjectPermissions extends DocumentPermissions<Project> {
     public static boolean isUserInBU(Project document, String bu) {
         final String buFromOrganisation = getBUFromOrganisation(bu);
         return !isNullOrEmpty(bu) && !isNullOrEmpty(buFromOrganisation) && !isNullOrEmpty(document.getBusinessUnit())
-                && document.getBusinessUnit().startsWith(buFromOrganisation);
+                && document.getBusinessUnit().equals(buFromOrganisation);
     }
 
     public static boolean userIsEquivalentToModeratorInProject(Project input, String user) {


### PR DESCRIPTION
Signed-off-by: Shi Qiu <shi1.qiu@toshiba.co.jp>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Issue: 
#1281 

### Suggest Reviewer

### How To Test?

Create two projects named as "Department" and "Department1", the member of each department can not see the project which is not themselves'.

Refer to this commit : https://github.com/eclipse/sw360/issues/1281#issue-928930066

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
