### PR TITLE
feat(UI): ModifiedOn & MOdifiedBy fields for Project/COmponent/Release

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentAwareDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/AttachmentAwareDatabaseHandler.java
@@ -19,6 +19,9 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.apache.thrift.TBase;
+import org.apache.thrift.TFieldIdEnum;
+import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.Source;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
@@ -83,5 +86,21 @@ public abstract class AttachmentAwareDatabaseHandler {
         Sets.SetView<String> deletedLinkedReleaseIds = Sets.difference(actualLinkedReleaseIds, updatedLinkedReleaseIds);
         Set<Source> owners = deletedLinkedReleaseIds.stream().map(Source::releaseId).collect(Collectors.toSet());
         attachmentDatabaseHandler.deleteUsagesBy(usedBy, owners);
+    }
+
+    protected <T extends TBase<T, ? extends TFieldIdEnum>> void updateModifiedFields(T type, String userEmail) {
+        if (type instanceof Release) {
+            Release release = (Release) type;
+            release.setModifiedBy(userEmail);
+            release.setModifiedOn(SW360Utils.getCreatedOn());
+        } else if (type instanceof Component) {
+            Component component = (Component) type;
+            component.setModifiedBy(userEmail);
+            component.setModifiedOn(SW360Utils.getCreatedOn());
+        } else if (type instanceof Project) {
+            Project project = (Project) type;
+            project.setModifiedBy(userEmail);
+            project.setModifiedOn(SW360Utils.getCreatedOn());
+        }
     }
 }

--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -411,6 +411,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
             setReleaseRelations(project, user, actual);
             updateProjectDependentLinkedFields(project, actual);
             project.unsetVendor();
+            updateModifiedFields(project, user.getEmail());
             repository.update(project);
 
             List<ChangeLogs> referenceDocLogList=new LinkedList<>();
@@ -570,6 +571,7 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         obligationRepository.add(obligation);
         Project project = getProjectById(obligation.getProjectId(), user);
         project.setLinkedObligationId(obligation.getId());
+        updateModifiedFields(project, user.getEmail());
         repository.update(project);
         project.unsetLinkedObligationId();
         dbHandlerUtil.addChangeLogs(obligation, null, user.getEmail(), Operation.CREATE, attachmentConnector,

--- a/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
+++ b/backend/src/src-components/src/main/java/org/eclipse/sw360/components/ComponentHandler.java
@@ -485,8 +485,10 @@ public class ComponentHandler implements ComponentService.Iface {
     }
 
     @Override
-    public Component recomputeReleaseDependentFields(String componentId) throws TException {
-        return handler.updateReleaseDependentFieldsForComponentId(componentId);
+    public Component recomputeReleaseDependentFields(String componentId, User user) throws TException {
+        assertUser(user);
+        assertId(componentId);
+        return handler.updateReleaseDependentFieldsForComponentId(componentId, user);
     }
 
     //////////////////////////////////

--- a/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorDatabaseHandler.java
+++ b/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorDatabaseHandler.java
@@ -182,7 +182,7 @@ public class VendorDatabaseHandler {
 
         // update computed fields of affected components
         for(String componentId : componentIds) {
-            componentsClient.recomputeReleaseDependentFields(componentId);
+            componentsClient.recomputeReleaseDependentFields(componentId, user);
         }
 
         return result;

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/editBasicInfo.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/editBasicInfo.jspf
@@ -130,11 +130,25 @@
     </core_rt:choose>
     
     <tr>
-        <td colspan="3">
+        <td >
             <div class="form-group">
                 <label for="comp_desc"><liferay-ui:message key="short.description" /></label>
-                <textarea class="form-control" id="comp_desc" name="<portlet:namespace/><%=Component._Fields.DESCRIPTION%>" rows="4"
+                <textarea class="form-control" id="comp_desc" name="<portlet:namespace/><%=Component._Fields.DESCRIPTION%>" rows="3"
                         placeholder="<liferay-ui:message key="enter.description" />"><sw360:out value="${component.description}"/></textarea>
+            </div>
+        </td>
+        <td>
+            <div class="form-group">
+                <label for="modified_on"><liferay-ui:message key="modified.on" /></label>
+                <input id="modified_on" name="<portlet:namespace/><%=Component._Fields.MODIFIED_ON%>" type="date"
+                    placeholder="<liferay-ui:message key="modified.date.yyyy.mm.dd" />"
+                    value="<sw360:out value="${component.modifiedOn}"/>" readonly class="form-control"/>
+            </div>
+        </td>
+        <td>
+            <div class="form-group">
+                <sw360:DisplayUserEdit email="${component.modifiedBy}" id="<%=Component._Fields.MODIFIED_BY.toString()%>"
+                                    description="modified.by" multiUsers="false" readonly="true"/>
             </div>
         </td>
     </tr>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/summary.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/summary.jspf
@@ -47,6 +47,14 @@
         <td><sw360:DisplayCollection value="${component.categories}"/></td>
     </tr>
     <tr>
+        <td><liferay-ui:message key="modified.on" />:</td>
+        <td><sw360:out value="${component.modifiedOn}"/></td>
+    </tr>
+    <tr>
+        <td><liferay-ui:message key="modified.by" />:</td>
+        <td><sw360:DisplayUserEmail email="${component.modifiedBy}"/></td>
+    </tr>
+    <tr>
         <td><liferay-ui:message key="component.type" />:</td>
         <td><sw360:DisplayEnum value="${component.componentType}"/></td>
     </tr>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/editReleaseInformation.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/editReleaseInformation.jspf
@@ -188,6 +188,25 @@
                                    description="moderators" multiUsers="true" readonly="false"/>
         </td>
     </tr>
+
+    <tr>
+        <td>
+            <div class="form-group">
+                <label for="modified_on"><liferay-ui:message key="modified.on" /></label>
+                <input id="modified_on" name="<portlet:namespace/><%=Release._Fields.MODIFIED_ON%>" type="date"
+                    placeholder="<liferay-ui:message key="modified.date.yyyy.mm.dd" />"
+                    value="<sw360:out value="${release.modifiedOn}"/>" readonly class="form-control"/>
+            </div>
+        </td>
+        <td>
+            <div class="form-group">
+                <sw360:DisplayUserEdit email="${release.modifiedBy}" id="<%=Release._Fields.MODIFIED_BY.toString()%>"
+                                    description="modified.by" multiUsers="false" readonly="true"/>
+            </div>
+        </td>
+        <td>
+        </td>
+    </tr>
 </table>
 
 <script>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/summaryRelease.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/summaryRelease.jspf
@@ -46,6 +46,14 @@
             <td><sw360:DisplayUserEmail email="${release.createdBy}"/></td>
         </tr>
         <tr>
+            <td><liferay-ui:message key="modified.on" />:</td>
+            <td><sw360:out value="${release.modifiedOn}"/></td>
+        </tr>
+        <tr>
+            <td><liferay-ui:message key="modified.by" />:</td>
+            <td><sw360:DisplayUserEmail email="${release.modifiedBy}"/></td>
+        </tr>
+        <tr>
             <td><liferay-ui:message key="contributors" />:</td>
             <td><sw360:DisplayUserEmailCollection value="${release.contributors}"/></td>
         </tr>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/basicInfo.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/basicInfo.jspf
@@ -136,6 +136,24 @@
     <tr>
         <td>
             <div class="form-group">
+                <label for="modified_on"><liferay-ui:message key="modified.on" /></label>
+                <input id="modified_on" name="<portlet:namespace/><%=Project._Fields.MODIFIED_ON%>" type="date"
+                    placeholder="<liferay-ui:message key="modified.date.yyyy.mm.dd" />"
+                    value="<sw360:out value="${project.modifiedOn}"/>" readonly class="form-control"/>
+            </div>
+        </td>
+        <td>
+            <div class="form-group">
+                <sw360:DisplayUserEdit email="${project.modifiedBy}" id="<%=Project._Fields.MODIFIED_BY.toString()%>"
+                                    description="modified.by" multiUsers="false" readonly="true"/>
+            </div>
+        </td>
+        <td>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="form-group">
                 <input id="enable_svm" type="checkbox" class="form-check-input"
                     name="<portlet:namespace/><%=Project._Fields.ENABLE_SVM%>"
                     value="<sw360:out value="${project.enableSvm}"/>"

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/summary.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/summary.jspf
@@ -50,6 +50,14 @@
         <td><sw360:DisplayUserEmail email="${project.createdBy}"/></td>
     </tr>
     <tr>
+        <td><liferay-ui:message key="modified.on" />:</td>
+        <td><sw360:out value="${project.modifiedOn}"/></td>
+    </tr>
+    <tr>
+        <td><liferay-ui:message key="modified.by" />:</td>
+        <td><sw360:DisplayUserEmail email="${project.modifiedBy}"/></td>
+    </tr>
+    <tr>
         <td><liferay-ui:message key="project.type" />:</td>
         <td><sw360:DisplayEnum value="${project.projectType}"/></td>
     </tr>

--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -810,6 +810,7 @@ moderator=Moderator
 moderators=Moderators
 modified=Modified
 modified.by=Modified By
+modified.date.yyyy.mm.dd=Modified date YYYY-MM-DD
 modified.on=Modified On
 monotone=Monotone
 more.info=More Info

--- a/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
@@ -810,6 +810,7 @@ moderator=モデレータ
 moderators=モデレータ
 modified=改造
 modified.by=変更方法
+modified.date.yyyy.mm.dd=Modified date YYYY-MM-DD
 modified.on=変更された
 monotone=Monotone
 more.info=詳細情報

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -814,6 +814,7 @@ moderator=Người kiểm duyệt
 moderators=Người kiểm duyệt
 modified=Sửa đổi
 modified.by=Sửa đổi bởi
+modified.date.yyyy.mm.dd=Modified date YYYY-MM-DD
 modified.on=Đã sửa đổi
 monotone=Giọng bằng bằng
 more.info=Thêm thông tin

--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -272,6 +272,8 @@ struct Release {
     90: optional DocumentState documentState,
 
     200: optional map<RequestedAction, bool> permissions,
+    204: optional string modifiedBy, // Last Modified By User Email
+    205: optional string modifiedOn, // Last Modified Date YYYY-MM-dd
 }
 
 enum ComponentType {
@@ -343,6 +345,8 @@ struct Component {
     70: optional DocumentState documentState,
 
     200: optional map<RequestedAction, bool> permissions,
+    204: optional string modifiedBy, // Last Modified By User Email
+    205: optional string modifiedOn, // Last Modified Date YYYY-MM-dd
 }
 
 struct ReleaseLink{
@@ -701,7 +705,7 @@ service ComponentService {
     /**
      * Recomputes the fields of a component that are aggregated by its releases.
      */
-    Component recomputeReleaseDependentFields(1: string componentId);
+    Component recomputeReleaseDependentFields(1: string componentId, 2: User user);
 
     /**
      * check if release is used by other releases, components or projects

--- a/libraries/lib-datahandler/src/main/thrift/projects.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/projects.thrift
@@ -160,6 +160,8 @@ struct Project {
     201: optional map<string, string> externalUrls,
     202: optional Vendor vendor,
     203: optional string vendorId,
+    204: optional string modifiedBy, // Last Modified By User Email
+    205: optional string modifiedOn, // Last Modified Date YYYY-MM-dd
 }
 
 struct ProjectLink {

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -186,7 +186,11 @@ public class JacksonCustomizations {
                 "setExternalUrls",
                 "externalUrls",
                 "setVendor",
-                "setVendorId"
+                "setVendorId",
+                "setModifiedOn",
+                "modifiedOn",
+                "setModifiedBy",
+                "modifiedBy"
         })
         static abstract class ProjectMixin extends Project {
 
@@ -373,6 +377,10 @@ public class JacksonCustomizations {
                 "setRoles",
                 "additionalDataSize",
                 "setAdditionalData",
+                "setModifiedOn",
+                "modifiedOn",
+                "setModifiedBy",
+                "modifiedBy"
         })
         static abstract class ComponentMixin extends Component {
             @Override
@@ -451,7 +459,11 @@ public class JacksonCustomizations {
                 "setBinaryDownloadurl",
                 "otherLicenseIds",
                 "otherLicenseIdsSize",
-                "setOtherLicenseIds"
+                "setOtherLicenseIds",
+                "setModifiedOn",
+                "modifiedOn",
+                "setModifiedBy",
+                "modifiedBy"
         })
         static abstract class ReleaseMixin extends Release {
             @Override


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
Added `ModifiedBy` and `ModifiedOn` fields for `Project`, `Component` and `Release.

Issue: #1479 


### How To Test?

- Modify / Update the project , component and release from UI and REST API. You should be able to see the `ModifiedOn` and `ModifiedBy` fields values in UI.
- Merge / Split the `Component`, Only the component that got merged should have appropriate `ModifiedOn` and `ModifiedBy` fields values, and not the linked releases.
- These 2 fields are not exposed via `REST` API. (in order to avoid changes in response structure) 

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: Abdul Kapti <abdul.kapti@siemens-healthineers.com>