### PR TITLE
Update docker base using Eclipse Temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-FROM maven:3.6.3-openjdk-11-slim as builder
+FROM maven:3.8-eclipse-temurin-11 AS builder
 
 WORKDIR /app/build/sw360
 
@@ -26,7 +26,7 @@ RUN ./scripts/docker-config/install_scripts/build_couchdb_lucene.sh
 RUN ./scripts/docker-config/install_scripts/download_liferay_and_dependencies.sh
 
 
-FROM ubuntu:20.04
+FROM eclipse-temurin:11-jre
 
 WORKDIR /app/
 
@@ -55,7 +55,5 @@ RUN ./install-thrift.sh
 RUN ./install_init_postgres_script.sh
 
 RUN ./install_configure_couchdb.sh
-
-RUN DEBIAN_FRONTEND=noninteractive apt-get install openjdk-11-jdk -y --no-install-recommends
 
 ENTRYPOINT ./entry_point.sh && bash


### PR DESCRIPTION
Set docker image in same origin for builder and runtime images.

Eclipse Temurin is OpenJDK, Ubuntu LTS 20.04 based.
Maven builder image share the same core,
Using OpenJDK 11 based image reduces the docker build process and the
difference in runtime that used previously OpenJDK build from
Ubuntu distribution.

Signed-off-by: Helio Chissini de Castro <helio.chissini-de-castro@bmw.de>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
