### PR TITLE
fix(ui): Fix the bug that attachments usages in project can not show "other" line correctly

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentUsagesRows.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentUsagesRows.jspf
@@ -51,6 +51,7 @@
             <td></td>
             <td></td>
             <td></td>
+            <td></td>
         </tr>
     </core_rt:if>
     <%--linked releases of linked projects--%>
@@ -68,6 +69,7 @@
             <td>
 		<sw360:DisplayEnum value="${releaseLink.releaseRelationship}"/>
             </td>
+            <td></td>
             <td></td>
             <td></td>
             <td></td>


### PR DESCRIPTION
Signed-off-by: Shi Qiu <shi1.qiu@toshiba.co.jp>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Fix the bug that attachments usages in project can not show "other" line correctly.

> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)

Issue: #1354 

Just add two TD tags.

> * Did you add or update any new dependencies that are required for your change?

No.


### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?

Upload some attachments and check the "Attachment Usages" page of a project.

> Have you implemented any additional tests?

No.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
