### PR TITLE
chore(readme): Update release badge to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/eclipse/sw360.svg?branch=master)](https://travis-ci.org/eclipse/sw360)
 [![Slack Channel](https://img.shields.io/badge/slack-sw360chat-blue.svg?longCache=true&logo=slack)](https://join.slack.com/t/sw360chat/shared_invite/enQtNzg5NDQxMTQyNjA5LThiMjBlNTRmOWI0ZjJhYjc0OTk3ODM4MjBmOGRhMWRmN2QzOGVmMzQwYzAzN2JkMmVkZTI1ZjRhNmJlNTY4ZGI)
 [![Changelog](https://badgen.net/badge/changelog/%E2%98%85/blue)](https://github.com/eclipse/sw360/blob/master/CHANGELOG.md)
-[![version](https://img.shields.io/badge/version-13.4.0-blue)](https://github.com/eclipse/sw360/releases/tag/sw360-14.0.0-M1)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/eclipse/sw360)](https://github.com/eclipse/sw360/releases/latest)
 
 ### SW360 Portal
 


### PR DESCRIPTION
Update release badge to always point to latest release from GitHub.

### Suggest Reviewer
> No preference

### How To Test?
Check the badge on README. It should point to latest release.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
    > No related issues available

Signed-off-by: Gaurav Mishra <gmishx@gmail.com>