### PR TITLE
fix(api): Correct the ECC status when release is created by API

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -1105,7 +1105,9 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
                 eccInfo.setAL(ECC_AUTOSET_VALUE);
                 eccInfo.setECCN(ECC_AUTOSET_VALUE);
                 eccInfo.setEccComment(ECC_AUTOSET_COMMENT);
-                eccInfo.setEccStatus(ECCStatus.APPROVED);
+                if (DatabaseHandlerUtil.AUTO_SET_ECC_STATUS) {
+                    eccInfo.setEccStatus(ECCStatus.APPROVED);
+                }
                 eccInfo.setAssessmentDate(SW360Utils.getCreatedOn());
             } else {
                 log.warn("Could not set ECC options for unmodified OSS because download url is not valid: " + url);

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtil.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/DatabaseHandlerUtil.java
@@ -128,6 +128,7 @@ public class DatabaseHandlerUtil {
     private static final String SW360CHANGELOG_OUTPUT_PATH;
     private static boolean isChangeLogDisabledMessageLogged = false;
     private static boolean isLiferayEnvVarNotPresent = true;
+    public static final boolean AUTO_SET_ECC_STATUS;
 
     static {
         Properties props = CommonUtils.loadProperties(DatabaseSettings.class, PROPERTIES_FILE_PATH);
@@ -143,6 +144,7 @@ public class DatabaseHandlerUtil {
                 "/etc/sw360/log4j2.xml");
         SW360CHANGELOG_OUTPUT_PATH = props.getProperty("sw360changelog.output.path",
                 "sw360changelog/sw360changelog");
+        AUTO_SET_ECC_STATUS = Boolean.parseBoolean(props.getProperty("auto.set.ecc.status", "false"));
     }
 
     public DatabaseHandlerUtil(DatabaseConnectorCloudant db) {

--- a/backend/src-common/src/main/resources/sw360.properties
+++ b/backend/src-common/src/main/resources/sw360.properties
@@ -78,4 +78,4 @@ textForRejectedClearingRequest= your clearing request with id: %s for the projec
 #sw360changelog.config.file.location=/etc/sw360/log4j2.xml
 enable.sw360.change.log=false
 sw360changelog.output.path=sw360changelog/sw360changelog
-
+auto.set.ecc.status=false


### PR DESCRIPTION
Signed-off-by: Tran Vu Quan <quan1.tranvu@toshiba.co.jp>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * When new Release is created by using API, if Source Code download URL is provided, the ECC status is automatically set as 'Approved';
> * ECC should be approved manually by user
> * With this PR, this automation setting can be configured in the file: backend/src-common/src/main/resources/sw360.properties - key 'auto.set.ecc.status'
> * auto.set.ecc.status = true: ECC status will be automatically set as 'Approved' if Source Code download ULR is provided correctly
> * auto.set.ecc.status = false: ECC status will be always set as 'Open' 

Issue: https://github.com/eclipse/sw360/issues/1454

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> A. Configuration: auto.set.ecc.status = true
> 1. Create a new Release with API: sourceCodeDownloadurl is in correct URL format
> 2. Open the recently created Release page, tab 'ECC Details': ECC Status should be 'Approved'
> 3. Open ECC list page, the ECC Status of recently created Release should be 'Approved'
>
> B. Configuration: auto.set.ecc.status = false
> 1. Create a new Release with API: sourceCodeDownloadurl is in correct URL format
> 2. Open the recently created Release page, tab 'ECC Details': ECC Status should be 'Open'
> 3. Open ECC list page, the ECC Status of recently created Release should be 'Open'

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
