### PR TITLE
fix(merge): Optimized code to check for write permission of release and components before starting to merge

### DIFF
--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -396,7 +396,7 @@ public class ComponentHandler implements ComponentService.Iface {
     @Override
     public RequestSummary updateReleases(Set<Release> releases, User user) throws TException {
         assertUser(user);
-        return handler.updateReleases(releases, user);
+        return handler.updateReleases(releases, user, false);
     }
 
     @Override


### PR DESCRIPTION
> Optimized code to check for write permission of release and components before starting to merge.

> As per changelogs, It is observed that in some cases, after merge of component . 
> The corresponding releases are not updated with new component Id.
> Thereby creating orphaned Release.

> Maybe Merge is failing in the middle due to permission issue of Release
> As a solution, check has been added for WRITE permission of all releases before actual merge is started.

> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change? - No

Issue: 

### How To Test?
> Test General functionality of merge/split component
> Have you implemented any additional tests?

### Checklist
Must:
- [X] All related issues are referenced in commit messages and in PR

Signed-off-by: Jaideep Palit <jaideep.palit@siemens.com>