### PR TITLE
typo in the docker run command

### DIFF
--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -107,7 +107,7 @@ docker exec -it sw360_postgresdb_1 createdb -U liferay -W fossology
 docker run \
     --network sw360net \
     -p 8081:80 \
-    -name fossology \
+    --name fossology \
     -e FOSSOLOGY_DB_HOST=postgresdb \
     -e FOSSOLOGY_DB_USER=liferay \
     -e FOSSOLOGY_DB_PASSWORD=liferay \


### PR DESCRIPTION
Just a typo in the documentation, the `docker run` command option `--name` doesn't have the double hyphen