### PR TITLE
fix(rest): Change base url of health api from /actuator to /

### DIFF
--- a/rest/resource-server/src/main/resources/application.yml
+++ b/rest/resource-server/src/main/resources/application.yml
@@ -15,6 +15,8 @@ server:
 management:
   endpoints:
     enabled-by-default: false
+    web:
+      base-path:
   endpoint:
     health:
       enabled: true

--- a/scripts/docker-config/etc_sw360/rest/application.yml
+++ b/scripts/docker-config/etc_sw360/rest/application.yml
@@ -15,6 +15,8 @@ server:
 management:
   endpoints:
     enabled-by-default: false
+    web:
+      base-path:
   endpoint:
     health:
       enabled: true


### PR DESCRIPTION
> Change base url of health api from /actuator to /.
> * Which issue is this pull request belonging to and how is it solving it? (*#1404*)
> * Did you add or update any new dependencies that are required for your change? - No

Issue: closes #1404

### How To Test?
> Place `application.yml` in `/etc/sw360/rest/application.yml`
>  - Test Health, Info, Get Project by Id api as per documentation

> Have you implemented any additional tests? - No

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>