### PR TITLE
fix(ClearingUI): ClearingExpert can't edit the CR

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
@@ -481,22 +481,19 @@ public class ModerationPortlet extends FossologyAwarePortlet {
             if (CommonUtils.isNotNullEmptyOrWhitespace(clearingRequest.getProjectId()) ) {
                 ProjectService.Iface projectClient = thriftClients.makeProjectClient();
                 Project project = projectClient.getProjectById(clearingRequest.getProjectId(), UserCacheHolder.getUserFromRequest(request));
-                String babl = CommonUtils.nullToEmptyMap(project.getAdditionalData()).get("BA BL");
-                if (CommonUtils.isNotNullEmptyOrWhitespace(babl)) {
-                    project.setBusinessUnit(babl);
-                }
-                request.setAttribute(PROJECT, project);
-
                 DocumentPermissions<Project> projectPermission = makePermission(project, user);
                 ImmutableSet<UserGroup> clearingExpertRoles = ImmutableSet.of(UserGroup.CLEARING_EXPERT);
                 ImmutableSet<UserGroup> adminRoles = ImmutableSet.of(UserGroup.ADMIN, UserGroup.SW360_ADMIN);
-
                 request.setAttribute(IS_CLEARING_EXPERT,
                         isPrimaryRoleOfUserAtLeastClearingExpert
                                 || projectPermission.isUserOfOwnGroupHasRole(clearingExpertRoles, UserGroup.CLEARING_EXPERT)
                                 || projectPermission.isUserOfOwnGroupHasRole(adminRoles, UserGroup.ADMIN));
                 request.setAttribute(WRITE_ACCESS_USER, projectPermission.isActionAllowed(RequestedAction.WRITE));
-
+                String babl = CommonUtils.nullToEmptyMap(project.getAdditionalData()).get("BA BL");
+                if (CommonUtils.isNotNullEmptyOrWhitespace(babl)) {
+                    project.setBusinessUnit(babl);
+                }
+                request.setAttribute(PROJECT, project);
                 List<Project> projects = getWithFilledClearingStateSummary(projectClient, Lists.newArrayList(project), user);
                 Project projWithCsSummary = projects.get(0);
                 if (null != projWithCsSummary && null != projWithCsSummary.getReleaseClearingStateSummary()) {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/clearing/clearingRequest.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/clearing/clearingRequest.jsp
@@ -89,7 +89,7 @@
                     <button type="button" id="reOpenRequest" class="btn btn-primary"><liferay-ui:message key="reopen.request" /></button>
                 </div>
             </core_rt:if>
-            <core_rt:if test="${isEditable}">
+            <core_rt:if test="${isEditableForClearingTeam or isEditableForRequestingUser}">
 	           <div class="btn-group" role="group">
 	               <button type="button" id="formSubmit" class="btn btn-primary"><liferay-ui:message key="update.request" /></button>
 	           </div>


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? 

This PR fixes the issue #1314 

> * Did you add or update any new dependencies that are required for your change?
No.

Issue: #1314 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?

* Login with user with role `user` and group as `Department` and then create a project `P1`.
* Set the `Additional Data` field with Key as `BA BL` and value to `Siemens` for the Project `P1`.
* Create the `clearing request` for project `P1`, while creating the CR assign [clearing team] it to user from another group.
* Login using the user with role `clearing expert` and group as `Department`, now the user should be able to edit the CR for project `P1`.

> Have you implemented any additional tests?

* No

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: Abdul Kapti <abdul.kapti@siemens-healthineers.com>
