### PR TITLE
feat(UI): import OSADL obligation information and update screen of Ad…

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ObligationElementSearchHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ObligationElementSearchHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright TOSHIBA CORPORATION, 2021. Part of the SW360 Portal Project.
+ * Copyright Toshiba Software Development (Vietnam) Co., Ltd., 2021. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.datahandler.db;
+
+import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.eclipse.sw360.datahandler.couchdb.lucene.LuceneAwareDatabaseConnector;
+import org.eclipse.sw360.datahandler.couchdb.lucene.LuceneSearchView;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationElement;
+import org.ektorp.http.HttpClient;
+
+import com.cloudant.client.api.CloudantClient;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.eclipse.sw360.datahandler.couchdb.lucene.LuceneAwareDatabaseConnector.prepareWildcardQuery;
+
+public class ObligationElementSearchHandler {
+
+    private static final LuceneSearchView luceneSearchView = new LuceneSearchView("lucene", "obligationelements",
+        "function(doc) {" +
+        "  if(doc.type == 'obligationElement') { " +
+        "      var ret = new Document();" +
+        "      ret.add(doc.langElement);  " +
+        "      ret.add(doc.action);  " +
+        "      ret.add(doc.object);  " +
+        "      return ret;" +
+        "  }" +
+        "}");
+
+    private final LuceneAwareDatabaseConnector connector;
+
+    public ObligationElementSearchHandler(Supplier<HttpClient> httpClient, Supplier<CloudantClient> cCLient, String dbName) throws IOException {
+        // Creates the database connector and adds the lucene search view
+        connector = new LuceneAwareDatabaseConnector(httpClient, cCLient, dbName);
+        connector.addView(luceneSearchView);
+        connector.setResultLimit(DatabaseSettings.LUCENE_SEARCH_LIMIT);
+    }
+
+    public List<ObligationElement> search(String searchText) {
+        return connector.searchView(ObligationElement.class, luceneSearchView, prepareWildcardQuery(searchText));
+    }
+
+}

--- a/backend/src/src-licenses/pom.xml
+++ b/backend/src/src-licenses/pom.xml
@@ -23,6 +23,10 @@
     <packaging>jar</packaging>
     <name>src-licenses</name>
         
+    <properties>
+        <liferay.portal.kernel.version>8.1.0</liferay.portal.kernel.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.spdx</groupId>
@@ -36,6 +40,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.liferay.portal</groupId>
+            <artifactId>com.liferay.portal.kernel</artifactId>
+            <version>${liferay.portal.kernel.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/LicenseServlet.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/LicenseServlet.java
@@ -14,6 +14,7 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.eclipse.sw360.projects.Sw360ThriftServlet;
 
 import java.net.MalformedURLException;
+import java.io.IOException;
 
 /**
  * Thrift Servlet instantiation
@@ -23,7 +24,7 @@ import java.net.MalformedURLException;
  */
 public class LicenseServlet extends Sw360ThriftServlet {
 
-    public LicenseServlet() throws MalformedURLException {
+    public LicenseServlet() throws MalformedURLException, IOException {
         // Create a service processor using the provided handler
         super(new LicenseService.Processor<>(new LicenseHandler()), new TCompactProtocol.Factory());
     }

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/ObligationElementRepository.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/ObligationElementRepository.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright TOSHIBA CORPORATION, 2021. Part of the SW360 Portal Project.
+ * Copyright Toshiba Software Development (Vietnam) Co., Ltd., 2021. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.licenses.db;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.*;
+
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseRepositoryCloudantClient;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationElement;
+
+import com.cloudant.client.api.model.DesignDocument.MapReduce;
+
+/**
+ * CRUD access for the Obligation Element class
+ */
+public class ObligationElementRepository extends DatabaseRepositoryCloudantClient<ObligationElement> {
+
+    private static final String ALL = "function(doc) { if (doc.type == 'obligationElement') emit(null, doc._id) }";
+    private static final String BYLANGELEMENT = "function(doc) { if(doc.type == 'obligationElement') { emit(doc.langElement, doc) } }";
+    private static final String BYACTION = "function(doc) { if(doc.type == 'obligationElement') { emit(doc.action, doc) } }";
+    private static final String BYOBJECT = "function(doc) { if(doc.type == 'obligationElement') { emit(doc.object, doc) } }";
+
+
+    public ObligationElementRepository(DatabaseConnectorCloudant db) {
+        super(db, ObligationElement.class);
+        Map<String, MapReduce> views = new HashMap<String, MapReduce>();
+        views.put("all", createMapReduce(ALL, null));
+        views.put("byobligationlang", createMapReduce(BYLANGELEMENT, null));
+        views.put("byobligationaction", createMapReduce(BYACTION, null));
+        views.put("byobligationobject", createMapReduce(BYOBJECT, null));
+        initStandardDesignDocument(views, db);
+    }
+
+
+    public List<ObligationElement> searchByObligationLang(String lang) {
+        return queryByPrefix("byobligationlang", lang);
+    }
+
+    public List<ObligationElement> searchByObligationAction(String action) {
+        return queryByPrefix("byobligationaction", action);
+    }
+
+    public List<ObligationElement> searchByObligationObject(String object) {
+        return queryByPrefix("byobligationobject", object);
+    }
+}

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/ObligationNodeRepository.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/ObligationNodeRepository.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright TOSHIBA CORPORATION, 2021. Part of the SW360 Portal Project.
+ * Copyright Toshiba Software Development (Vietnam) Co., Ltd., 2021. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.licenses.db;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.*;
+
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
+import org.eclipse.sw360.datahandler.cloudantclient.DatabaseRepositoryCloudantClient;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationNode;
+
+import com.cloudant.client.api.model.DesignDocument.MapReduce;
+ /**
+ * CRUD access for the Obligation Node class
+ */
+
+public class ObligationNodeRepository extends DatabaseRepositoryCloudantClient<ObligationNode> {
+
+    private static final String ALL = "function(doc) { if (doc.type == 'obligationNode') emit(null, doc._id) }";
+    private static final String BYNODETYPE = "function(doc) { if(doc.type == 'obligationNode') { emit(doc.nodeType, doc) } }";
+    private static final String BYNODETEXT = "function(doc) { if(doc.type == 'obligationNode') { emit(doc.nodeText, doc) } }";
+    private static final String BYOBLIGATIONID = "function(doc) { if(doc.type == 'obligationNode') { emit(doc.oblElementId, doc) } }";
+
+    public ObligationNodeRepository(DatabaseConnectorCloudant db) {
+        super(db, ObligationNode.class);
+        Map<String, MapReduce> views = new HashMap<String, MapReduce>();
+        views.put("all", createMapReduce(ALL, null));
+        views.put("byobligationnodetype", createMapReduce(BYNODETYPE, null));
+        views.put("byobligationnodetext", createMapReduce(BYNODETEXT, null));
+        views.put("byobligationid", createMapReduce(BYOBLIGATIONID, null));
+        initStandardDesignDocument(views, db);
+    }
+
+    public List<ObligationNode> searchByObligationNodeType(String type) {
+        return queryByPrefix("byobligationnodetype", type);
+    }
+
+    public List<ObligationNode> searchByObligationNodeText(String text) {
+        return queryByPrefix("byobligationnodetext", text);
+    }
+
+    public List<ObligationNode> searchByObligationNodeOblElementId(String oblElementId) {
+        return queryByPrefix("byobligationid", oblElementId);
+    }
+
+}

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/tools/OSADLObligationConnector.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/tools/OSADLObligationConnector.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright TOSHIBA CORPORATION, 2021. Part of the SW360 Portal Project.
+ * Copyright Toshiba Software Development (Vietnam) Co., Ltd., 2021. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Creative Commons 4.0
+ * which is available at https://creativecommons.org/2014/01/07/plaintext-versions-of-creative-commons-4-0-licenses/
+ *
+ * SPDX-License-Identifier: CC-BY-4.0
+ *
+ * This product depends on software developed by the Open Source Automation Development Lab eG (OSADL) (https://www.osadl.org/).
+ */
+
+package org.eclipse.sw360.licenses.tools;
+
+import java.util.*;
+import java.net.*;
+import java.io.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import org.eclipse.sw360.datahandler.thrift.licenses.Obligation;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationLevel;
+import org.eclipse.sw360.datahandler.thrift.licenses.ObligationType;
+import org.eclipse.sw360.datahandler.thrift.users.User;
+import static org.eclipse.sw360.datahandler.common.CommonUtils.TMP_OBLIGATION_ID_PREFIX;
+
+public class OSADLObligationConnector extends ObligationConnector {
+	public static final String EXTERNAL_ID_OSADL = "OSADL-Obligation-License";
+	private static final Logger log = LogManager.getLogger(OSADLObligationConnector.class);
+    private static final String SOURCE = "OSADL";
+	private static final String BASE_URL = "https://www.osadl.org/fileadmin/checklists/unreflicenses/";
+
+	@Override
+    protected String generateURL(String licenseId) {
+        return BASE_URL + licenseId + ".txt";
+    }
+
+    @Override
+    protected String getText(String licenseId) {
+        String obligationURL = generateURL(licenseId);
+		try {
+			URL url = new URL(obligationURL);
+			HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+			int responseCode = conn.getResponseCode();
+			if (responseCode != HttpURLConnection.HTTP_OK) {
+				log.error("Could not open OSADL License URL: " + obligationURL);
+				log.error("HTTP Response Code: " + responseCode);
+				return null;
+			}
+			BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+			StringBuffer buffer = new StringBuffer();
+			String inputLine;
+			while ((inputLine = in.readLine()) != null) {
+				buffer.append(inputLine);
+				buffer.append(System.lineSeparator());
+			}
+			in.close();
+			return buffer.toString();
+		} catch (IOException e) {
+			log.error("Could not get OSADL License for: " + licenseId);
+			return null;
+		}
+    }
+
+	@Override
+	public JSONObject parseText(String obligationText) {
+        String lines = obligationText;
+        String[] arraylines = lines.split("\n");
+		List<String> jsonText = setLinePath(setLineLevel(arraylines));
+		return buildTreeObject(jsonText);
+	}
+
+	public static Optional<Obligation> get(String licenseId, User user) {
+		OSADLObligationConnector osadlConnector = new OSADLObligationConnector();
+		String obligationText = osadlConnector.getText(licenseId);
+		if (obligationText == null) {
+			return Optional.empty();
+		}
+
+		Obligation obligation = new Obligation();
+		obligation.setId(TMP_OBLIGATION_ID_PREFIX + UUID.randomUUID().toString());
+		obligation.setText(obligationText);
+		obligation.setTitle(licenseId);
+		obligation.setObligationLevel(ObligationLevel.LICENSE_OBLIGATION);
+		obligation.setObligationType(ObligationType.OBLIGATION);
+		obligation.setDevelopment(false);
+		obligation.setDistribution(false);
+		obligation.addToWhitelist(user.getDepartment());
+		obligation.setExternalIds(Collections.singletonMap(EXTERNAL_ID_OSADL, licenseId));
+		return Optional.of(obligation);
+	}
+
+	private List<String> setLineLevel(String[] arraylines) {
+		List<String> refinedLines = new ArrayList<>();
+		for (int i = 0; i < arraylines.length; i++) {
+			if (arraylines[i].isEmpty()) {
+				continue;
+			}
+			int currentLevel = getLevel(arraylines[i]);
+			String lineWithLevel = "{ 'id': '" + i + "', 'text': '" + arraylines[i].replace("\t","") + "', 'level': '" + currentLevel + "', 'path': '-1'}";
+			refinedLines.add(lineWithLevel);
+		}
+		return refinedLines;
+	}
+
+	private int getLevel(String line) {
+		return line.length() - line.replace("\t","").length();
+	}
+
+	private List<String> setLinePath(List<String> lines) {
+		List<String> refinedLines = new ArrayList<>();
+		int i = 0;
+		for (String line : lines) {
+			String parentLinePath = "-1";
+			try {
+				JSONObject currentLine = JSONFactoryUtil.createJSONObject(line);
+				int parentLineId = getParentLineId(currentLine, lines);
+				if (parentLineId >= 0) {
+					JSONObject parentLine = JSONFactoryUtil.createJSONObject(lines.get(parentLineId));
+					parentLinePath = parentLine.get("path").toString();
+				}
+				currentLine.remove("path");
+				String path = parentLinePath.replace("@", "") + "@" + currentLine.get("id").toString();
+				currentLine.put("path", path.trim());
+				lines.set(i, currentLine.toJSONString());
+				i++;
+				String jsonLine = "{ 'id': '" + currentLine.get("id") + "', 'text': '" + currentLine.get("text") + "', 'level': '" + currentLine.get("level") + "', 'path': '" +currentLine.get("path")+ "'}";
+				refinedLines.add(jsonLine);
+			} catch (Exception e) {
+				log.error("Can not set line path: " + line);
+				return null;
+			}
+		}
+		return refinedLines;
+	}
+
+	private int getParentLineId(JSONObject currentLine, List<String> lines) {
+		int currentLevel = Integer.parseInt(currentLine.get("level").toString());
+		for (int i = Integer.parseInt(currentLine.get("id").toString()); i >= 0; i--) {
+			try {
+				JSONObject lineCheck =JSONFactoryUtil.createJSONObject(lines.get(i));
+				if (Integer.parseInt(lineCheck.get("level").toString()) == currentLevel - 1) {
+					return i;
+				}
+			} catch (Exception e) {
+				log.error("Can not get parent line id from: " + currentLine);
+				return -1;
+			}
+		}
+		return -1;
+	}
+
+	private JSONObject buildTreeObject(List<String> lines) {
+		try {
+			String rootNodeText = "{'val': ['ROOT'], 'children': [], 'path': '-1'}";
+			JSONObject rootNode = JSONFactoryUtil.createJSONObject(rootNodeText);
+			return removeField(addNode(rootNode, lines), "path");
+		} catch (Exception e) {
+			log.error("Can not build tree object from: " + lines);
+			return null;
+		}
+	}
+
+	private JSONObject removeField(JSONObject rootNode, String field) {
+		rootNode.remove(field);
+		for (int i = 0; i < rootNode.getJSONArray("children").length(); i++) {
+			JSONObject contactObject = rootNode.getJSONArray("children").getJSONObject(i);
+			removeField(contactObject, field);
+		}
+		return rootNode;
+	}
+
+	private JSONObject addNode(JSONObject rootNode, List<String> lines) {
+		for (int i = 0; i < lines.size(); i++) {
+			try {
+				JSONObject line = JSONFactoryUtil.createJSONObject(lines.get(i));
+				if (line.get("path").toString().split("@")[0].equals(rootNode.get("path").toString().replace("@", ""))) {
+					String childNode;
+					List<String> text = parseSentenceElement(line.get("text").toString());
+					if (text.get(0).equals("Obligation")) {
+						childNode = "{'val': ['" +text.get(0)+ "', '" +text.get(1)+ "', '" +text.get(2)+ "', '" +text.get(3)+"'], 'children': [], 'path': '" +line.get("path")+ "'}";
+					} else {
+						childNode = "{'val': ['" +text.get(0)+ "', '" +text.get(1)+ "'], 'children': [], 'path': '" +line.get("path")+ "'}";
+					}
+					rootNode.getJSONArray("children").put(JSONFactoryUtil.createJSONObject(childNode));
+				}
+			} catch (Exception e) {
+				log.error("Can not add node from: " + lines);
+				return null;
+			}
+		}
+		for (int i = 0; i < rootNode.getJSONArray("children").length(); i++) {
+			JSONObject contactObject = rootNode.getJSONArray("children").getJSONObject(i);
+			addNode(contactObject, lines);
+		}
+		return rootNode;
+	}
+
+	private List<List<String>> getProperty() {
+		List<List<String>> keywords = new ArrayList<List<String>>();
+		List<String> obligation = new ArrayList<>(Arrays.asList("YOU MUST", "YOU MUST NOT"));
+		List<String> other = new ArrayList<>(Arrays.asList(
+		"USE CASE",
+		"IF",
+		"EITHER",
+		"EITHER IF",
+		"OR",
+		"OR IF",
+		"EXCEPT IF",
+		"EXCEPT IF NOT",
+		"ATTRIBUTE",
+		"ATTRIBUTE NOT",
+		"COMPATIBILITY",
+		"DEPENDING COMPATIBILITY",
+		"INCOMPATIBILITY",
+		"PATENT HINTS",
+		"COPYLEFT CLAUSE"));
+		keywords.add(obligation);
+		keywords.add(other);
+		return keywords;
+	}
+
+	private List<String> sortArray(List<List<String>> arrList, String type) {
+		List<String> both = new ArrayList<>();
+		for (List<String> arr: arrList) {
+			for (String i : arr) {
+				both.add(i);
+			}
+		}
+
+		if ( type.equals("ASC")) {
+			both.sort((String s1, String s2) -> s1.length() - s2.length());
+		} else {
+			both.sort((String s1, String s2) -> s2.length() - s1.length());
+		}
+		return both;
+	}
+
+	private List<String> parseSentenceElement(String text) {
+		text = text.trim();
+		List<List<String>> data = getProperty();
+		List<String> allKeywords = sortArray(data, "1");
+		List<String> obligationProperty = data.get(0);
+		for (int i = 0; i < allKeywords.size(); i++ ) {
+			if (text.startsWith(allKeywords.get(i))) {
+				if (obligationProperty.contains(allKeywords.get(i))) {
+					String languageElement = allKeywords.get(i);
+					String actionAndObjectText = text.substring(languageElement.length()).trim();
+					String actions = getActions(actionAndObjectText);
+					String object = actionAndObjectText.substring(actions.length()).trim();
+					return new ArrayList<>(Arrays.asList("Obligation", languageElement, actions, object));
+				} else {
+					String type = allKeywords.get(i);
+					return new ArrayList<>(Arrays.asList(type, text.substring(type.length()).trim()));
+				}
+			}
+		}
+
+		String type = "";
+		String value = "";
+		String[] words = text.split(" ");
+		for (int i = 0; i < words.length; i++) {
+			if (words[i].equals(words[i].toUpperCase())) {
+				type = type + ' ' + words[i];
+			} else {
+				break;
+			}
+		}
+		type = type.trim();
+		if (type.length() == 0) {
+			type = words[0];
+		}
+		value = text.substring(type.length());
+		return new ArrayList<>(Arrays.asList(type, value));
+	}
+
+	private String getActions(String text) {
+		if (text.contains("OR")) {
+			List<String> words = Arrays.asList(text.split(" "));
+			List<Integer> ORpos = new ArrayList<>();
+			for (int i = 0; i < words.size(); i++) {
+				if (words.get(i).equals("OR")) {
+					ORpos.add(i);
+				}
+			}
+
+			if (ORpos.get(0) != 1) {
+				return text.split(" ")[0];
+			} else {
+				int lastORPos = ORpos.get(0);
+				for (int i = 0; i < ORpos.size() - 1; i++) {
+					if (ORpos.get(i + 1) == ORpos.get(i) + 2) {
+						lastORPos = ORpos.get(i + 1);
+					} else {
+						break;
+					}
+				}
+
+				List<String> result = new ArrayList<>();
+				for (int i = 0; i < lastORPos + 1; i++) {
+					result.add(words.get(i));
+				}
+
+				if (lastORPos < words.size() - 1) {
+					result.add(words.get(lastORPos + 1));
+				}
+				return String.join(" ", result);
+			}
+		} else {
+			return text.split(" ")[0];
+		}
+	}
+}

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/tools/ObligationConnector.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/tools/ObligationConnector.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright TOSHIBA CORPORATION, 2021. Part of the SW360 Portal Project.
+ * Copyright Toshiba Software Development (Vietnam) Co., Ltd., 2021. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.sw360.licenses.tools;
+
+import com.liferay.portal.kernel.json.JSONObject;
+
+public abstract class ObligationConnector {
+    protected abstract String generateURL(String licenseId);
+
+    protected abstract String getText(String licenseId);
+
+    public abstract JSONObject parseText(String obligationText);
+}

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -257,6 +257,9 @@ public class PortalConstants {
     public static final String PROJECT_SEARCH = "projectSearch";
     public static final String RELEASE_SEARCH = "releaseSearch";
     public static final String RELEASE_SEARCH_BY_VENDOR = "releaseSearchByVendor";
+    public static final String OBLIGATION_ELEMENT_SEARCH = "obligationElementSearch";
+    public static final String OBLIGATION_ELEMENT_ID = "obligationElementId";
+
     public static final String RELEASE_LIST_FROM_LINKED_PROJECTS = "releaseListFromLinkedProjects";
     public static final String STATE;
     public static final String PROJECT_TYPE;
@@ -321,6 +324,7 @@ public class PortalConstants {
     public static final String DUPLICATE_PROJECTS = "duplicateProjects";
     public static final String ACTION_DELETE_ALL_LICENSE_INFORMATION = "deleteAllLicenseInformation";
     public static final String ACTION_IMPORT_SPDX_LICENSE_INFORMATION = "importSpdxLicenseInformation";
+    public static final String ACTION_IMPORT_OSADL_LICENSE_INFORMATION = "importOSADLLicenseInformation";
 
 
     //! Specialized keys for vulnerability management
@@ -378,6 +382,12 @@ public class PortalConstants {
     public static final String LICENSE_INFO_RELEASE_TO_ATTACHMENT = "licenseInfoAttachmentSelected";
     public static final String LICENSE_INFO_EMPTY_FILE = "isEmptyFile";
     public static final String SW360_USER = "sw360User";
+
+    //! Specialized keys for obligation node
+    public static final String OBLIGATION_NODE_LIST = "obligationNodeList";
+
+    //! Specialized keys for obligation element
+    public static final String OBLIGATION_ELEMENT_LIST = "obligationElementList";
 
     //! Serve resource generic keywords
     public static final String ACTION = "action";
@@ -549,6 +559,9 @@ public class PortalConstants {
     // license actions
     public static final String LICENSE_PREFIX = "license";
     public static final String LICENSE_SEARCH = LICENSE_PREFIX + "search";
+
+    // obligation actions
+    public static final String VIEW_IMPORT_OBLIGATION_ELEMENTS = "view_import_obligation_elements";
 
     //vulnerability actions
     public static  final String UPDATE_VULNERABILITIES_RELEASE = "updateVulnerabilitiesRelease";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/LicenseAdminPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/LicenseAdminPortlet.java
@@ -89,6 +89,13 @@ public class LicenseAdminPortlet extends Sw360Portlet {
                     throw new PortletException(e);
                 }
                 break;
+            case PortalConstants.ACTION_IMPORT_OSADL_LICENSE_INFORMATION:
+                try {
+                    importLicensesFromOSADL(request, response);
+                } catch (TException e) {
+                    throw new PortletException(e);
+                }
+                break;
             default:
                 log.warn("The LicenseAdminPortlet was called with unsupported action=[" + action + "]");
         }
@@ -114,6 +121,13 @@ public class LicenseAdminPortlet extends Sw360Portlet {
                 inputStream.close();
             }
         }
+    }
+
+    private void importLicensesFromOSADL(ResourceRequest request, ResourceResponse response) throws TException {
+        User user = UserCacheHolder.getUserFromRequest(request);
+        LicenseService.Iface licenseClient = thriftClients.makeLicenseClient();
+        RequestSummary requestSummary = licenseClient.importAllOSADLLicenses(user);
+        renderRequestSummary(request, response, requestSummary);
     }
 
     private void deleteAllLicenseInformation(ResourceRequest request, ResourceResponse response){

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/components/_table.scss
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/components/_table.scss
@@ -92,3 +92,41 @@ table  {
 		vertical-align: top;
 	}
 }
+
+.table-license-list {
+	height: auto;
+	max-height: 190px;
+
+	overflow: auto;
+
+	font-size: 14px;
+
+	table {
+		border-collapse: collapse;
+		width: 100%;
+	}
+
+	th {
+		position: sticky;
+		top: 0;
+		z-index: 1;
+		background: #5d8ea9;
+		color:white;
+		border: 1px solid #e7e7ed;
+		border-top: 2px;
+		border-bottom: 2px;
+		height: 47px;
+
+		font-weight: 600;
+
+		padding: 0.75rem;
+	}
+	td {
+		border: 1px solid #e7e7ed;
+		color: #272833;
+		height: 47px;
+		font-weight: 400;
+
+		padding: 0.75rem;
+	}
+}

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/licenseAdmin/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/licenseAdmin/view.jsp
@@ -1,6 +1,8 @@
 <%--
   ~ Copyright Siemens AG, 2013-2017, 2019.
   ~ Copyright Bosch Software Innovations GmbH, 2016.
+  ~ Copyright TOSHIBA CORPORATION, 2021.
+  ~ Copyright Toshiba Software Development (Vietnam) Co., Ltd., 2021.
   ~ Part of the SW360 Portal Project.
   ~
   ~ This program and the accompanying materials are made
@@ -30,6 +32,10 @@
                    value='<%=PortalConstants.ACTION_IMPORT_SPDX_LICENSE_INFORMATION%>'/>
 </portlet:resourceURL>
 
+<portlet:resourceURL var="importOSADLLicenseInformationURL">
+    <portlet:param name="<%=PortalConstants.ACTION%>"
+                   value='<%=PortalConstants.ACTION_IMPORT_OSADL_LICENSE_INFORMATION%>'/>
+</portlet:resourceURL>
 
 <div class="container">
 	<div class="row">
@@ -47,6 +53,11 @@
                                 <liferay-ui:message key="import.spdx.information" />
                             </button>
 						</div>
+                        <div class="btn-group" role="group">
+                            <button type="button" class="btn btn-primary" data-action="import-OSADL">
+                                <liferay-ui:message key="import.osadl.information" />
+                            </button>
+                        </div>
                         <div class="btn-group" role="group">
 							<button type="button" class="btn btn-danger" data-action="delete-licenses">
                                 <liferay-ui:message key="delete.all.license.information" />
@@ -101,12 +112,16 @@
 require(['jquery', 'modules/dialog', 'modules/validation'], function($, dialog, validation) {
 
     validation.enableForm('#uploadLicenseArchiveForm');
+    var progress = null;
 
     $('.portlet-toolbar button[data-action="import-spdx"]').on('click', function() {
         var $dialog;
+        if (progress != null) {
+            progress.abort();
+        }
 
         function importSpdxLicenseInformationInternal(callback) {
-            $.ajax({
+            progress = $.ajax({
                 type: 'POST',
                 url: '<%=importSpdxLicenseInformationURL%>',
                 cache: false,
@@ -137,11 +152,75 @@ require(['jquery', 'modules/dialog', 'modules/validation'], function($, dialog, 
         );
     });
 
+    $('.portlet-toolbar button[data-action="import-OSADL"]').on('click', function() {
+        var $dialog;
+        if (progress != null) {
+            progress.abort();
+        }
+
+        function importOSADLLicenseInformationInternal(callback) {
+            progress = $.ajax({
+                type: 'POST',
+                url: '<%=importOSADLLicenseInformationURL%>',
+                cache: false,
+                dataType: 'json'
+            }).always(function() {
+                callback();
+            }).done(function (data) {
+                $('.alert.alert-dialog').hide();
+                if (data.result == 'SUCCESS') {
+                    $dialog.success(`<liferay-ui:message key="i.imported.x.out.of.y.osadl.license.obliations" />`);
+                    if (data.totalAffectedObjects != 0 ) {
+                        $('.modal-body').append(`<div id="listLicenseSuccess">
+                                        <p style="margin-top: 1rem; margin-bottom: 0.5rem;"><liferay-ui:message key="list.of.licenses.were.imported"/></p>
+                                    <div id="licenseSuccessTable">
+                                    </div>`);
+                        var licensesSuccessTable = createLicenseTable(data.message, 'licensesSuccess');
+                        $('#licenseSuccessTable').append(licensesSuccessTable);
+                    }
+                    if (data.totalObjects != data.totalAffectedObjects) {
+                        $('.modal-body').append(`<div id="listLicenseMissing">
+                                        <p style="margin-top: 1rem; margin-bottom: 0.5rem;"><liferay-ui:message key="list.of.licenses.could.not.be.imported"/></p>
+                                    <div id="licenseMissingTable">
+                                    </div>`);
+                        var licensesMissingTable = createLicenseTable(data.message, 'licensesMissing');
+                        $('#licenseMissingTable').append(licensesMissingTable);
+                    }
+                } else if (data.result == 'PROCESSING') {
+                    $dialog.info('<liferay-ui:message key="importing.process.is.already.running.please.try.again.later" />');
+                } else {
+                    $dialog.alert('<liferay-ui:message key="error.happened.during.license.obligation.importing.some.license.obliations.may.not.be.imported" />');
+                }
+            }).fail(function(){
+                $('.alert.alert-dialog').hide();
+                $dialog.alert('<liferay-ui:message key="something.went.wrong" />');
+            });
+        }
+
+        $dialog = dialog.confirm(
+            null,
+            'question-circle',
+            '<liferay-ui:message key="import.osadl.license.obligations" />?',
+            '<p id="OSADLConfirmMessage"><liferay-ui:message key="do.you.really.want.to.import.all.osadl.license.obligations" />',
+            '<liferay-ui:message key="import.osadl.license.obligations" />',
+            {},
+            function(submit, callback) {
+                $('#OSADLConfirmMessage').hide();
+                $dialog.info('<liferay-ui:message key="importing.process.is.running.it.may.takes.a.few.minutes" />', true);
+                $('.modal-header > button').prop('disabled', false);
+                importOSADLLicenseInformationInternal(callback);
+            }
+        );
+    });
+
     $('.portlet-toolbar button[data-action="delete-licenses"]').on('click', function() {
         var $dialog;
+        if (progress != null) {
+            progress.abort();
+        }
 
         function deleteAllLicenseInformationInternal(callback) {
-            $.ajax({
+            progress = $.ajax({
                 type: 'POST',
                 url: '<%=deleteAllLicenseInformationURL%>',
                 cache: false,
@@ -173,5 +252,42 @@ require(['jquery', 'modules/dialog', 'modules/validation'], function($, dialog, 
             }
         );
     });
+
+    function createLicenseTable(dataMessage, status) {
+        const jsonData = JSON.parse(dataMessage);
+        const licensesJson = jsonData[status];
+
+        var licenseTable = '<div class="table-license-list dataTable">';
+        licenseTable += '<table>';
+        licenseTable += '<thead>';
+        licenseTable += '<tr>';
+        licenseTable += '<th><liferay-ui:message key="index" /></th>';
+        licenseTable += '<th><liferay-ui:message key="license.shortname" /></th>';
+        licenseTable += '<th><liferay-ui:message key="license.fullname" /></th>';
+        licenseTable += '</tr>';
+        licenseTable += '</thead>';
+        licenseTable += '<tbody>';
+
+        var i = 1;
+        for (var key in licensesJson) {
+            licenseTable += createRowTable(i, key, licensesJson[key]);
+            i++;
+        }
+
+        licenseTable += '</tbody>';
+        licenseTable += '</table>';
+        licenseTable += '</div>';
+        return licenseTable;
+    }
+
+    function createRowTable(index, shortname, fullname){
+        var row = '<tr>';
+        row += '<td>' + index + '</td>';
+        row += '<td>' + shortname + '</td>';
+        row += '<td>' + fullname + '</td>';
+        row += '</tr>';
+        return row;
+    }
+
 });
 </script>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/obligations/ajax/searchObligationElementsAjax.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/obligations/ajax/searchObligationElementsAjax.jsp
@@ -1,0 +1,37 @@
+<%--
+  ~ Copyright TOSHIBA CORPORATION, 2021. Part of the SW360 Portal Project.
+  ~ Copyright Toshiba Software Development (Vietnam) Co., Ltd., 2021. Part of the SW360 Portal Project.
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  --%>
+
+<%@include file="/html/init.jsp"%>
+
+<portlet:defineObjects />
+<liferay-theme:defineObjects />
+
+<jsp:useBean id="obligationElementSearch" type="java.util.List<org.eclipse.sw360.datahandler.thrift.licenses.ObligationElement>" scope="request"/>
+<core_rt:if test="${obligationElementSearch.size()>0}" >
+    <core_rt:forEach items="${obligationElementSearch}" var="entry">
+        <tr>
+            <td style="width: fit-content">
+                <div class="form-check" style="text-align: center;">
+                    <input type="radio" class="form-check-input" name="<portlet:namespace/>obligationElementId" lang="<sw360:out value="${entry.langElement}"/>" action="<sw360:out value="${entry.action}"/>" object="<sw360:out value="${entry.object}"/>">
+                </div>
+            </td>
+            <td style="width: fit-content">
+                <sw360:out value="${entry.langElement}"/>
+            </td>
+            <td style="width: fit-content">
+                <sw360:out value="${entry.action}"/>
+            </td>
+            <td style="width: fit-content">
+                <sw360:out value="${entry.object}"/>
+            </td>
+        </tr>
+    </core_rt:forEach>
+</core_rt:if>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/obligations/includes/searchObligationElements.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/obligations/includes/searchObligationElements.jsp
@@ -1,0 +1,69 @@
+<%--
+  ~ Copyright TOSHIBA CORPORATION, 2021. Part of the SW360 Portal Project.
+  ~ Copyright Toshiba Software Development (Vietnam) Co., Ltd., 2021. Part of the SW360 Portal Project.
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  --%>
+
+<%@ page import="com.liferay.portal.kernel.portlet.PortletURLFactoryUtil" %>
+<%@include file="/html/init.jsp" %>
+<portlet:defineObjects/>
+<liferay-theme:defineObjects/>
+
+<%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
+<jsp:useBean id="obligationElement" class="org.eclipse.sw360.datahandler.thrift.licenses.ObligationElement" scope="request" />
+
+<portlet:resourceURL var="viewObligationELementURL">
+    <portlet:param name="<%=PortalConstants.ACTION%>" value="<%=PortalConstants.VIEW_IMPORT_OBLIGATION_ELEMENTS%>"/>
+    <portlet:param name="<%=PortalConstants.OBLIGATION_ELEMENT_ID%>" value="${obligationElement.id}"/>
+</portlet:resourceURL>
+<%@ include file="/html/utils/includes/requirejs.jspf" %>
+<div class="dialogs">
+    <div id="searchObligationElementsDialog" data-title="<liferay-ui:message key="import.obligation.element" />" class="modal fade" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable" role="document">
+      <div class="modal-content">
+        <div class="modal-body container">
+            <form>
+            <div class="row form-group">
+                            <div class="col">
+                                <input type="text" name="searchobligationelement" id="searchobligationelement" placeholder="<liferay-ui:message key="enter.search.text" />" class="form-control"/>
+                            </div>
+                            <div class="col">
+                                <button type="button" class="btn btn-secondary" id="searchbuttonobligation"><liferay-ui:message key="search" /></button>
+                            </div>
+                        </div>
+
+                        <div id="ObligationElementsearchresults">
+                            <div class="spinner text-center" style="display: none;">
+                                <div class="spinner-border" role="status">
+                                    <span class="sr-only"><liferay-ui:message key="loading" /></span>
+                                </div>
+                            </div>
+
+                            <table id="obligationElementSearchResultstable" class="table table-bordered">
+                                <thead>
+                                    <tr>
+                                        <th></th>
+                                        <th><liferay-ui:message key="language.element" /></th>
+                                        <th><liferay-ui:message key="action" /></th>
+                                        <th><liferay-ui:message key="object" /></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                </tbody>
+                            </table>
+                        </div>
+                    </form>
+				</div>
+			    <div class="modal-footer">
+		            <button type="button" class="btn btn-light" data-dismiss="modal"><liferay-ui:message key="close" /></button>
+			        <button id="importObligationElementsButton" type="button" class="btn btn-primary" title="<liferay-ui:message key="import.obligation.element" />"><liferay-ui:message key="import.obligation.element" /></button>
+			    </div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/obligations/obligationTextTree.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/obligations/obligationTextTree.jsp
@@ -1,0 +1,453 @@
+<%--
+  ~ Copyright TOSHIBA CORPORATION, 2021. Part of the SW360 Portal Project.
+  ~ Copyright Toshiba Software Development (Vietnam) Co., Ltd., 2021. Part of the SW360 Portal Project.
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  --%>
+
+<%@include file="/html/init.jsp"%>
+<%@ page import="org.eclipse.sw360.portal.users.UserCacheHolder" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.licenses.Obligation" %>	
+<%@ page import="org.eclipse.sw360.datahandler.thrift.licenses.ObligationElement" %>
+<%@ page import="org.eclipse.sw360.datahandler.thrift.licenses.ObligationNode" %>
+<jsp:useBean id="obligationNodeList" type="java.util.List<org.eclipse.sw360.datahandler.thrift.licenses.ObligationNode>" scope="request"/>
+<jsp:useBean id="obligationElementList" type="java.util.List<org.eclipse.sw360.datahandler.thrift.licenses.ObligationElement>" scope="request"/>
+
+<style type="text/css">
+.tree-container {
+    padding-left: 0;
+}
+
+.tree-container ul,
+.tree-container li {
+    list-style-type: circle;
+    margin: 0.5rem;
+}
+
+.tree-container .btn-link {
+    color: blue;
+}
+
+#obligationText {
+    padding-left: 0;
+    list-style-type: none !important;
+}
+
+#out {
+    font-size: 100%;
+}
+
+#tree input {
+    width: 15rem;
+
+}
+</style>
+
+<div id="obligationTree">    
+    <main class="container tree-container">
+        <div class="wrapper">
+            <div class="main-ctn">
+                <div id="tree">
+                    <ul id="obligationText">
+                        <li class="tree-node" id="root">
+                            <input type="text" name="<portlet:namespace/><%=ObligationNode._Fields.NODE_TEXT%>" class="elementType" placeholder="<liferay-ui:message key="title" />">
+                            <span class="controls">
+                                &raquo;
+                                <a class="btn-link" href="#" data-func="add-child"
+                                    >+<liferay-ui:message key="child" /></a
+                                >
+                            </span>
+                        </li>
+                    </ul>
+                </div>
+
+                <hr />
+
+                <div class="right">
+                    <b class="app-subtitle"><liferay-ui:message key="preview" /></b>
+                    <div class="output-tree-ctn" style="padding-left: 2.5rem">
+                        <pre id="out"></pre>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <div style="display: none;" class="hidden" id="template">
+        <ul>
+            <li class="tree-node">
+                <input type="text" name="<portlet:namespace/><%=ObligationNode._Fields.NODE_TYPE%>" class="elementType" list="typeList" placeholder="<liferay-ui:message key="type" />">
+                <datalist id="typeList" class="typeListData">
+                    <option value="Obligation">
+                </datalist>
+
+                <%-- Obligation element --%>
+                <input type="text" name="<portlet:namespace/><%=ObligationElement._Fields.LANG_ELEMENT%>" class="obLangElement" list="obLangElement" element-type="Obligation" placeholder="<liferay-ui:message key="language.element" />">
+                <datalist id="obLangElement" class="obLangElementData">
+                </datalist>
+
+                <input type="text" name="<portlet:namespace/><%=ObligationElement._Fields.ACTION%>" class="obAction" list="obAction" element-type="Obligation" placeholder="<liferay-ui:message key="action" />">
+                <datalist id="obAction" class="obActionData">
+                </datalist>
+
+                <input type="text" name="<portlet:namespace/><%=ObligationElement._Fields.OBJECT%>" class="obObject" list="obObject" element-type="Obligation" placeholder="<liferay-ui:message key="object" />">
+                <datalist id="obObject" class="obObjectData">
+                </datalist>
+
+                <%-- Other Type --%>
+                <input type="text" name="<portlet:namespace/><%=ObligationNode._Fields.NODE_TEXT%>" class="other" list="otherText" element-type="Other" placeholder="<liferay-ui:message key="text" />">
+                <datalist id="otherText" class="otherTextData">
+                </datalist>
+
+                <%-- Action with element --%>
+                <span class="controls">
+                    &raquo;
+                    <a class="btn-link" href="#"Attribute data-func="add-sibling">+<liferay-ui:message key="sibling" /></a> |
+                    <a class="btn-link" href="#" data-func="add-child">+<liferay-ui:message key="child" /></a> |
+                    <a class="btn-link" href="#" data-func="delete"><liferay-ui:message key="delete" /></a> |
+                    <a class="btn-link" href="#" data-func="import" id="importObligationElementtButton"><liferay-ui:message key="import" /></a>
+                </span>
+            </li>
+        </ul>
+    </div>
+</div>
+<%@ include file="/html/admin/obligations/includes/searchObligationElements.jsp" %>
+<%@ include file="/html/utils/includes/requirejs.jspf" %>
+<script>
+require(['jquery', 'modules/dialog', 'bridges/datatables', 'utils/keyboard', 'utils/cssloader'], function($, dialog, datatables, keyboard, cssloader) {
+    var $dataTable,
+    $dialog;
+
+    $(document).ready(function () {
+        const indent = "    ",                  // Use 4 spaces for indentation of previewing
+            ul_template = $("#template > ul");
+
+        const action = {
+            "add-sibling": function (obj) {
+                var newNode = ul_template.clone();
+                var newId = Date.now();
+                newNode.find('#otherText').attr('id', newId);
+                newNode.find("[list='otherText']").attr('list', newId);
+                obj.parent().after(newNode);
+                $('.elementType').on('change keyup', changeElementType);
+                showElementControls(newNode.find(".elementType"));
+            },
+            "add-child": function (obj) {
+                var newNode = ul_template.clone();
+                var newId = Date.now();
+                newNode.find('#otherText').attr('id', newId);
+                newNode.find("[list='otherText']").attr('list', newId);
+                obj.append(newNode);
+                $('.elementType').on('change keyup', changeElementType);
+                showElementControls(newNode.find(".elementType"));
+            },
+            delete: function (obj) {
+                obj.parent().remove();
+            },
+            "import": function (obj) {
+                showObligationElementDialog(obj)
+            },
+        };
+
+        $(document).on("click", "li.tree-node .controls > a", function () {
+            action[this.getAttribute("data-func")]($(this).closest("li"));
+            updatePreview();
+            return false;
+        });
+
+        //Disable the first textbox because the title will be set automatically
+        $("#root .elementType").first().prop('disabled', true);
+
+        $('#todoTitle').on('change keyup', (event) => {
+            $("#root .elementType").first().val(document.getElementById('todoTitle').value)
+            updatePreview()
+        });
+
+        const typeSuggestions = getTypeSuggestions();
+
+        const obligationSuggestions = getObligationSuggestions();
+
+        function getJSONObjectKeys(object) {
+            var keys = [];
+
+            for (var key in object) {
+                keys.push(key);
+            }
+
+            return keys;
+        }
+
+        function getTypeSuggestions() {
+            var suggestions = {};
+            <core_rt:forEach items="${obligationNodeList}" var="node">
+                var nodeType = "<sw360:out value='${node.nodeType}'/>";
+                if (nodeType != "" && nodeType != "ROOT" && !suggestions.hasOwnProperty(nodeType)) {
+                    suggestions[nodeType] = new Set();
+                }
+            </core_rt:forEach>
+
+            <core_rt:forEach items="${obligationNodeList}" var="node">
+                var nodeType = "<sw360:out value='${node.nodeType}'/>";
+
+                if (suggestions.hasOwnProperty(nodeType)) {
+                    suggestions[nodeType].add("<sw360:out value='${node.nodeText}'/>");
+                }
+            </core_rt:forEach>
+
+            if (Object.keys(suggestions).length === 0) {
+                suggestions['Obligation'] = new Set()
+            }
+
+            return suggestions;
+        }
+
+        function getObligationSuggestions() {
+            var suggestions = {};
+            suggestions['LE'] = new Set();
+            suggestions['Action'] = new Set();
+            suggestions['Object'] = new Set();
+
+            <core_rt:forEach items="${obligationElementList}" var="obligationElement">
+                suggestions['LE'].add("<sw360:out value='${obligationElement.langElement}'/>");
+                suggestions['Action'].add("<sw360:out value='${obligationElement.action}'/>");
+                suggestions['Object'].add("<sw360:out value='${obligationElement.object}'/>");
+            </core_rt:forEach>
+
+            if (suggestions['LE'].size === 0) {
+                suggestions['LE'].add("YOU MUST")
+                suggestions['LE'].add("YOU MUST NOT")
+            }
+
+            if (suggestions['Action'].size === 0) {
+                suggestions['Action'].add("Provide")
+                suggestions['Action'].add("Modify")
+            }
+
+            if (suggestions['Object'].size === 0) {
+                suggestions['Object'].add("Copyright notices")
+                suggestions['Object'].add("License text")
+            }
+
+            return suggestions;
+        }
+
+        function addSuggestion(selector, suggestions) {
+            $.each($(selector), function(i, element) {
+                $(element).empty();
+                $.each(suggestions, function(j, suggestion) {
+                    $(element).html($(element).html() + "<option value=\"" + suggestion + "\">");
+                });
+            });
+        }
+
+        addSuggestion(".typeListData", getJSONObjectKeys(typeSuggestions));
+        addSuggestion(".obLangElementData", Array.from(obligationSuggestions['LE']));
+        addSuggestion(".obActionData", Array.from(obligationSuggestions['Action']));
+        addSuggestion(".obObjectData", Array.from(obligationSuggestions['Object']));
+
+
+        $(".elementType").each(function() {
+            showElementControls($(this));
+        });
+
+        function changeElementType() {
+            showElementControls($(this));
+
+            const type = $(this).val();
+
+            if (typeSuggestions.hasOwnProperty(type)) {
+                addSuggestion($(this).siblings('.otherTextData'), Array.from(typeSuggestions[type]));
+            }
+        }
+
+        function showElementControls(typeControl) {
+            var type = typeControl.val();
+            var siblings = typeControl.siblings();
+            siblings.hide();
+
+            if (type == 'Obligation') {
+                $.each(siblings, function(key, sibling) {
+                    if ($(sibling).attr('element-type') == type) {
+                        $(sibling).show();
+                    }
+                });
+            } else {
+            $.each(siblings, function(key, sibling) {
+                    if ($(sibling).attr('element-type') == undefined) {
+                        $(sibling).hide();
+                        return;
+                    }
+                    if ($(sibling).attr('element-type') != 'Obligation') {
+                        $(sibling).show();
+                    }
+                });
+            }
+
+            typeControl.siblings().each(function(key, element) {
+                if($(element).is('ul')) {
+                    $(element).css('display', '');
+                }
+            });
+        }
+
+        function getNodeText(node, pad) {
+            let padding = pad || "",
+                out = "",
+                items = node.children("li");
+
+            items.each(function (index) {
+                if ($(this).attr('id') != "root") {
+                    if ($(this).children(".elementType").val() == "Obligation") {
+                        out += padding +
+                                ($(this).children(".obLangElement").val() == null ? "" : $(this).children(".obLangElement").val()) + " " +
+                                ($(this).children(".obAction").val() == null ? "" : $(this).children(".obAction").val()) + " " +
+                                ($(this).children(".obObject").val() == null ? "" : $(this).children(".obObject").val()) + "\n";
+                    } else {
+                        out += padding +
+                                $(this).children(".elementType").val() + " " +
+                                ($(this).children(".other").val() == null ? "" : $(this).children(".other").val()) + "\n";
+                    }
+                }
+
+                const childNodes = $(this).children("ul");
+
+                if (childNodes.length) {
+                    out += getNodeText(childNodes, padding + indent);
+                }
+            });
+
+            return out;
+        }
+
+        function updatePreview() {
+            $("#out").text(getNodeText($("#obligationText")));
+        }
+
+        $(document).on("keyup", "#tree input", updatePreview);
+
+        $(document)
+            .on("mouseover", "li, #tree", function (e) {
+                $(this).children(".controls").show();
+                e.stopPropagation();
+            })
+            .on("mouseout", "li, #tree", function (e) {
+                $(this).children(".controls").hide();
+                e.stopPropagation();
+            });
+
+        updatePreview();
+
+        keyboard.bindkeyPressToClick('searchobligationelement', 'searchbuttonobligation');
+
+        $('[data-dismiss=modal]').on('click', function (e) {
+            var $t = $(this),
+            target = $t[0].href || $t.data("target") || $t.parents('.modal') || [];
+
+        $(target)
+           .find("input,textarea,select")
+               .val('')
+               .end()
+           .find("input[type=checkbox], input[type=radio]")
+               .prop("checked", "")
+               .end();
+        })
+
+        // if search func work can call func showObligationElements() after click #searchbuttonobligation
+
+        $('#searchbuttonobligation').on('click', function() {
+            showObligationElements();
+        });
+
+        function showObligationElements() {
+            obligationElementContentFromAjax('<%=PortalConstants.OBLIGATION_ELEMENT_SEARCH%>', $('#searchobligationelement').val(), function(data) {
+                    if ($dataTable) {
+                        $dataTable.destroy();
+                    }
+                    $('#obligationElementSearchResultstable tbody').html(data);
+                    makeObligatiobElementsDataTable();
+            });
+        }
+
+        $('#obligationElementSearchResultstable').on('change', 'input', function() {
+            $dialog.enablePrimaryButtons($('#obligationElementSearchResultstable input:checked').length > 0);
+        });
+
+        function obligationElementContentFromAjax(what, where, callback) {
+            $dialog.$.find('.spinner').show();
+            $dialog.$.find('#obligationElementSearchResultstable').hide();
+            $dialog.$.find('#searchbuttonobligation').prop('disabled', true);
+            $dialog.enablePrimaryButtons(false);
+
+            jQuery.ajax({
+                type: 'POST',
+                url: '<%=viewObligationELementURL%>',
+                data: {
+                    '<portlet:namespace/><%=PortalConstants.WHAT%>': what,
+                    '<portlet:namespace/><%=PortalConstants.WHERE%>': where
+                },
+                success: function (data) {
+                    callback(data);
+
+                    $dialog.$.find('.spinner').hide();
+                    $dialog.$.find('#obligationElementSearchResultstable').show();
+                    $dialog.$.find('#searchbuttonobligation').prop('disabled', false);
+                },
+                error: function() {
+                    $dialog.alert('Can not import Obligation ELement');
+                }
+            });
+        }
+
+        function makeObligatiobElementsDataTable() {
+            $dataTable = datatables.create('#obligationElementSearchResultstable', {
+                destroy: true,
+                paging: false,
+                info: false,
+                language: {
+                    emptyTable: "<liferay-ui:message key="no.obligation.element.found" />",
+                    processing: "<liferay-ui:message key="processing" />",
+                    loadingRecords: "<liferay-ui:message key="loading" />",
+                    emptyTable: "<liferay-ui:message key="please.perform.a.new.search" />"
+                },
+                select: 'single'
+            }, undefined, [0]);
+            datatables.enableCheckboxForSelection($dataTable, 0);
+        }
+
+        function showObligationElementDialog(obj) {
+            if($dataTable) {
+                $dataTable.destroy();
+                $dataTable = undefined;
+            }
+
+            $dialog = dialog.open('#searchObligationElementsDialog', {
+            }, function(submit, callback) {
+                var obligationElement = [];
+                if($("input[type='radio'].form-check-input").is(':checked')) {
+                    var selected_value =  $("input[type='radio'].form-check-input:checked").val();
+                    obligationElement.push($("input[type='radio'].form-check-input:checked").attr("lang"));
+                    obligationElement.push($("input[type='radio'].form-check-input:checked").attr("action"));
+                    obligationElement.push($("input[type='radio'].form-check-input:checked").attr("object"));
+
+                    obj.first().children(".elementType").val("Obligation")
+                    obj.first().children(".other").attr("style","display:none;")
+                    obj.first().children(".obLangElement").attr("style","").val(obligationElement[0])
+                    obj.first().children(".obAction").attr("style","").val(obligationElement[1])
+                    obj.first().children(".obObject").attr("style","").val(obligationElement[2])
+                }
+                updatePreview();
+                callback(true);
+            }, function() {
+                this.$.find('.spinner').hide();
+                this.$.find('#obligationElementSearchResultstable').hide();
+                this.$.find('#searchobligationelement').val('');
+                this.enablePrimaryButtons(false);
+            });
+        }
+    });
+});
+</script>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/obligations/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/obligations/view.jsp
@@ -86,11 +86,14 @@
                 result = [];
 
             <core_rt:forEach items="${obligList}" var="oblig">
+                var obligText = "<sw360:out value='${oblig.text}' stripNewlines='false' jsQuoting='true'/>";
+                obligText = obligText.replace(/[\r\n]/g, '<br>');
+                obligText = obligText.replace(/\t/g, '&ensp;&ensp;&ensp;&ensp;');
                 result.push({
                     DT_RowId: "${oblig.id}",
                     id: "${oblig.id}",
                     title: "<sw360:out value='${oblig.title}'/>",
-                    text: "<sw360:out value='${oblig.text}'/>",
+                    text: '<p style="overflow: auto; max-height: 10rem;">'+obligText+'</p>',
                     obligationLevel: "<sw360:DisplayEnum value="${oblig.obligationLevel}"/>"
                 });
             </core_rt:forEach>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/licenses/includes/detailAddTodo.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/licenses/includes/detailAddTodo.jspf
@@ -49,12 +49,15 @@
     require(['jquery', 'modules/dialog', 'bridges/datatables', 'modules/validation', 'utils/render'], function($, dialog, datatables, validation, render) {
         var licenseObligationJSON = [];
         <core_rt:forEach var="ob" varStatus="status" items="${linkedObligations}">
+            var obligText = "<sw360:out value='${ob.text}' stripNewlines='false' jsQuoting='true'/>";
+            obligText = obligText.replace(/[\r\n]/g, '<br>');
+            obligText = obligText.replace(/\t/g, '&ensp;&ensp;&ensp;&ensp;');
             licenseObligationJSON.push({
                 "DT_RowId": "oblLinkRow${ob.id}",
                 "obligationId": "<sw360:out value='${ob.id}'/>",
                 "obligationTitle": "<sw360:out value='${ob.title}'/>",
                 "obligationType": "<sw360:DisplayEnum value='${ob.obligationType}'/>",
-                "text": "<sw360:out value='${ob.text}'/>",
+                "text": '<p style="overflow: auto; max-height: 20rem;">'+obligText+'</p>',
             });
         </core_rt:forEach>
 

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/licenses/includes/detailTodos.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/licenses/includes/detailTodos.jspf
@@ -114,11 +114,14 @@
         var licenseObligationJSON = [];
         <core_rt:forEach var="ob" varStatus="status" items="${licenseDetail.obligations}">
             <core_rt:if test="${not empty ob.whitelist}">
+            var obText = "<sw360:out value='${ob.text}' stripNewlines='false' jsQuoting='true'/>";
+            obText = obText.replace(/[\r\n]/g, '<br>');
+            obText = obText.replace(/\t/g, '&ensp;&ensp;&ensp;&ensp;');
             licenseObligationJSON.push({
                 "obligationId": "<sw360:out value='${ob.id}'/>",
                 "obligationType": "<sw360:DisplayEnum value='${ob.obligationType}'/>",
                 "obligationTitle": "<sw360:out value='${ob.title}'/>",
-                "text": "<sw360:out value='${ob.text}'/>",
+                "text": obText,
             });
             </core_rt:if>
         </core_rt:forEach>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/licenses/includes/licObligations.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/licenses/includes/licObligations.jsp
@@ -46,12 +46,15 @@
     	
     var licenseObligationJSON = [];
     <core_rt:forEach var="ob" varStatus="status" items="${obligationList}">
+        var obligText = "<sw360:out value='${ob.text}' stripNewlines='false' jsQuoting='true'/>";
+        obligText = obligText.replace(/[\r\n]/g, '<br>');
+        obligText = obligText.replace(/\t/g, '&ensp;&ensp;&ensp;&ensp;');
     	licenseObligationJSON.push({
     		"DT_RowId": "oblLinkRow${ob.id}",
             "obligationId": "<sw360:out value='${ob.id}'/>",
             "obligationType": "<sw360:DisplayEnum value='${ob.obligationType}'/>", 
             "obligationTitle": "<sw360:out value='${ob.title}'/>",
-            "text": "<sw360:out value='${ob.text}'/>",
+            "text": '<p style="overflow: auto; max-height: 10rem;">'+obligText+'</p>',
         });
     </core_rt:forEach>
     

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligations.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligations.jspf
@@ -201,7 +201,9 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
                 releaseNames.push("<sw360:out value='${release.name}'/> (<sw360:out value='${release.version}'/>)");
             </core_rt:forEach >
         </core_rt:if>
-
+        var obligText = "<sw360:out value='${projectObligations.text}' stripNewlines='false' jsQuoting='true'/>";
+        obligText = obligText.replace(/[\r\n]/g, '<br>');
+        obligText = obligText.replace(/\t/g, '&ensp;&ensp;&ensp;&ensp;');
         obligationJSON.push({
             "obligation": "<sw360:out value='${entry.key}'/>",
             "lIds": licenseIds.join(', <br>'),
@@ -212,7 +214,7 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
             "type": "<sw360:DisplayEnum value='${projectObligations.obligationType}'/>",
             "id": "<sw360:out value='${projectObligations.id}'/>",
             "comment": "<sw360:out value='${projectObligations.comment}'/>",
-            "text": '<sw360:out value="${projectObligations.text}"/>',
+            "text": '<p style="overflow: auto; max-height: 20rem;">'+obligText+'</p>',
             "modifiedBy": '${projectObligations.modifiedBy}',
             "modifiedOn": '${projectObligations.modifiedOn}'
         });
@@ -342,13 +344,16 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
 
     //project Obligation
     <core_rt:forEach items="${projectLevelObligations}" var="projOblig" varStatus="loop">
+    var obligText = "<sw360:out value='${projOblig.value.text}' stripNewlines='false' jsQuoting='true'/>";
+    obligText = obligText.replace(/[\r\n]/g, '<br>');
+    obligText = obligText.replace(/\t/g, '&ensp;&ensp;&ensp;&ensp;');
     projectObligationJSON.push({
         "obligation": "<sw360:out value='${projOblig.key}'/>",
         "status": "<sw360:DisplayEnum value='${projOblig.value.status}'/>",
         "type": "<sw360:DisplayEnum value='${projOblig.value.obligationType}'/>",
         "id": "<sw360:out value='${projOblig.value.id}'/>",
         "comment": "<sw360:out value='${projOblig.value.comment}'/>",
-        "text": '<sw360:out value="${projOblig.value.text}"/>',
+        "text": '<p style="overflow: auto; max-height: 20rem;">'+obligText+'</p>',
         "modifiedBy": '${projOblig.value.modifiedBy}',
         "modifiedOn": '${projOblig.value.modifiedOn}'
     });
@@ -428,13 +433,16 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
 
     //Comp Obligation
     <core_rt:forEach items="${componentLevelObligations}" var="compOblig" varStatus="loop">
+      var obligText = "<sw360:out value='${compOblig.value.text}' stripNewlines='false' jsQuoting='true'/>";
+      obligText = obligText.replace(/[\r\n]/g, '<br>');
+      obligText = obligText.replace(/\t/g, '&ensp;&ensp;&ensp;&ensp;');
       compObligationJSON.push({
         "obligation": "<sw360:out value='${compOblig.key}'/>",
         "status": "<sw360:DisplayEnum value='${compOblig.value.status}'/>",
         "type": "<sw360:DisplayEnum value='${compOblig.value.obligationType}'/>",
         "id": "<sw360:out value='${compOblig.value.id}'/>",
         "comment": "<sw360:out value='${compOblig.value.comment}'/>",
-        "text": '<sw360:out value="${compOblig.value.text}"/>',
+        "text": '<p style="overflow: auto; max-height: 20rem;">'+obligText+'</p>',
         "modifiedBy": '${compOblig.value.modifiedBy}',
         "modifiedOn": '${compOblig.value.modifiedOn}'
       });
@@ -514,13 +522,16 @@ require(['jquery', 'bridges/datatables', 'utils/render'], function ($, datatable
 
     //Org Obligation
     <core_rt:forEach items="${organisationLevelObligations}" var="orgOblig" varStatus="loop">
+    var obligText = "<sw360:out value='${orgOblig.value.text}' stripNewlines='false' jsQuoting='true'/>";
+    obligText = obligText.replace(/[\r\n]/g, '<br>');
+    obligText = obligText.replace(/\t/g, '&ensp;&ensp;&ensp;&ensp;');
     orgObligationJSON.push({
         "obligation": "<sw360:out value='${orgOblig.key}'/>",
         "status": "<sw360:DisplayEnum value='${orgOblig.value.status}'/>",
         "type": "<sw360:DisplayEnum value='${orgOblig.value.obligationType}'/>",
         "id": "<sw360:out value='${orgOblig.value.id}'/>",
         "comment": "<sw360:out value='${orgOblig.value.comment}'/>",
-        "text": '<sw360:out value="${orgOblig.value.text}"/>',
+        "text": '<p style="overflow: auto; max-height: 20rem;">'+obligText+'</p>',
         "modifiedBy": '${orgOblig.value.modifiedBy}',
         "modifiedOn": '${orgOblig.value.modifiedOn}'
     });

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligationsEdit.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/obligationsEdit.jspf
@@ -230,6 +230,9 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
             </core_rt:forEach>
         </core_rt:if>
 
+        var obligText = "<sw360:out value='${projectObligations.text}' stripNewlines='false' jsQuoting='true'/>";
+        obligText = obligText.replace(/[\r\n]/g, '<br>');
+        obligText = obligText.replace(/\t/g, '&ensp;&ensp;&ensp;&ensp;');
         obligationJSON.push({
             "obligation": "<sw360:out value='${entry.key}'/>",
             "licenseLinks": licenseLinks,
@@ -240,7 +243,7 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
             "level": "${projectObligations.obligationLevel}",
             "id": "<sw360:out value='${projectObligations.id}'/>",
             "comment": "<sw360:out value='${projectObligations.comment}'/>",
-            "text": '<sw360:out value="${projectObligations.text}"/>',
+            "text": '<p style="overflow: auto; max-height: 20rem;">'+obligText+'</p>',
             "modifiedBy": "${projectObligations.modifiedBy}",
             "modifiedOn": "${projectObligations.modifiedOn}"
         });
@@ -526,13 +529,16 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
     
     //project Obligation
     <core_rt:forEach items="${projectLevelObligations}" var="projOblig" varStatus="loop">
+    var obligText = "<sw360:out value='${projOblig.value.text}' stripNewlines='false' jsQuoting='true'/>";
+    obligText = obligText.replace(/[\r\n]/g, '<br>');
+    obligText = obligText.replace(/\t/g, '&ensp;&ensp;&ensp;&ensp;');
     projectObligationJSON.push({
         "obligation": "<sw360:out value='${projOblig.key}'/>",
         "status": '<sw360:DisplayEnumOptions type="<%=ObligationStatus.class%>" selected="${projOblig.value.status}" />',
         "type": "<sw360:DisplayEnum value='${projOblig.value.obligationType}'/>",
         "id": "<sw360:out value='${projOblig.value.id}'/>",
         "comment": "<sw360:out value='${projOblig.value.comment}'/>",
-        "text": '<sw360:out value="${projOblig.value.text}"/>',
+        "text": '<p style="overflow: auto; max-height: 20rem;">'+obligText+'</p>',
         "modifiedBy": "${projOblig.value.modifiedBy}",
         "modifiedOn": "${projOblig.value.modifiedOn}"
     });
@@ -614,13 +620,16 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
     
     //component Obligation
     <core_rt:forEach items="${componentLevelObligations}" var="compOblig" varStatus="loop">
+    var obligText = "<sw360:out value='${compOblig.value.text}' stripNewlines='false' jsQuoting='true'/>";
+    obligText = obligText.replace(/[\r\n]/g, '<br>');
+    obligText = obligText.replace(/\t/g, '&ensp;&ensp;&ensp;&ensp;');
     compObligationJSON.push({
         "obligation": "<sw360:out value='${compOblig.key}'/>",
         "status": '<sw360:DisplayEnumOptions type="<%=ObligationStatus.class%>" selected="${compOblig.value.status}" />',
         "type": "<sw360:DisplayEnum value='${compOblig.value.obligationType}'/>",
         "id": "<sw360:out value='${compOblig.value.id}'/>",
         "comment": "<sw360:out value='${compOblig.value.comment}'/>",
-        "text": '<sw360:out value="${compOblig.value.text}"/>',
+        "text": '<p style="overflow: auto; max-height: 20rem;">'+obligText+'</p>',
         "modifiedBy": "${compOblig.value.modifiedBy}",
         "modifiedOn": "${compOblig.value.modifiedOn}"
     });
@@ -702,13 +711,16 @@ require(['jquery', 'bridges/datatables', 'utils/render', 'modules/button', 'modu
     
     //Org Obligation
     <core_rt:forEach items="${organisationLevelObligations}" var="orgOblig" varStatus="loop">
+      var obligText = "<sw360:out value='${orgOblig.value.text}' stripNewlines='false' jsQuoting='true'/>";
+      obligText = obligText.replace(/[\r\n]/g, '<br>');
+      obligText = obligText.replace(/\t/g, '&ensp;&ensp;&ensp;&ensp;');
       orgObligationJSON.push({
           "obligation": "<sw360:out value='${orgOblig.key}'/>",
           "status": '<sw360:DisplayEnumOptions type="<%=ObligationStatus.class%>" selected="${orgOblig.value.status}" />',
           "type": "<sw360:DisplayEnum value='${orgOblig.value.obligationType}'/>",
           "id": "<sw360:out value='${orgOblig.value.id}'/>",
           "comment": "<sw360:out value='${orgOblig.value.comment}'/>",
-          "text": '<sw360:out value="${orgOblig.value.text}"/>',
+          "text": '<p style="overflow: auto; max-height: 20rem;">'+obligText+'</p>',
           "modifiedBy": "${orgOblig.value.modifiedBy}",
           "modifiedOn": "${orgOblig.value.modifiedOn}"
       });

--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -1456,7 +1456,24 @@ id=Id
 templates=Templates
 osi.approved=OSI Approved?
 fsf.free.libre=FSF Free/Libre?
-
+do.you.really.want.to.import.all.osadl.license.obligations=Do you really want to import all OSADL license obligations?
+error.happened.during.license.obligation.importing.some.license.obliations.may.not.be.imported=Error happened during license obligation importing. Some license obligations may not be imported.
+i.imported.x.out.of.y.osadl.license.obliations=I imported ${data.totalAffectedObjects} out of ${data.totalObjects} OSADL license obligation(s).
+import.osadl.information=Import OSADL Information
+import.osadl.license.obligations=Import OSADL license obligations
+importing.process.is.running.it.may.takes.a.few.minutes=Importing process is running. It may takes a few minutes.
+list.of.licenses.could.not.be.imported=List of licenses could not be imported:
+list.of.licenses.were.imported=List of licenses were imported:
+index=No.
+importing.process.is.already.running.please.try.again.later=Importing process is already running. Please try again later.
+child=Child
+sibling=Sibling
+preview=Preview
+language.element=Language Element
+object=Object
+import.obligation.element=Import Obligation Element
+input=Input
+an.obligation.with.the.same.name.already.exists=An Obligation with the same name already exists.
 ## Refer to http://cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/ and add your datatables language
 
 datatables.lang=https://cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/English.json

--- a/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
@@ -1456,6 +1456,17 @@ id=Id
 templates=テンプレート
 osi.approved=OSI 承認か否か
 fsf.free.libre=FSF Free/Libre
+templates=Templates
+do.you.really.want.to.import.all.osadl.license.obligations=本当に全てのOSDALのライセンスオブリゲーション情報をインポートしますか？
+error.happened.during.license.obligation.importing.some.license.obliations.may.not.be.imported=ライセンスオブリゲーション取得中にエラーが起きました．いくつかのオブリゲーション取得に失敗した可能性があります．
+i.imported.x.out.of.y.osadl.license.obliations=${data.totalObjects}件の中${data.totalAffectedObjects}件のライセンスオブリゲーションをOSDALからインポートしました．
+import.osadl.information=OSADL情報のインポート
+import.osadl.license.obligations=OSADLライセンスオブリゲーションのインポート
+importing.process.is.running.it.may.takes.a.few.minutes=インポート中です．この作業には数分かかる場合があります．
+list.of.licenses.could.not.be.imported=インポート失敗ライセンス一覧：
+list.of.licenses.were.imported=インポート成功ライセンス一覧：
+index=No.
+importing.process.is.already.running.please.try.again.later=インポートプロセスはすでに実行されています。 後でもう一度やり直してください。
 
 ## Refer to http://cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/ and add your datatables language
 

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -1461,7 +1461,24 @@ id=Id
 templates=Templates
 osi.approved=OSI Approved?
 fsf.free.libre=FSF Free/Libre?
-
+do.you.really.want.to.import.all.osadl.license.obligations=Do you really want to import all OSADL license obligations?
+error.happened.during.license.obligation.importing.some.license.obliations.may.not.be.imported=Error happened during license obligation importing. Some license obligations may not be imported.
+i.imported.x.out.of.y.osadl.license.obliations=I imported ${data.totalAffectedObjects} out of ${data.totalObjects} OSADL license obligation(s).
+import.osadl.information=Import OSADL Information
+import.osadl.license.obligations=Import OSADL license obligations
+importing.process.is.running.it.may.takes.a.few.minutes=Importing process is running. It may takes a few minutes.
+list.of.licenses.could.not.be.imported=List of licenses could not be imported:
+list.of.licenses.were.imported=List of licenses were imported:
+index=No.
+importing.process.is.already.running.please.try.again.later=Importing process is already running. Please try again later.
+child=Con
+sibling=Anh em
+preview=Xem trước
+language.element=Thành phần ngôn ngữ
+object=Đối tượng
+import.obligation.element=Nhập nghĩa vụ thành phần
+input=Nhập
+an.obligation.with.the.same.name.already.exists=Nghĩa vụ có cùng tên đã tồn tại.
 ## Refer to http://cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/ and add your datatables language
 
 datatables.lang=https://cdn.datatables.net/plug-ins/9dcbecd42ad/i18n/Vietnamese.json

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Constants.java
@@ -70,6 +70,8 @@ public class SW360Constants {
     public static final String TYPE_SEARCHRESULT = "searchResult";
     public static final String TYPE_CHANGELOG = "changeLog";
     public static final String TYPE_VULNERABILITYDTO = "vulDTO";
+    public static final String TYPE_OBLIGATIONELEMENT = "obligationElement";
+    public static final String TYPE_OBLIGATIONNODE = "obligationNode";
 
     /**
      * Hashmap containing the name field for each type.

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftUtils.java
@@ -56,6 +56,8 @@ public class ThriftUtils {
             .add(AttachmentUsage.class) // Attachment service
             .add(Component.class).add(Release.class) // Component service
             .add(License.class).add(Obligation.class)
+            .add(ObligationElement.class)
+            .add(ObligationNode.class)
             .add(LicenseType.class) // License service
             .add(CustomProperties.class) // License service
             .add(Project.class).add(ObligationList.class).add(UsedReleaseRelations.class).add(ClearingRequest.class)  // Project service

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
@@ -69,6 +69,20 @@ public class ThriftValidate {
         licenseType.setType(TYPE_LICENSETYPE);
     }
 
+    public static void prepareObligationElement(ObligationElement obligationElement) throws SW360Exception {
+        // Check required fields
+        assertNotNull(obligationElement);
+        // Check type
+        obligationElement.setType(TYPE_OBLIGATIONELEMENT);
+    }
+
+    public static void prepareObligationNode(ObligationNode obligationNode) throws SW360Exception {
+        // Check required fields
+        assertNotNull(obligationNode);
+        // Check type
+        obligationNode.setType(TYPE_OBLIGATIONNODE);
+    }
+
     public static void prepareLicense(License license) throws SW360Exception {
         // Check required fields
         assertNotNull(license);

--- a/libraries/lib-datahandler/src/main/thrift/licenses.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/licenses.thrift
@@ -1,6 +1,8 @@
 /*
  * Copyright Siemens AG, 2014-2017. Part of the SW360 Portal Project.
  * With contributions by Bosch Software Innovations GmbH, 2016.
+ * With contributions by TOSHIBA CORPORATION, 2021.
+ * With contributions by Toshiba Software Development (Vietnam) Co., Ltd., 2021.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,6 +41,12 @@ enum ObligationType {
     OBLIGATION = 4
 }
 
+enum ObligationElementStatus {
+    UPDATED = 0,
+    DEFINED = 1
+    UNDEFINED = 2
+}
+
 struct Obligation {
     1: optional string id,
     2: optional string revision,
@@ -60,6 +68,7 @@ struct Obligation {
     22: optional ObligationLevel obligationLevel,
     23: optional ObligationType obligationType,
     300: optional map<string, string> additionalData,
+    97: optional string node,
 
 }
 
@@ -69,6 +78,25 @@ struct LicenseType {
     3: optional string type = "licenseType",
 	5: required i32 licenseTypeId,
     6: required string licenseType;
+}
+
+struct ObligationNode {
+    1: optional string id,
+    2: optional string revision,
+    3: optional string type = "obligationNode",
+    4: optional string nodeType,
+    5: optional string nodeText,
+    6: optional string oblElementId
+}
+
+struct ObligationElement {
+    1: optional string id,
+    2: optional string revision,
+    3: optional string type = "obligationElement",
+    4: required string langElement,
+    5: required string action,
+    6: required string object,
+    7: optional ObligationElementStatus status
 }
 
 struct License {
@@ -245,6 +273,8 @@ service LicenseService {
     RequestSummary deleteAllLicenseInformation(1: User user);
 
     RequestSummary importAllSpdxLicenses(1: User user);
+
+    RequestSummary importAllOSADLLicenses(1: User user);
     /**
      * delete obligation from database if user has permissions
      **/
@@ -259,4 +289,50 @@ service LicenseService {
      * Check license type is in using by license
      **/
     int checkLicenseTypeInUse(1: string id);
+
+    /* Add a new Obligation Element object to database, return id
+    **/
+    string addObligationElements(1:ObligationElement obligationElement, 2: User user);
+
+    /**
+     * get complete list of filled obligation elements
+     **/
+    list<ObligationElement> getObligationElements();
+
+    /**
+     * Add a new Obligation Node object to database, return id
+     **/
+    string addObligationNodes(1:ObligationNode obligationNode, 2: User user);
+
+    /**
+     * get complete list of filled obligation nodes
+     **/
+    list<ObligationNode> getObligationNodes();
+
+    /**
+     * get ObligationNode by id
+     **/
+    ObligationNode getObligationNodeById( 1: string id);
+
+    /**
+     * get ObligationElement by id
+     **/
+    ObligationElement getObligationElementById( 1: string id);
+
+    /**
+     * add ObligationNode from jsonString input
+     **/
+    string addNodes(1:string jsonString, 2: User user)
+
+    /**
+     * build obligation text after addNodes
+     **/
+    string buildObligationText(1: string nodes, 2: string level)
+
+    // Search functions
+
+    /**
+     * global search function to list obigation elements which match the text argument
+     */
+    list<ObligationElement> searchObligationElement(1: string text);
 }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -579,6 +579,7 @@ public class JacksonCustomizations {
                 "comments",
                 "additionalData",
                 "additionalDataSize",
+                "node",
                 "setId",
                 "setRevision",
                 "setType",
@@ -594,7 +595,8 @@ public class JacksonCustomizations {
                 "setComments",
                 "setObligationLevel",
                 "setObligationType",
-                "setAdditionalData"
+                "setAdditionalData",
+                "setNode"
         })
         static abstract class ObligationMixin extends Obligation {
         }


### PR DESCRIPTION
Signed-off-by: Tran Vu Quan <quan1.tranvu@toshiba.co.jp>

> Please provide a summary of your changes here.
> * Import Obligation information from https://www.osadl.org/
> * New GUI for Adding obligation screen

Issue: https://github.com/eclipse/sw360/issues/513

### How To Test?
> 1. Import Obligation information
> - Open 'Admin Licenses' screen
> - Click 'Import OSADL Information', then click 'Import OSADL license obligations' in the popup dialog (Make sure that you
> already got licenses registered in SW360 system).
> - After importing successfully, open 'Admin Obligations' screen, obligations information from OSADL  will be displayed in the table
> 2. Add obligation screen
> Refer: https://github.com/eclipse/sw360/issues/513#issuecomment-877964654

> Have you implemented any additional tests? No

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
