### PR TITLE
feat(rest): Add Rest API for linking release to release

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/releases.adoc
+++ b/rest/resource-server/src/docs/asciidoc/releases.adoc
@@ -329,6 +329,22 @@ include::{snippets}/should_document_delete_releases/curl-request.adoc[]
 ===== Example response
 include::{snippets}/should_document_delete_releases/http-response.adoc[]
 
+
+[[resources-release-link]]
+==== Link release to release
+
+A `POST` request is used to link releases to the release.
+
+===== Request structure
+Pass a map of Release Relationship to usage to be linked as request body.
+
+===== Example request
+include::{snippets}/should_document_link_releases_to_release/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_link_releases_to_release/http-response.adoc[]
+
+
 [[resources-release-usedby-list]]
 ==== Resources using the release
 

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -96,6 +96,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
     private Attachment attachment;
     Component component;
     private Project project;
+    private Map<String, ReleaseRelationship> releaseIdToRelationship1;
 
     private final String releaseId = "3765276512";
     private final String attachmentSha1 = "da373e491d3863477568896089ee9457bc316783";
@@ -318,6 +319,8 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         release3.setExternalToolProcesses(ImmutableSet.of(fossologyProcess));
         when(releaseServiceMock.getReleaseForUserById(eq(release3.getId()), anyObject())).thenReturn(release3);
         when(releaseServiceMock.getExternalToolProcess(release3)).thenReturn(fossologyProcess);
+
+        releaseIdToRelationship1 = ImmutableMap.of(release2.getId(), ReleaseRelationship.DYNAMICALLY_LINKED, release3.getId(), ReleaseRelationship.CONTAINED);
     }
 
     @Test
@@ -703,6 +706,18 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                 .accept(MediaTypes.HAL_JSON))
                 .andExpect(status().isOk())
                 .andDo(documentReleaseProperties());
+    }
+
+    @Test
+    public void should_document_link_releases_to_release() throws Exception {
+
+        String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
+        mockMvc.perform(post("/api/releases/" + release.getId() + "/releases")
+                .contentType(MediaTypes.HAL_JSON)
+                .content(this.objectMapper.writeValueAsString(releaseIdToRelationship1))
+                .header("Authorization", "Bearer" + accessToken)
+                .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isCreated());
     }
 
     private RestDocumentationResultHandler documentReleaseProperties() {


### PR DESCRIPTION
Signed-off-by: Tran Vu Quan <quan1.tranvu@toshiba.co.jp>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Implement Rest API for linking release to release

Issue: #863 

### How To Test?
> Refer to:
> Link Release to Release API doc: http://localhost/resource/docs/api-guide.html#resources-release-link

> Have you implemented any additional tests? - Yes

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
