### PR TITLE
fix(MyProjectErrorMessageUI):update the error message in UI for the project which is not accessible.

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
@@ -55,7 +55,7 @@ public class ErrorMessages {
     public static final String REST_API_TOKEN_NAME_DUPLICATE = "Token name already exists.";
     public static final String REST_API_EXPIRE_DATE_NOT_VALID = "Your selected token expiration date is not valid.";
     public static final String ERROR_PROJECT_OR_DEPENDENCIES_NOT_FOUND = "Error fetching project. Project or its dependencies are not found.";
-    public static final String ERROR_PROJECT_OR_LINKEDPROJECT_NOT_ACCESSIBLE = "Error fetching project. Project or its Linked Projects are not accessible.";
+    public static final String ERROR_PROJECT_OR_LINKEDPROJECT_NOT_ACCESSIBLE = "Project or its Linked Projects are restricted and / or not accessible.";
     public static final String ERROR_GETTING_CLEARING_REQUEST = "Error fetching clearing request from backend.";
     public static final String LICENSE_TYPE_DUPLICATE = "This license type already exists.";
     public static final String LICENSE_TYPE_ACCESS_DENIED = "User does not have the permission to add license type.";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -2860,7 +2860,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 } catch (SW360Exception sw360Exp) {
                     if (sw360Exp.getErrorCode() == 403) {
                         jsonObject = buildResponse(srcProject, project,
-                                "Error fetching project. Project or its Linked Projects are not accessible.", false,
+                                "Project or its Linked Projects are restricted and / or not accessible.", false,
                                 true);
                     } else if (sw360Exp.getErrorCode() == 404) {
                         jsonObject = buildResponse(srcProject, project,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -630,7 +630,7 @@ public class RestControllerHelper<T> {
             } else if (sw360Exp.getErrorCode() == 403) {
                 if (element instanceof Project) {
                     throw new AccessDeniedException(
-                            "Error fetching project. Either Project or its Linked Projects are not accessible");
+                            "Project or its Linked Projects are restricted and / or not accessible");
                 }
             } else {
                 throw sw360Exp;

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -123,7 +123,7 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
                 throw new ResourceNotFoundException("Requested Project Not Found");
             } else if (sw360Exp.getErrorCode() == 403) {
                 throw new AccessDeniedException(
-                        "Error fetching project. Either Project or its Linked Projects are not accessible");
+                        "Project or its Linked Projects are restricted and / or not accessible");
             } else {
                 throw sw360Exp;
             }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

>  Rename the error message from "Error:Error fetching project. Project or its Linked Projects are not accessible. " to "Error:Project or its Linked Projects are restricted and / or not accessible."
> * Which issue is this pull request belonging to and how is it solving it? (*#1329*)
> * Did you add or update any new dependencies that are required for your change? No

Issue: #1329 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?

One way to test this.
- User 1 creates a project.
- User 2 link this project to his own project.
- User 1 update the project for e.g. User 1 change the project Visibility to private.
- Now User 2 tries to access his project, it throws the new error message "Error: Project or its Linked Projects are restricted and / or not accessible"

> Have you implemented any additional tests? No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: ravi110336 <kumar.ravindra@siemens.com>