### PR TITLE
fix(UI):Component details are not shown for the Security Admin Role.

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -1537,7 +1537,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
         Set<UserGroup> allSecRoles = !CommonUtils.isNullOrEmptyMap(userFromRequest.getSecondaryDepartmentsAndRoles())
                 ? userFromRequest.getSecondaryDepartmentsAndRoles().entrySet().stream().flatMap(entry -> entry.getValue().stream()).collect(Collectors.toSet())
                 : new HashSet<UserGroup>();
-        if (PermissionUtils.isAdmin(userFromRequest) || PermissionUtils.isAdminBySecondaryRoles(allSecRoles)) {
+        if (PermissionUtils.isAdmin(userFromRequest) || PermissionUtils.isAdminBySecondaryRoles(allSecRoles) || PermissionUtils.isSecurityAdmin(userFromRequest) || PermissionUtils.isSecurityAdminBySecondaryRoles(allSecRoles)) {
             long numberOfIncorrectVuls = vuls.stream()
                     .filter(v -> VerificationState.INCORRECT.equals(getVerificationState(v)))
                     .map(VulnerabilityDTO::getExternalId)


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Component details not shown for the Security Admin Role.
> * Which issue is this pull request belonging to and how is it solving it? (*#1368*)
> * Did you add or update any new dependencies that are required for your change?

Issue: closes #1368 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
 
- Select the Site Role for the sw360 user as Security Admin.
- Open Components link in the UI.
- Open a component details.

![image](https://user-images.githubusercontent.com/56516845/132221591-b30fc6b5-4c1b-49c4-8d2e-4128b6b2de35.png)
![image](https://user-images.githubusercontent.com/56516845/132221833-7184adb4-5ab2-4af4-b87e-581e5ea85446.png)

   
> Have you implemented any additional tests? No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: ravi110336 <kumar.ravindra@siemens.com>
