### PR TITLE
fix(REST): fixed release update issue for releases with invalid licenses

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/ReleaseController.java
@@ -242,8 +242,9 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         Release updateRelease = setBackwardCompatibleFieldsInRelease(reqBodyMap);
         updateRelease.setClearingState(sw360Release.getClearingState());
         sw360Release = this.restControllerHelper.updateRelease(sw360Release, updateRelease);
+        boolean isMainLicenseModified = CommonUtils.nullToEmptyCollection(sw360Release.getMainLicenseIds()).equals(CommonUtils.nullToEmptyCollection(updateRelease.getMainLicenseIds()));
         releaseService.setComponentNameAsReleaseName(sw360Release, user);
-        RequestStatus updateReleaseStatus = releaseService.updateRelease(sw360Release, user);
+        RequestStatus updateReleaseStatus = releaseService.updateRelease(sw360Release, user, isMainLicenseModified);
         HalResource<Release> halRelease = createHalReleaseResource(sw360Release, true);
         if (updateReleaseStatus == RequestStatus.SENT_TO_MODERATOR) {
             return new ResponseEntity(RESPONSE_BODY_FOR_MODERATION_REQUEST, HttpStatus.ACCEPTED);
@@ -311,7 +312,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         final Release sw360Release = releaseService.getReleaseForUserById(id, sw360User);
         Set<Attachment> attachments = sw360Release.getAttachments();
         Attachment updatedAttachment = attachmentService.updateAttachment(attachments, attachmentData, attachmentId, sw360User);
-        RequestStatus updateReleaseStatus = releaseService.updateRelease(sw360Release, sw360User);
+        RequestStatus updateReleaseStatus = releaseService.updateRelease(sw360Release, sw360User, true);
         if (updateReleaseStatus == RequestStatus.SENT_TO_MODERATOR) {
             return new ResponseEntity(RESPONSE_BODY_FOR_MODERATION_REQUEST, HttpStatus.ACCEPTED);
         }
@@ -334,7 +335,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         }
 
         release.addToAttachments(attachment);
-        RequestStatus updateReleaseStatus = releaseService.updateRelease(release, sw360User);
+        RequestStatus updateReleaseStatus = releaseService.updateRelease(release, sw360User, true);
         HalResource halRelease = createHalReleaseResource(release, true);
         if (updateReleaseStatus == RequestStatus.SENT_TO_MODERATOR) {
             return new ResponseEntity(RESPONSE_BODY_FOR_MODERATION_REQUEST, HttpStatus.ACCEPTED);
@@ -367,7 +368,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         }
         log.debug("Deleting the following attachments from release " + releaseId + ": " + attachmentsToDelete);
         release.getAttachments().removeAll(attachmentsToDelete);
-        RequestStatus updateReleaseStatus = releaseService.updateRelease(release, user);
+        RequestStatus updateReleaseStatus = releaseService.updateRelease(release, user, true);
         HalResource<Release> halRelease = createHalReleaseResource(release, true);
         if (updateReleaseStatus == RequestStatus.SENT_TO_MODERATOR) {
             return new ResponseEntity(RESPONSE_BODY_FOR_MODERATION_REQUEST, HttpStatus.ACCEPTED);
@@ -444,7 +445,7 @@ public class ReleaseController implements RepresentationModelProcessor<Repositor
         }
         sw360Release.setReleaseIdToRelationship(releaseIdToRelationship);
 
-        RequestStatus updateReleaseStatus = releaseService.updateRelease(sw360Release, sw360User);
+        RequestStatus updateReleaseStatus = releaseService.updateRelease(sw360Release, sw360User, true);
         if (updateReleaseStatus == RequestStatus.SENT_TO_MODERATOR) {
             return new ResponseEntity(RESPONSE_BODY_FOR_MODERATION_REQUEST, HttpStatus.ACCEPTED);
         }

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/release/Sw360ReleaseService.java
@@ -162,24 +162,25 @@ public class Sw360ReleaseService implements AwareOfRestServices<Release> {
         release.setName(componentById.getName());
     }
 
-    public RequestStatus updateRelease(Release release, User sw360User) throws TException {
+    public RequestStatus updateRelease(Release release, User sw360User, boolean isMainLicenseModified) throws TException {
         ComponentService.Iface sw360ComponentClient = getThriftComponentClient();
         rch.checkForCyclicOrInvalidDependencies(sw360ComponentClient, release, sw360User);
 
-        List <String> licenseIncorrect = new ArrayList<>();
-        if (release.isSetMainLicenseIds() && !release.getMainLicenseIds().isEmpty()) {
-            for (String licenseId : release.getMainLicenseIds()) {
-                try {
-                    licenseService.getLicenseById(licenseId);
-                } catch (Exception e) {
-                    licenseIncorrect.add(licenseId);
+        if (isMainLicenseModified) {
+            List <String> licenseIncorrect = new ArrayList<>();
+            if (release.isSetMainLicenseIds() && !release.getMainLicenseIds().isEmpty()) {
+                for (String licenseId : release.getMainLicenseIds()) {
+                    try {
+                        licenseService.getLicenseById(licenseId);
+                    } catch (Exception e) {
+                        licenseIncorrect.add(licenseId);
+                    }
                 }
             }
+            if (!licenseIncorrect.isEmpty()) {
+                throw new HttpMessageNotReadableException("License with ids " + licenseIncorrect + " not existed.");
+            }
         }
-        if (!licenseIncorrect.isEmpty()) {
-            throw new HttpMessageNotReadableException("License with ids " + licenseIncorrect + " not existed.");
-        }
-
         RequestStatus requestStatus = sw360ComponentClient.updateRelease(release, sw360User);
         if (requestStatus == RequestStatus.INVALID_INPUT) {
             throw new HttpMessageNotReadableException("Dependent document Id/ids not valid.");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/integration/ReleaseTest.java
@@ -47,6 +47,7 @@ import static org.junit.Assert.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -107,7 +108,7 @@ public class ReleaseTest extends TestIntegrationBase {
     @Test
     public void should_update_release_valid() throws IOException, TException {
         String updatedReleaseName = "updatedReleaseName";
-        given(this.releaseServiceMock.updateRelease(any(), any())).willReturn(RequestStatus.SUCCESS);
+        given(this.releaseServiceMock.updateRelease(any(), any(), anyBoolean())).willReturn(RequestStatus.SUCCESS);
         given(this.releaseServiceMock.getReleaseForUserById(eq(TestHelper.release1Id), any())).willReturn(TestHelper.getDummyReleaseListForTest().get(0));
         HttpHeaders headers = getHeaders(port);
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -223,7 +224,7 @@ public class ReleaseTest extends TestIntegrationBase {
         String strIds = String.join(",", attachmentIds);
         release.setAttachments(new HashSet<>(attachments));
         given(releaseServiceMock.getReleaseForUserById(release.id, TestHelper.getTestUser())).willReturn(release);
-        given(releaseServiceMock.updateRelease(any(), eq(TestHelper.getTestUser())))
+        given(releaseServiceMock.updateRelease(any(), eq(TestHelper.getTestUser()), anyBoolean()))
                 .will(invocationOnMock -> {
                     refUpdatedRelease.set(new Release((Release) invocationOnMock.getArguments()[0]));
                     return RequestStatus.SUCCESS;
@@ -275,6 +276,6 @@ public class ReleaseTest extends TestIntegrationBase {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
         then(releaseServiceMock)
                 .should(never())
-                .updateRelease(any(), any());
+                .updateRelease(any(), any(), anyBoolean());
     }
 }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

1. `Main License Id` validation will happen only if there has been any modifications in `Main License Id` while updating the `release` over `REST` API.
2. `Release` update will fail, if `Main License` field is modified in update operation and validations fails in step 1.
3. `Release` update will be successful, if `Main License` validations is successful or if there is no modifications in `Main License Id` in update operation.

Issue: #1536


### How To Test?

1. Create a `release` with invalid `main license id` (from back end or using CLI), such that this `main license id` should not be present in `SW360`.
2. Try to update the `release` over `REST` API with modifications in `Main License Ids`, such that the modified `Main License Ids` and invalid and not be present in `SW360`, Update should **fail**.
3. Now try to update the `release` over `REST` API without modifications in `Main License Ids`, update should be **successful**.

Please see Issue #1536 to understand the issue.


### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: Abdul Kapti <abdul.kapti@siemens-healthineers.com>