### PR TITLE
fix(rest): Added new parameter luceneSearch to Get Project List Api, to get project list based on lucene search

### DIFF
--- a/rest/resource-server/src/docs/asciidoc/projects.adoc
+++ b/rest/resource-server/src/docs/asciidoc/projects.adoc
@@ -55,6 +55,25 @@ include::{snippets}/should_document_get_projects_with_all_details/http-response.
 ===== Links
 include::{snippets}/should_document_get_projects_with_all_details/links.adoc[]
 
+[[resources-projects-list-by-lucene-search]]
+==== Listing by lucene search
+
+A `GET` request will list all of the service's projects by lucene search.
+
+===== Request parameter
+include::{snippets}/should_document_get_projects_by_lucene_search/request-parameters.adoc[]
+
+===== Response structure
+include::{snippets}/should_document_get_projects_by_lucene_search/response-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_get_projects_by_lucene_search/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_get_projects_by_lucene_search/http-response.adoc[]
+
+===== Links
+include::{snippets}/should_document_get_projects_by_lucene_search/links.adoc[]
 
 [[resources-projects-list-by-name]]
 ==== Listing by name

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -379,4 +379,9 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             releaseExecutor.shutdownNow();
         }
     }
+
+    public List<Project> refineSearch(Map<String, Set<String>> filterMap, User sw360User) throws TException {
+        ProjectService.Iface sw360ProjectClient = getThriftProjectClient();
+        return sw360ProjectClient.refineSearch(null, filterMap, sw360User);
+    }
 }


### PR DESCRIPTION
> Added new parameter luceneSearch to Get Project List Api, to get project list based on lucene search.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change? - No

Issue: 

### How To Test?
> Refer Rest Documentation - `3.3.3. Listing by lucene search` - http://localhost:8080/resource/docs/api-guide.html#resources-projects-list-by-lucene-search
  ```
    curl 'https://sw360.org/api/projects? 
    name=Test&type=PRODUCT&group=sw360+AR&tag=project+test+tag+1&luceneSearch=true' -i -X GET \
    -H 'Authorization: Bearer ******************'
   ```
> Pass parameters with different combination like name, group, tag, type
>  - Verify output should be same as in UI Project Listing Page with Advanced Search
![image](https://user-images.githubusercontent.com/56534710/132000432-a3e9f9fa-0877-4e03-a449-af143f861580.png)

> Have you implemented any additional tests? - No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>
