### PR TITLE
fix(Rest):make SW360 REST API Get Releases by Name Case-Insensitive.

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -127,7 +127,7 @@ public class ReleaseController implements ResourceProcessor<RepositoryLinksResou
         }
 
         sw360Releases = sw360Releases.stream()
-                .filter(release -> name == null || name.isEmpty() || release.getName().equals(name))
+                .filter(release -> name == null || name.isEmpty() || release.getName().equalsIgnoreCase(name))
                 .collect(Collectors.toList());
 
         PaginationResult<Release> paginationResult = restControllerHelper.createPaginationResult(request, pageable, sw360Releases, SW360Constants.TYPE_RELEASE);


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Make the REST API getReleaseByName case insensitive, to fetch all the releases for a component.
> * Which issue is this pull request belonging to and how is it solving it? (*#1327*)
> * Did you add or update any new dependencies that are required for your change? NA

Issue: #1327

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
    

- http://localhost:8080/resource/api/releases?name=ECHARTS

> Have you implemented any additional tests? No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: ravi110336 <kumar.ravindra@siemens.com>