### PR TITLE
fix(ReleaseClearingState): ClearingState not changing to New from Scan Available

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/detailOverview.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/detailOverview.jspf
@@ -61,22 +61,20 @@
                         <div class="btn-toolbar" role="toolbar">
                             <div class="btn-group" role="group">
                                 <button id="changeReleaseButton" type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    <core_rt:if test="${release.clearingState.value == 4}"><span class="badge badge-circle badge-success"></span></core_rt:if>
-                                    <core_rt:if test="${release.clearingState.value == 0}"><span class="badge badge-circle badge-danger"></span></core_rt:if>
-                                    <core_rt:if test="${release.clearingState.value == 1}"><span class="badge badge-circle badge-danger"></span></core_rt:if>
-                                    <core_rt:if test="${release.clearingState.value == 2}"><span class="badge badge-circle badge-warning"></span></core_rt:if>
-                                    <core_rt:if test="${release.clearingState.value == 3}"><span class="badge badge-circle badge-warning"></span></core_rt:if>
+                                    <core_rt:set var = "clearingState" value = "${release.clearingState.value}"/>
+                                    <core_rt:if test="${clearingState == 4}"><span class="badge badge-circle badge-success"></span></core_rt:if>
+                                    <core_rt:if test="${clearingState == 0 || clearingState == 1}"><span class="badge badge-circle badge-danger"></span></core_rt:if>
+                                    <core_rt:if test="${clearingState == 2 || clearingState == 3 || clearingState == 5}"><span class="badge badge-circle badge-warning"></span></core_rt:if>
                                     <liferay-ui:message key="version" /> <sw360:out value="${release.version}"/>
                                     <clay:icon symbol="caret-bottom" />
                                 </button>
                                 <div class="dropdown-menu" aria-labelledby="changeReleaseButton">
                                     <core_rt:forEach var="releaseItr" items="${component.releases}">
+                                        <core_rt:set var = "clrngState" value = "${releaseItr.clearingState.value}"/>
                                         <a class="dropdown-item" href="<portlet:renderURL ><portlet:param name="<%=PortalConstants.COMPONENT_ID%>" value="${component.id}"/><portlet:param name="<%=PortalConstants.RELEASE_ID%>" value="${releaseItr.id}"/><portlet:param name="<%=PortalConstants.PAGENAME%>" value="<%=PortalConstants.PAGENAME_RELEASE_DETAIL%>"/></portlet:renderURL>">
-                                            <core_rt:if test="${releaseItr.clearingState.value == 4}"><span class="badge badge-circle badge-success"></span></core_rt:if>
-                                            <core_rt:if test="${releaseItr.clearingState.value == 0}"><span class="badge badge-circle badge-danger"></span></core_rt:if>
-                                            <core_rt:if test="${releaseItr.clearingState.value == 1}"><span class="badge badge-circle badge-danger"></span></core_rt:if>
-                                            <core_rt:if test="${releaseItr.clearingState.value == 2}"><span class="badge badge-circle badge-warning"></span></core_rt:if>
-                                            <core_rt:if test="${releaseItr.clearingState.value == 3}"><span class="badge badge-circle badge-warning"></span></core_rt:if>
+                                            <core_rt:if test="${clrngState == 4}"><span class="badge badge-circle badge-success"></span></core_rt:if>
+                                            <core_rt:if test="${clrngState == 0 || clrngState == 1}"><span class="badge badge-circle badge-danger"></span></core_rt:if>
+                                            <core_rt:if test="${clrngState == 2 || clrngState == 3 || clrngState == 5}"><span class="badge badge-circle badge-warning"></span></core_rt:if>
                                             <liferay-ui:message key="version" /> <sw360:out value="${releaseItr.version}"/>
                                         </a>
                                     </core_rt:forEach>

--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -672,6 +672,7 @@ infoempty=Showing 0 to 0 of 0 entries
 inner.source=Inner Source
 in.case.you.need.the.clearing.at.an.earlier.date.then.the.preferred.date.that.is.available.please.check.the.critical.checkbox.and.reselect.the.preferred.clearing.date=In case you need the clearing at an earlier date than the preferred date that is available, please check the critical checkbox and reselect the preferred clearing date
 in.order.to.go.ahead.please.sign.in.or.create.a.new.account=In order to go ahead, please sign in or create a new account!
+in.progress=In Progress
 in.queue=In Queue
 inaccessible.component=Restricted component
 inaccessible.count=Other restricted items

--- a/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
@@ -672,6 +672,7 @@ infoempty=0件中0件から0件を表示
 inner.source=内部ソース
 in.case.you.need.the.clearing.at.an.earlier.date.then.the.preferred.date.that.is.available.please.check.the.critical.checkbox.and.reselect.the.preferred.clearing.date=希望日よりも早い時期にクリアリングが必要な場合は、重要なチェックボックスにチェックを入れ、希望するクリアリング希望日を選択し直してください。
 in.order.to.go.ahead.please.sign.in.or.create.a.new.account=先に進むためには、サインインするか、新しいアカウントを作成してください
+in.progress=In Progress
 in.queue=待機中
 inaccessible.component=権限の無いコンポーネント
 inaccessible.count=その他 権限の無いアイテム

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -676,6 +676,7 @@ infoempty=Hiện thị 0 tới 0 của 0 mục
 inner.source=Nguồn bên trong
 in.case.you.need.the.clearing.at.an.earlier.date.then.the.preferred.date.that.is.available.please.check.the.critical.checkbox.and.reselect.the.preferred.clearing.date=In case you need the clearing at an earlier date than the preferred date that is available, please check the critical checkbox and reselect the preferred clearing date
 in.order.to.go.ahead.please.sign.in.or.create.a.new.account=Để tiếp tục, vui lòng đăng nhập hoặc tạo một tài khoản mới!
+in.progress=In Progress
 in.queue=In Queue
 inaccessible.component=Restricted component
 inaccessible.count=Other restricted items


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)


Issue: #1466 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
 * Add an attachment to release (with clearing state `NEW`) of type `Initial Scan Report`, the release clearing status should change to `Scan Available`.
 * Now, Delete the attachment of type ISR uploaded to release in step 1, post deletion (update release), the clearing state should change to `NEW`.
Please refer Issue #1390  for more details.


### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR


Signed-off-by: Abdul Kapti <abdul.kapti@siemens-healthineers.com>