### PR TITLE
feat(export): Enable mailing for exported spreadsheet for components

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ComponentDatabaseHandler.java
@@ -2502,4 +2502,10 @@ public class ComponentDatabaseHandler extends AttachmentAwareDatabaseHandler {
                     });
         }
     }
+
+    public void sendExportSpreadsheetSuccessMail(String url, String recepient) throws TException {
+        mailUtil.sendMail(recepient, MailConstants.SUBJECT_SPREADSHEET_EXPORT_SUCCESS,
+                MailConstants.TEXT_SPREADSHEET_EXPORT_SUCCESS, SW360Constants.NOTIFICATION_CLASS_COMPONENT, "", false,
+                "component", url);
+    }
 }

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -1556,7 +1556,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
     public void sendExportSpreadsheetSuccessMail(String url, String recepient) throws TException {
         mailUtil.sendMail(recepient, MailConstants.SUBJECT_SPREADSHEET_EXPORT_SUCCESS,
                 MailConstants.TEXT_SPREADSHEET_EXPORT_SUCCESS, SW360Constants.NOTIFICATION_CLASS_PROJECT, "", false,
-                url);
+                "project", url);
     }
 
     private Map<String, String> createProjectCSRow(String relation, Project prj,

--- a/backend/src-common/src/main/resources/sw360.properties
+++ b/backend/src-common/src/main/resources/sw360.properties
@@ -56,7 +56,7 @@ subjectForRejectedClearingRequest= Your clearing request <%s> has been rejected 
 subjectForUpdatedProjectWithClearingRequest= Project <%s> with clearing request <%s> updated
 subjectForSuccessfulExport = Spreadsheet Export Successful
 
-textForSuccessfulExport = The project spreadsheet export successfully completed. Please find the download link(%s) here.
+textForSuccessfulExport = The %s spreadsheet export successfully completed. Please find the download link(%s) here.
 textForNewModerationRequest= a new moderation request has been added to your SW360-account.\n\n
 textForUpdateModerationRequest= \
   one of the moderation requests previously added to your \
@@ -83,3 +83,4 @@ enable.sw360.change.log=false
 sw360changelog.output.path=sw360changelog/sw360changelog
 auto.set.ecc.status=false
 send.project.spreadsheet.export.to.mail.enabled=false
+send.component.spreadsheet.export.to.mail.enabled=false

--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -643,4 +643,9 @@ public class ComponentHandler implements ComponentService.Iface {
             PaginationData pageData) throws TException {
         return handler.getRecentComponentsSummaryWithPagination(user, pageData);
     }
+
+    @Override
+    public void sendExportSpreadsheetSuccessMail(String url, String recepient) throws TException {
+        handler.sendExportSpreadsheetSuccessMail(url, recepient);
+    }
 }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -46,6 +46,7 @@ public class PortalConstants {
     public static final String CLEARING_REPORT_TEMPLATE_FORMAT;
     public static final String DISABLE_CLEARING_REQUEST_FOR_PROJECT_WITH_GROUPS;
     public static final Boolean SEND_PROJECT_SPREADSHEET_EXPORT_TO_MAIL_ENABLED;
+    public static final Boolean SEND_COMPONENT_SPREADSHEET_EXPORT_TO_MAIL_ENABLED;
     public static final String LOAD_OPEN_MODERATION_REQUEST = "loadOpenModerationRequest";
     public static final String LOAD_CLOSED_MODERATION_REQUEST = "loadClosedModerationRequest";
 
@@ -699,6 +700,7 @@ public class PortalConstants {
             System.getProperty("RunComponentVisibilityRestrictionTest", props.getProperty("component.visibility.restriction.enabled", "false")));
         DISABLE_CLEARING_REQUEST_FOR_PROJECT_WITH_GROUPS = props.getProperty("org.eclipse.sw360.disable.clearing.request.for.project.group", "");
         SEND_PROJECT_SPREADSHEET_EXPORT_TO_MAIL_ENABLED = Boolean.parseBoolean(props.getProperty("send.project.spreadsheet.export.to.mail.enabled", "false"));
+        SEND_COMPONENT_SPREADSHEET_EXPORT_TO_MAIL_ENABLED = Boolean.parseBoolean(props.getProperty("send.component.spreadsheet.export.to.mail.enabled", "false"));
     }
 
     private PortalConstants() {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -219,6 +219,10 @@ public class ComponentPortlet extends FossologyAwarePortlet {
             updateVulnerabilityVerification(request, response);
         } else if (PortalConstants.EXPORT_TO_EXCEL.equals(action)) {
             exportExcel(request, response);
+        } else if (PortalConstants.DOWNLOAD_EXCEL.equals(action)) {
+            downloadExcel(request, response);
+        } else if (PortalConstants.EMAIL_EXPORTED_EXCEL.equals(action)) {
+            exportExcelWithEmail(request, response);
         } else if (PortalConstants.RELEASE_LINK_TO_PROJECT.equals(action)) {
             linkReleaseToProject(request, response);
         } else if (PortalConstants.LOAD_SPDX_LICENSE_INFO.equals(action)) {
@@ -240,6 +244,59 @@ public class ComponentPortlet extends FossologyAwarePortlet {
         } else if (PortalConstants.EVALUATE_CLI_ATTACHMENTS.equals(action)) {
             evaluateCLIAttachments(request, response);
         }
+    }
+
+    private void exportExcelWithEmail(ResourceRequest request, ResourceResponse response) {
+        final User user = UserCacheHolder.getUserFromRequest(request);
+        final String componentId = request.getParameter(Component._Fields.ID.toString());
+        ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content.Language", request.getLocale(), getClass());
+        String token = null;
+
+        try {
+            setSessionMessage(request, LanguageUtil.get(resourceBundle,
+                    "excel.report.generation.has.started.we.will.send.you.an.email.with.download.link.once.completed"));
+            boolean extendedByReleases = Boolean.valueOf(request.getParameter(PortalConstants.EXTENDED_EXCEL_EXPORT));
+            ComponentService.Iface client = thriftClients.makeComponentClient();
+            int total = client.getTotalComponentsCount(user);
+            PaginationData pageData = new PaginationData();
+            pageData.setAscending(true);
+            Map<PaginationData, List<Component>> pageDtToProjects;
+            Set<Component> projects = new HashSet<>();
+            int displayStart = 0;
+            int rowsPerPage = 500;
+            while (0 < total) {
+                pageData.setDisplayStart(displayStart);
+                pageData.setRowsPerPage(rowsPerPage);
+                displayStart = displayStart + rowsPerPage;
+                pageDtToProjects = getFilteredComponentList(request, pageData);
+                projects.addAll(pageDtToProjects.entrySet().iterator().next().getValue());
+                total = total - rowsPerPage;
+            }
+            List<Component> listOfComponent = new ArrayList<Component>(projects);
+            ComponentExporter exporter = new ComponentExporter(thriftClients.makeComponentClient(), listOfComponent,
+                    user, extendedByReleases);
+
+            token = exporter.makeExcelExportForProject(listOfComponent, user);
+
+            String portletId = (String) request.getAttribute(WebKeys.PORTLET_ID);
+            ThemeDisplay tD = (ThemeDisplay) request.getAttribute(WebKeys.THEME_DISPLAY);
+            long plid = tD.getPlid();
+
+            LiferayPortletURL componentUrl = PortletURLFactoryUtil.create(request, portletId, plid,
+                    PortletRequest.RESOURCE_PHASE);
+            componentUrl.setParameter("action", PortalConstants.DOWNLOAD_EXCEL);
+            componentUrl.setParameter("token", token);
+            componentUrl.setParameter(PortalConstants.EXTENDED_EXCEL_EXPORT, String.valueOf(extendedByReleases));
+
+            if(!CommonUtils.isNullEmptyOrWhitespace(token)) {
+                client.sendExportSpreadsheetSuccessMail(componentUrl.toString(), user.getEmail());
+            }
+        } catch (IOException | TException | PortletException e) {
+            log.error("An error occurred while generating the Excel export", e);
+            response.setProperty(ResourceResponse.HTTP_STATUS_CODE,
+                    Integer.toString(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
+        }
+
     }
 
     private void evaluateCLIAttachments(ResourceRequest request, ResourceResponse response) throws IOException {
@@ -466,13 +523,47 @@ public class ComponentPortlet extends FossologyAwarePortlet {
 
         try {
             boolean extendedByReleases = Boolean.valueOf(request.getParameter(PortalConstants.EXTENDED_EXCEL_EXPORT));
-            List<Component> components = getFilteredComponentList(request);
-            ComponentExporter exporter = new ComponentExporter(thriftClients.makeComponentClient(), components, user,
+            ComponentService.Iface client = thriftClients.makeComponentClient();
+            int total = client.getTotalComponentsCount(user);
+            PaginationData pageData = new PaginationData();
+            pageData.setAscending(true);
+            Map<PaginationData, List<Component>> pageDtToProjects;
+            Set<Component> projects = new HashSet<>();
+            int displayStart = 0;
+            int rowsPerPage = 500;
+            while (0 < total) {
+                pageData.setDisplayStart(displayStart);
+                pageData.setRowsPerPage(rowsPerPage);
+                displayStart = displayStart + rowsPerPage;
+                pageDtToProjects = getFilteredComponentList(request, pageData);
+                projects.addAll(pageDtToProjects.entrySet().iterator().next().getValue());
+                total = total - rowsPerPage;
+            }
+            List<Component> listOfComponent = new ArrayList<Component>(projects);
+            ComponentExporter exporter = new ComponentExporter(thriftClients.makeComponentClient(), listOfComponent, user,
                     extendedByReleases);
             String filename = String.format("components-%s.xlsx", SW360Utils.getCreatedOn());
-            PortletResponseUtil.sendFile(request, response, filename, exporter.makeExcelExport(components),
+            PortletResponseUtil.sendFile(request, response, filename, exporter.makeExcelExport(listOfComponent),
                     CONTENT_TYPE_OPENXML_SPREADSHEET);
-        } catch (IOException | SW360Exception e) {
+        } catch (IOException | TException e) {
+            log.error("An error occurred while generating the Excel export", e);
+            response.setProperty(ResourceResponse.HTTP_STATUS_CODE,
+                    Integer.toString(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    private void downloadExcel(ResourceRequest request, ResourceResponse response) {
+        final User user = UserCacheHolder.getUserFromRequest(request);
+        final String token = request.getParameter("token");
+
+        try {
+            boolean extendedByReleases = Boolean.valueOf(request.getParameter(PortalConstants.EXTENDED_EXCEL_EXPORT));
+            ComponentExporter exporter = new ComponentExporter(thriftClients.makeComponentClient(), user,
+                    extendedByReleases);
+            String filename = String.format("components-%s.xlsx", SW360Utils.getCreatedOn());
+            PortletResponseUtil.sendFile(request, response, filename, exporter.downloadExcelSheet(token),
+                    CONTENT_TYPE_OPENXML_SPREADSHEET);
+        } catch (IOException | TException e) {
             log.error("An error occurred while generating the Excel export", e);
             response.setProperty(ResourceResponse.HTTP_STATUS_CODE,
                     Integer.toString(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/view.jsp
@@ -66,6 +66,11 @@
     <portlet:param name="<%=PortalConstants.LICENSE_ID%>" value="<%=PortalConstants.FRIENDLY_URL_PLACEHOLDER_LICENSE_ID%>"/>
 </liferay-portlet:renderURL>
 
+<portlet:resourceURL var="generateExcelReport">
+    <portlet:param name="<%=PortalConstants.ACTION%>" value="<%=PortalConstants.EMAIL_EXPORTED_EXCEL%>"/>
+    <portlet:param name="<%=PortalConstants.COMPONENT_ID%>" value="${docid}"/>
+</portlet:resourceURL>
+
 <div class="container" style="display: none;">
   <div class="row">
     <div class="col-3 sidebar">
@@ -399,19 +404,32 @@
 
             // Export Spreadsheet action
             function exportSpreadsheet(type){
-                var portletURL = PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RESOURCE_PHASE) %>')
+                var  isEMailEnabled = <%=PortalConstants.SEND_COMPONENT_SPREADSHEET_EXPORT_TO_MAIL_ENABLED%>;
+                if(isEMailEnabled){
+                    var isWithReleases = (type === 'componentWithReleases' ? 'true' : 'false');
+                    $.ajax({
+                        type: 'POST',
+                        url: '<%=generateExcelReport%>',
+                        cache: false,
+                        data: {
+                            "<portlet:namespace/><%=PortalConstants.EXTENDED_EXCEL_EXPORT%>": isWithReleases,
+                        }
+                    });
+                } else {
+                    var portletURL = PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RESOURCE_PHASE) %>')
                         .setParameter('<%=PortalConstants.ACTION%>', '<%=PortalConstants.EXPORT_TO_EXCEL%>');
-                portletURL.setParameter('<%=Component._Fields.NAME%>', $('#component_name').val());
-                portletURL.setParameter('<%=Component._Fields.CATEGORIES%>', $('#categories').val());
-                portletURL.setParameter('<%=Component._Fields.LANGUAGES%>', $('#languages').val());
-                portletURL.setParameter('<%=Component._Fields.SOFTWARE_PLATFORMS%>', $('#software_platforms').val());
-                portletURL.setParameter('<%=Component._Fields.OPERATING_SYSTEMS%>', $('#operating_systems').val());
-                portletURL.setParameter('<%=Component._Fields.VENDOR_NAMES%>', $('#vendor_names').val());
-                portletURL.setParameter('<%=Component._Fields.COMPONENT_TYPE%>', $('#component_type').val());
-                portletURL.setParameter('<%=Component._Fields.MAIN_LICENSE_IDS%>', $('#main_licenses').val());
-                portletURL.setParameter('<%=PortalConstants.EXTENDED_EXCEL_EXPORT%>', type === 'componentWithReleases' ? 'true' : 'false');
+                    portletURL.setParameter('<%=Component._Fields.NAME%>', $('#component_name').val());
+                    portletURL.setParameter('<%=Component._Fields.CATEGORIES%>', $('#categories').val());
+                    portletURL.setParameter('<%=Component._Fields.LANGUAGES%>', $('#languages').val());
+                    portletURL.setParameter('<%=Component._Fields.SOFTWARE_PLATFORMS%>', $('#software_platforms').val());
+                    portletURL.setParameter('<%=Component._Fields.OPERATING_SYSTEMS%>', $('#operating_systems').val());
+                    portletURL.setParameter('<%=Component._Fields.VENDOR_NAMES%>', $('#vendor_names').val());
+                    portletURL.setParameter('<%=Component._Fields.COMPONENT_TYPE%>', $('#component_type').val());
+                    portletURL.setParameter('<%=Component._Fields.MAIN_LICENSE_IDS%>', $('#main_licenses').val());
+                    portletURL.setParameter('<%=PortalConstants.EXTENDED_EXCEL_EXPORT%>', type === 'componentWithReleases' ? 'true' : 'false');
 
-                window.location.href = portletURL.toString();
+                    window.location.href = portletURL.toString();
+                }
             }
 
             // Delete component action

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ComponentExporter.java
@@ -74,6 +74,11 @@ public class ComponentExporter extends ExcelExporter<Component, ComponentHelper>
         preloadLinkedReleasesFor(components, extendedByReleases);
     }
 
+    public ComponentExporter(ComponentService.Iface componentClient, User user,
+            boolean extendedByReleases) throws SW360Exception {
+        super(new ComponentHelper(extendedByReleases, new ReleaseHelper(componentClient, user)));
+    }
+
     private void preloadLinkedReleasesFor(List<Component> components, boolean extendedByReleases)
             throws SW360Exception {
         Set<String> linkedReleaseIds = components

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -838,4 +838,9 @@ service ComponentService {
      * Gets all releases with complete details
      */
     list<Release> getAllReleasesForUser(1: User user);
+
+    /**
+    * Send email to the user once spreadsheet export completed
+    */
+    void sendExportSpreadsheetSuccessMail(1: string url, 2: string userEmail);
 }


### PR DESCRIPTION
Signed-off-by: Smruti Prakash Sahoo <smruti.sahoo@siemens.com>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

* Enable mailing for exported "component" and "component with releases" spreadsheet functionality.

> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?

* Set `send.component.spreadsheet.export.to.mail.enabled` to true and hit the export spreadsheet for components or components with releases and verify if you are getting a mail with the link to download spreadsheet.
 
> Have you implemented any additional tests? - No

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
