### PR TITLE
fix(ui): Search function does not work if Keyword is empty

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -70,6 +70,7 @@ public class PortalConstants {
     public static final String NO_FILTER = "noFilter";
     public static final String KEY_SEARCH_TEXT = "searchtext";
     public static final String KEY_SEARCH_FILTER_TEXT = "searchfilter";
+    public static final String SUBMIT_SEARCH = "submitSearch";
     public static final String DOCUMENT_ID = "documentID";
     public static final String PAGENAME = "pagename";
     public static final String PAGENAME_DETAIL = "detail";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/search/SearchPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/search/SearchPortlet.java
@@ -61,6 +61,7 @@ public class SearchPortlet extends Sw360Portlet {
         String searchtext = request.getParameter(KEY_SEARCH_TEXT);
         String[] typeMaskArray = request.getParameterValues(TYPE_MASK);
         String searchQuery = PortalUtil.getOriginalServletRequest(PortalUtil.getHttpServletRequest(request)).getParameter("q");
+        String submitSearch = request.getParameter(SUBMIT_SEARCH);
 
         List<String> typeMask;
         if (typeMaskArray != null) { // premature optimization would add && typeMaskArray.length<6
@@ -70,8 +71,12 @@ public class SearchPortlet extends Sw360Portlet {
             log.info("typeMask set to emptyList");
         }
 
-        if (isNullOrEmpty(searchtext)) {
-            searchtext = searchQuery;
+        if (isNullOrEmpty(searchtext) && !isNullOrEmpty(submitSearch)) {
+            if (isNullOrEmpty(searchQuery)) {
+                searchtext = " ";
+            } else {
+                searchtext = searchQuery;
+            }
         }
         searchtext = Strings.nullToEmpty(searchtext);
 
@@ -82,6 +87,10 @@ public class SearchPortlet extends Sw360Portlet {
         } catch (TException e) {
             log.error("Search could not be performed!", e);
             searchResults = Collections.emptyList();
+        }
+
+        if (isNullOrEmpty(request.getParameter(KEY_SEARCH_TEXT))) {
+            searchtext = "";
         }
 
         // Set the results

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/search/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/search/view.jsp
@@ -20,6 +20,7 @@
 <%@ page import="org.eclipse.sw360.portal.common.PortalConstants" %>
 
 <portlet:renderURL var="edit">
+    <portlet:param name="<%=PortalConstants.SUBMIT_SEARCH%>" value='<%=PortalConstants.SUBMIT_SEARCH%>'/>
 </portlet:renderURL>
 
 <jsp:useBean id="searchtext" type="java.lang.String" scope="request"/>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/images/icons.svg
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/images/icons.svg
@@ -38,5 +38,17 @@
             <path d="M16.739 0v6.379c4.108 0.616 7.511 3.795 8.189 8.135s-1.622 8.521-5.577 10.355c-3.493 1.62-8.313 0.926-11.045-2.415v7.831c1.321 0.748 7.096 3.266 13.633 0.314s10.31-9.957 9.202-17.056c-1.108-7.098-6.926-12.876-14.401-13.544z"></path>
             <path d="M14.8 0.056c-7.808 0.662-13.87 6.336-14.8 14.719v17.199h6.332v-12.248h7.911v-6.329h-7.569c1.089-3.915 4.45-6.571 8.126-7.063z"></path>
         </symbol>
+        <symbol id="oblig">
+            <g id="Group_2" data-name="Group 2" transform="translate(-620.824 -423.396)">
+                <rect id="Rectangle_1" data-name="Rectangle 1" width="19.19" height="19.19" rx="2" transform="translate(620.824 423.396)"/>
+                <g id="Group_1" data-name="Group 1" transform="translate(-36.360 -1.104)">
+                    <g id="rect1055" transform="translate(660.595 424.5)">
+                        <text id="O" transform="translate(0 15)" fill="#fff" font-size="16" font-family="sans-serif" font-weight="700">
+                            <tspan x="0" y="0">O</tspan>
+                        </text>
+                    </g>
+                </g>
+            </g>
+        </symbol>
     </defs>
 </svg>


### PR DESCRIPTION
Signed-off-by: Tran Vu Quan <quan1.tranvu@toshiba.co.jp>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> In Search screen, if you leave the Keyword empty, there will be no data in the table after searching finished.
> 
> But if Keyword is filled with some space characters, depend on which Type is checked, all the data of that Type will be displayed.
>
> Expectation: if Keyword is empty, returns all data of selected Type.

Issue: https://github.com/eclipse/sw360/issues/1430

### How To Test?
> 1. From Main menu, open 'Search' screen.
> 2. Leave Keyword empty, and not check any Type, click 'Search': all data of all Types is displayed.
> 3. Leave Keyword empty, check some Types, click 'Search': all data of checked Types is displayed.

### Checklist
Must:
- [x] All related issues are referenced in PR
