### PR TITLE
fix(rest): Get component by name case insensitive

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -1875,8 +1875,8 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
         return DatabaseHandlerUtil.getCyclicLinkedPath(release, this, user);
     }
 
-    public List<Component> searchComponentByNameForExport(String name) {
-        return componentRepository.searchByNameForExport(name);
+    public List<Component> searchComponentByNameForExport(String name, boolean caseSensitive) {
+        return componentRepository.searchByNameForExport(name, caseSensitive);
     }
 
     public Set<Component> getUsingComponents(String releaseId) {

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentRepository.java
@@ -215,8 +215,13 @@ public class ComponentRepository extends SummaryAwareRepository<Component> {
         return queryForIdsAsValue("byname", name);
     }
 
-    public List<Component> searchByNameForExport(String name) {
-        Set<String> componentIds = queryForIdsAsValueByPrefix("fullbyname", name);
+    public List<Component> searchByNameForExport(String name, boolean caseSensitive) {
+        Set<String> componentIds;
+        if (caseSensitive) {
+            componentIds = queryForIdsAsValueByPrefix("fullbyname", name);
+        } else {
+            componentIds = queryForIdsAsValueByPrefix("bynamelowercase", name);
+        }
         final List<Component> componentList = new ArrayList<Component>(getFullDocsById(componentIds));
         return makeSummaryFromFullDocs(SummaryType.EXPORT_SUMMARY, componentList);
     }

--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -438,8 +438,8 @@ public class ComponentHandler implements ComponentService.Iface {
     }
 
     @Override
-    public List<Component> searchComponentForExport(String name) throws TException {
-        return handler.searchComponentByNameForExport(name);
+    public List<Component> searchComponentForExport(String name, boolean caseSensitive) throws TException {
+        return handler.searchComponentByNameForExport(name, caseSensitive);
     }
 
     @Override

--- a/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/thrift/ThriftExchange.java
+++ b/backend/src/src-wsimport/src/main/java/org/eclipse/sw360/wsimport/thrift/ThriftExchange.java
@@ -155,7 +155,7 @@ public class ThriftExchange {
 
     public Optional<List<Component>> searchComponentByName(String name) {
         try {
-            return Optional.of(thriftClients.makeComponentClient().searchComponentForExport(name));
+            return Optional.of(thriftClients.makeComponentClient().searchComponentForExport(name, true));
         } catch (TException e) {
             LOGGER.error("Could not fetch Component list for name=[" + name + "]:" + e);
             return Optional.empty();

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -653,7 +653,7 @@ service ComponentService {
     /**
      * get export summary for components whose name is matching parameter name
      **/
-    list<Component> searchComponentForExport(1: string name);
+    list<Component> searchComponentForExport(1: string name, 2: bool caseSensitive);
 
     /**
      *  get component with fossologyId equal to uploadId, filled with releases and main licenses,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/component/Sw360ComponentService.java
@@ -146,7 +146,7 @@ public class Sw360ComponentService implements AwareOfRestServices<Component> {
 
     public List<Component> searchComponentByName(String name) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
-        return sw360ComponentClient.searchComponentForExport(name);
+        return sw360ComponentClient.searchComponentForExport(name.toLowerCase(), false);
     }
 
     private ComponentService.Iface getThriftComponentClient() throws TTransportException {


### PR DESCRIPTION
Signed-off-by: Smruti Prakash Sahoo <smruti.sahoo@siemens.com>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?

 -  Need to test the listing components by name endpoint w.r.t case sensitivity. 

> Have you implemented any additional tests? - No

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
