### PR TITLE
fix(script): Update CouchDB version and add password and user

### DIFF
--- a/scripts/startCouchdbForTests.sh
+++ b/scripts/startCouchdbForTests.sh
@@ -20,11 +20,13 @@ if [[ ! "$(docker ps -q -f name=$NAME)" ]]; then
 
     echo "Test container is not running, starting it ..."
     docker run \
+	   -e COUCHDB_USER=admin \
+	   -e COUCHDB_PASSWORD=password \
            --rm \
            -p 5984:5984 \
            -d \
            --name "$NAME" \
-           couchdb:1
+           couchdb:3.1
     echo "Test container is started and listening on 5984."
 else
     echo "Test container is running, shutting it down ..."


### PR DESCRIPTION
Signed-off-by: Kouki Hama <kouki1.hama@toshiba.co.jp>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue:  #1287 

Update couchdb docker image from version 1 to version 3.1 with password

I used the same password settings and couchdb's vesrion as here.

https://github.com/eclipse/sw360/blob/1bda34fa3625e7cdc66fc0875384adc01c792b1a/.github/workflows/githubactions.yml#L39

https://github.com/eclipse/sw360/blob/1bda34fa3625e7cdc66fc0875384adc01c792b1a/.github/workflows/githubactions.yml#L22-L23

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

Start script
/sw360/scripts/startCouchdbForTests.sh

Check  by access CouchDB (http://127.0.0.1:5984/_utils) on GUI

![image](https://user-images.githubusercontent.com/39894802/125710224-b3fe969d-f254-4950-8e08-70b338cd4ba7.png)

Then login user:  admin, password : password

![image](https://user-images.githubusercontent.com/39894802/125710386-7990d96d-96e9-49e2-b384-b507490b766d.png)

Check by Curl commnd

>$ curl http://127.0.0.1:5984
{"couchdb":"Welcome","version":"3.1.1","git_sha":"ce596c65d","uuid":"d170b762050
6bf49504c9ef702676910","features":["access-ready","partitioned","pluggable-stora
ge-engines","reshard","scheduler"],"vendor":{"name":"The Apache Software Foundat
ion"}}


### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
