### PR TITLE
feat(LoginHook):Login Hook for the user if Organisation/Department is null or empty in Liferay/CouchDB.

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -623,6 +623,9 @@ public class PortalConstants {
     public static final String PREDEFINED_TAGS;
     public static final boolean SSO_LOGIN_ENABLED;
 
+    // Default Department
+    public static final String SW360 = "SW360";
+
     static {
         Properties props = CommonUtils.loadProperties(PortalConstants.class, PROPERTIES_FILE_PATH);
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/UserUtils.java
@@ -269,12 +269,19 @@ public class UserUtils {
     }
 
     public static String getDepartment(User user) {
-        String department = "";
+        String department = null;
+        Organization organization = null;
+        final OrganizationHelper orgHelper = new OrganizationHelper();
         try {
             List<Organization> organizations = user.getOrganizations();
             if (!organizations.isEmpty()) {
-                Organization organization = organizations.get(0);
+                organization = organizations.get(0);
                 department = organization.getName();
+            } else {
+                department = PortalConstants.SW360;
+                long companyId = user.getCompanyId();
+                organization = orgHelper.addOrGetOrganization(department, companyId);
+                orgHelper.reassignUserToOrganizationIfNecessary(user, organization);
             }
         } catch (PortalException | SystemException e) {
             log.error("Error getting department", e);

--- a/scripts/docker-config/etc_sw360/sw360.properties
+++ b/scripts/docker-config/etc_sw360/sw360.properties
@@ -10,4 +10,4 @@
 
 rest.apitoken.generator.enable = true
 custom.welcome.page.guideline = true
-sw360.liferay.company.id=20098
+sw360.liferay.company.id=20101


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Created a login hook for the sw360 user for the first time login, from the UI as well as from the REST API. If the Organization value is null or empty in CouchDB or in Liferay, Then it assign the default organization value as "SW360".

_From SW360 UI:_

- The login hook to update the organizations detail if it is empty in Liferay then, during the first login from the UI, it will update the Liferay organization to the default value as "SW360" and also it updates the couchdb department column.

_From the Rest API:_

- From the rest endpoints during the user authentication if the department is null/empty in couchdb then it updates the department column in couchdb with the default value as "SW360".

> * Which issue is this pull request belonging to and how is it solving it? (*#1361*)
> * Did you add or update any new dependencies that are required for your change?

Issue: closes #1361 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?

-    Login to SW360 from the UI or from the RestAPI with the Token value.
-    If the Organization value in Liferay or Department value is null/empty in Liferay or in CouchDB, Then it set the default value as SW360.

![liferayUser](https://user-images.githubusercontent.com/56516845/130567252-6321cb96-bfd6-4660-838d-5e4157c35c7e.JPG)
![couchdb](https://user-images.githubusercontent.com/56516845/130567271-21a599e8-c0a0-4cf6-b6d2-86661dcd6a66.JPG)

> Have you implemented any additional tests? No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: ravi110336 <kumar.ravindra@siemens.com>