### PR TITLE
fix(CR-UI): fixed the count mismatch in Open Components column of CR table

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/view.jsp
@@ -790,7 +790,7 @@ AUI().use('liferay-portlet-url', function () {
                         projCell.data(renderLinkToProject(response[i].id, projName));
                         if (isOpenCrTable) {
                             let clearing = response[i].clearing,
-                                totalCount = d(clearing.newRelease) + d(clearing.underClearing) + d(clearing.sentToClearingTool) + d(clearing.reportAvailable) + d(clearing.approved),
+                                totalCount = d(clearing.newRelease) + d(clearing.underClearing) + d(clearing.sentToClearingTool) + d(clearing.reportAvailable) + d(clearing.approved) + d(clearing.scanAvailable),
                                 approvedCount = d(clearing.reportAvailable) + d(clearing.approved);
                             compCell.data(totalCount - approvedCount);
                             if (!totalCount || $(table.cell('#'+crId, 4).node()).find('span.sw360-tt-ClearingRequestState-NEW').text()) {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/view.jsp
@@ -523,7 +523,7 @@
                     approvedCount;
 
                 if (clearing) {
-                    releaseCount = d(clearing.newRelease) + d(clearing.underClearing) + d(clearing.sentToClearingTool) + d(clearing.reportAvailable) + d(clearing.approved);
+                    releaseCount = d(clearing.newRelease) + d(clearing.underClearing) + d(clearing.sentToClearingTool) + d(clearing.reportAvailable) + d(clearing.approved) + d(clearing.scanAvailable);
                     approvedCount = d(clearing.approved);
                     resultElementAsString = "<span class=\"clearingstate content-center\" title=\"" + approvedCount + (approvedCount === 1 ? " <liferay-ui:message key='release' />" : " <liferay-ui:message key='releases' />")
                         + " <liferay-ui:message key='out.of' /> " + releaseCount + (approvedCount === 1 ? " <liferay-ui:message key='has' />" : " <liferay-ui:message key='have' />")


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Fixed the incorrect open components count in Open Clearing request table.

Issue: #1523 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
Follow the steps mentioned in issue #1523 

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: Abdul Kapti <abdul.kapti@siemens-healthineers.com>
