### PR TITLE
fix(rest): Fixed hateoas link not showing correct protocol

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/Sw360ResourceServer.java
@@ -21,6 +21,7 @@ import org.eclipse.sw360.rest.resourceserver.security.apiToken.ApiTokenAuthentic
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -30,6 +31,7 @@ import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurerAdapt
 import org.springframework.hateoas.UriTemplate;
 import org.springframework.hateoas.hal.CurieProvider;
 import org.springframework.hateoas.hal.DefaultCurieProvider;
+import org.springframework.web.filter.ForwardedHeaderFilter;
 
 @SpringBootApplication
 @Import(Sw360CORSFilter.class)
@@ -93,5 +95,12 @@ public class Sw360ResourceServer extends SpringBootServletInitializer {
             .properties(PropertyUtils.createDefaultProperties(APPLICATION_ID))
             .build()
             .run(args);
+    }
+
+    @Bean
+    public FilterRegistrationBean<ForwardedHeaderFilter> forwardedHeaderFilter() {
+        FilterRegistrationBean<ForwardedHeaderFilter> bean = new FilterRegistrationBean<>();
+        bean.setFilter(new ForwardedHeaderFilter());
+        return bean;
     }
 }


### PR DESCRIPTION
> Fixed hateoas link not showing correct protocol.
> * Which issue is this pull request belonging to and how is it solving it? (*#1385*)
> * Did you add or update any new dependencies that are required for your change? - No

Issue: closes #1385 

### How To Test?
> Perform sanity check of all rest apis.
> verify if ssl is enabled then response body link should be `https` instead of `http`

> Have you implemented any additional tests? - No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>