### PR TITLE
feat(Vendor):Trim fields, Restrict vendor duplication & create Vendor via REST

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/VendorRepository.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/VendorRepository.java
@@ -11,8 +11,11 @@ package org.eclipse.sw360.datahandler.db;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseRepositoryCloudantClient;
@@ -31,11 +34,19 @@ public class VendorRepository extends DatabaseRepositoryCloudantClient<Vendor> {
 
     private static final String ALL = "function(doc) { if (doc.type == 'vendor') emit(null, doc._id) }";
 
+    private static final String BY_FULL_NAME = "function(doc) { if (doc.type == 'vendor' && doc.fullname != null) emit(doc.fullname.toLowerCase(), doc._id) }";
+
     public VendorRepository(DatabaseConnectorCloudant db) {
         super(db, Vendor.class);
         Map<String, MapReduce> views = new HashMap<String, MapReduce>();
         views.put("all", createMapReduce(ALL, null));
+        views.put("vendorbyfullname", createMapReduce(BY_FULL_NAME, null));
         initStandardDesignDocument(views, db);
+    }
+
+    public List<Vendor> searchByFullname(String fullname) {
+        List<Vendor> vendorsMatchingFullname =  new ArrayList<Vendor>(get(queryForIdsAsValue("vendorbyfullname", fullname)));
+        return vendorsMatchingFullname;
     }
 
     public void fillVendor(Component component) {

--- a/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorHandler.java
+++ b/backend/src/src-vendors/src/main/java/org/eclipse/sw360/vendors/VendorHandler.java
@@ -14,6 +14,7 @@ import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.db.VendorSearchHandler;
+import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
 import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
@@ -87,13 +88,11 @@ public class VendorHandler implements VendorService.Iface {
 
 
     @Override
-    public String addVendor(Vendor vendor) throws TException {
+    public AddDocumentRequestSummary addVendor(Vendor vendor) throws TException {
         assertNotNull(vendor);
         assertIdUnset(vendor.getId());
 
-        vendorDatabaseHandler.addVendor(vendor);
-
-        return vendor.getId();
+        return vendorDatabaseHandler.addVendor(vendor);
     }
 
     @Override
@@ -108,6 +107,7 @@ public class VendorHandler implements VendorService.Iface {
     public RequestStatus updateVendor(Vendor vendor, User user) throws TException {
         assertUser(user);
         assertNotNull(vendor);
+        assertId(vendor.getId());
 
         return vendorDatabaseHandler.updateVendor(vendor, user);
     }

--- a/backend/src/src-vendors/src/test/java/org/eclipse/sw360/vendors/VendorHandlerTest.java
+++ b/backend/src/src-vendors/src/test/java/org/eclipse/sw360/vendors/VendorHandlerTest.java
@@ -13,6 +13,7 @@ import org.eclipse.sw360.datahandler.TestUtils;
 import org.eclipse.sw360.datahandler.common.DatabaseSettingsTest;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseConnector;
 import org.eclipse.sw360.datahandler.couchdb.DatabaseInstance;
+import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.junit.After;
 import org.junit.Before;
@@ -78,11 +79,11 @@ public class VendorHandlerTest {
     @Test
     public void testAddVendor() throws Exception {
         Vendor oracle = new Vendor().setShortname("Oracle").setFullname("Oracle Corporation Inc").setUrl("http://www.oracle.com");
-        String id = vendorHandler.addVendor(oracle);
-        assertNotNull(id);
+        AddDocumentRequestSummary summary = vendorHandler.addVendor(oracle);
+        assertNotNull(summary.getId());
         assertEquals(vendorList.size() + 1, vendorHandler.getAllVendors().size());
 
-        Vendor actual = vendorHandler.getByID(id);
+        Vendor actual = vendorHandler.getByID(summary.getId());
 
         assertVendorEquals(oracle, actual);
     }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ErrorMessages.java
@@ -63,6 +63,9 @@ public class ErrorMessages {
     public static final String LICENSE_TYPE_ACCESS_DENIED = "User does not have the permission to add license type.";
     public static final String OBLIGATION_NOT_ADDED = "Obligation could not be added.";
     public static final String OBLIGATION_NOT_UPDATED = "Obligation could not be updated.";
+    public static final String VENDOR_DUPLICATE = "A vendor with the same name already exists.";
+    public static final String ERROR_VENDOR = "Error: Invalid vendor Name or Url.";
+
 
     //this map is used in errorKeyToMessage.jspf to generate key-value pairs for the liferay-ui error tag
     public static final ImmutableList<String> allErrorMessages = ImmutableList.<String>builder()
@@ -113,6 +116,8 @@ public class ErrorMessages {
             .add(ERROR_USER_ACTIVATE_DEACTIVATE)
             .add(OBLIGATION_NOT_ADDED)
             .add(OBLIGATION_NOT_UPDATED)
+            .add(VENDOR_DUPLICATE)
+            .add(ERROR_VENDOR)
             .build();
 
     private ErrorMessages() {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/Sw360Portlet.java
@@ -291,7 +291,7 @@ abstract public class Sw360Portlet extends MVCPortlet {
         }
         switch (requestStatus) {
         case SUCCESS:
-            statusMessage = type + name + " " + verb + "d successfully!";
+            statusMessage = new StringBuilder(type).append(" ").append(name).append(" ").append(verb).append("d successfully!").toString();
             SessionMessages.add(request, "request_processed", statusMessage);
             break;
         case SENT_TO_MODERATOR:

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -332,9 +332,17 @@ public class ComponentPortlet extends FossologyAwarePortlet {
 
         try {
             VendorService.Iface client = thriftClients.makeVendorClient();
-            String vendorId = client.addVendor(vendor);
+            AddDocumentRequestSummary summary = client.addVendor(vendor);
+            AddDocumentRequestStatus status = summary.getRequestStatus();
             JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
-            jsonObject.put("id", vendorId);
+
+            if (AddDocumentRequestStatus.SUCCESS.equals(status)) {
+                jsonObject.put("id", summary.getId());
+            } else if (AddDocumentRequestStatus.DUPLICATE.equals(status)) {
+                jsonObject.put("error", ErrorMessages.VENDOR_DUPLICATE);
+            } else if (AddDocumentRequestStatus.FAILURE.equals(status)) {
+                jsonObject.put("error", summary.getMessage());
+            }
             try {
                 writeJSON(request, response, jsonObject);
             } catch (IOException e) {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -328,9 +328,17 @@ public class ProjectPortlet extends FossologyAwarePortlet {
 
         try {
             VendorService.Iface client = thriftClients.makeVendorClient();
-            String vendorId = client.addVendor(vendor);
+            AddDocumentRequestSummary summary = client.addVendor(vendor);
+            AddDocumentRequestStatus status = summary.getRequestStatus();
             JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
-            jsonObject.put("id", vendorId);
+
+            if (AddDocumentRequestStatus.SUCCESS.equals(status)) {
+                jsonObject.put("id", summary.getId());
+            } else if (AddDocumentRequestStatus.DUPLICATE.equals(status)) {
+                jsonObject.put("error", ErrorMessages.VENDOR_DUPLICATE);
+            } else if (AddDocumentRequestStatus.FAILURE.equals(status)) {
+                jsonObject.put("error", summary.getMessage());
+            }
             try {
                 writeJSON(request, response, jsonObject);
             } catch (IOException e) {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/vendors/edit.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/admin/vendors/edit.jsp
@@ -99,7 +99,7 @@
                                     <td>
                                         <div class="form-group">
                                             <label for="vendorURL"><liferay-ui:message key="url" /></label>
-                                            <input id="vendorURL" type="text" required class="form-control" placeholder="<liferay-ui:message key="enter.vendor.url" />" name="<portlet:namespace/><%=Vendor._Fields.URL%>"
+                                            <input id="vendorURL" type="url" required class="form-control" placeholder="<liferay-ui:message key="enter.vendor.url" />" name="<portlet:namespace/><%=Vendor._Fields.URL%>"
                                                 value="<sw360:out value="${vendor.url}"/>" />
                                             <div class="invalid-feedback">
                                                 <liferay-ui:message key="please.enter.an.url" />

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/components/includes/vendors/addVendor.js
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/components/includes/vendors/addVendor.js
@@ -40,8 +40,13 @@ define('components/includes/vendors/addVendor', ['jquery', 'modules/dialog', 'mo
             url: addVendorUrl,
             data: data,
             success: function (data) {
-                vendorAddedCb(data.id + ',' + fullname);
-                callback(true);
+                if (data.id) {
+                    vendorAddedCb(data.id + ',' + fullname);
+                    callback(true);
+                } else {
+                    $dialog.alert(data.error ? data.error : "Failed to add vendor!");
+                    callback();
+                }
             },
             error: function() {
                 $dialog.alert('Cannot add vendor.');

--- a/libraries/importers/src/main/java/org/eclipse/sw360/importer/ComponentImportUtils.java
+++ b/libraries/importers/src/main/java/org/eclipse/sw360/importer/ComponentImportUtils.java
@@ -26,6 +26,7 @@ import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentService;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
 import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
+import org.eclipse.sw360.datahandler.thrift.AddDocumentRequestSummary;
 import org.eclipse.sw360.datahandler.thrift.ReleaseRelationship;
 import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
@@ -453,8 +454,8 @@ public class ComponentImportUtils {
                 String vendorName = componentCSVRecord.getVendorName();
                 if (!vendorNameToVendorId.containsKey(vendorName)) {
                     Vendor vendor = componentCSVRecord.getVendor();
-                    String vendorId = vendorClient.addVendor(vendor);
-
+                    AddDocumentRequestSummary summary = vendorClient.addVendor(vendor);
+                    String vendorId = summary.getId();
                     vendorNameToVendorId.put(vendorName, vendorId);
                     log.trace(format("created vendor with name '%s' as %s: %s", vendorName, vendorId, vendor));
                 } else {

--- a/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
+++ b/libraries/lib-datahandler/src/main/java/org/eclipse/sw360/datahandler/thrift/ThriftValidate.java
@@ -120,8 +120,9 @@ public class ThriftValidate {
 
     public static void prepareVendor(Vendor vendor) throws SW360Exception {
         // Check required fields
-        assertNotEmpty(vendor.getShortname());
-        assertNotEmpty(vendor.getFullname());
+        assertNotEmpty(vendor.getShortname(), "vendor short name cannot be empty!");
+        assertNotEmpty(vendor.getFullname(), "vendor full name cannot be empty!");
+        assertValidUrl(vendor.getUrl());
 
         // Check type
         vendor.setType(TYPE_VENDOR);

--- a/libraries/lib-datahandler/src/main/thrift/vendors.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/vendors.thrift
@@ -17,6 +17,7 @@ namespace php sw360.thrift.vendors
 typedef sw360.RequestStatus RequestStatus
 typedef users.User User
 typedef users.RequestedAction RequestedAction
+typedef sw360.AddDocumentRequestSummary AddDocumentRequestSummary
 
 struct Vendor {
     1: optional string id,
@@ -57,9 +58,9 @@ service VendorService {
     list<string> searchVendorIds(1: string searchText);
 
     /**
-     * write vendor to database and return id
+     * write vendor to database and return id with status summary
      **/
-    string addVendor(1: Vendor vendor);
+    AddDocumentRequestSummary addVendor(1: Vendor vendor);
 
     /**
      * vendor specified by id is deleted from database if user has sufficient permissions, otherwise FAILURE is returned

--- a/rest/resource-server/src/docs/asciidoc/vendors.adoc
+++ b/rest/resource-server/src/docs/asciidoc/vendors.adoc
@@ -48,3 +48,21 @@ include::{snippets}/should_document_get_vendor/http-response.adoc[]
 
 ===== Links
 include::{snippets}/should_document_get_vendor/links.adoc[]
+
+
+[[resources-vendor-create]]
+==== Creating a vendor
+
+A `POST` request is used to create a vendor.
+
+===== Request structure
+include::{snippets}/should_document_create_vendor/request-fields.adoc[]
+
+===== Example request
+include::{snippets}/should_document_create_vendor/curl-request.adoc[]
+
+===== Example response
+include::{snippets}/should_document_create_vendor/http-response.adoc[]
+
+===== Links
+include::{snippets}/should_document_create_vendor/links.adoc[]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vendor/VendorController.java
@@ -11,7 +11,6 @@ package org.eclipse.sw360.rest.resourceserver.vendor;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.eclipse.sw360.datahandler.thrift.vendors.Vendor;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
@@ -37,7 +36,6 @@ import java.util.List;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 @BasePathAwareController
-@Slf4j
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class VendorController implements RepresentationModelProcessor<RepositoryLinksResource> {
     public static final String VENDORS_URL = "/vendors";
@@ -46,7 +44,7 @@ public class VendorController implements RepresentationModelProcessor<Repository
     private final Sw360VendorService vendorService;
 
     @NonNull
-    private final RestControllerHelper restControllerHelper;
+    private final RestControllerHelper<?> restControllerHelper;
 
     @RequestMapping(value = VENDORS_URL, method = RequestMethod.GET)
     public ResponseEntity<CollectionModel<EntityModel<Vendor>>> getVendors() {
@@ -72,7 +70,7 @@ public class VendorController implements RepresentationModelProcessor<Repository
 
     @PreAuthorize("hasAuthority('WRITE')")
     @RequestMapping(value = VENDORS_URL, method = RequestMethod.POST)
-    public ResponseEntity createVendor(
+    public ResponseEntity<?> createVendor(
             @RequestBody Vendor vendor) {
         vendor = vendorService.createVendor(vendor);
         HalResource<Vendor> halResource = createHalVendor(vendor);


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: #1554

### How To Test?

1. All the 3 fields of vendor object -> `full name`, `short name` and `url` should get trim from both end before being saved in database.
2. User should NOT be able to create a duplicate Vendor from REST API, Admin portlet, Editing of project / component and release.
3. An appropriate error message should be shown whenever vendor creation failed in REST and UI.
4. A vendor is considered as duplicate if `full name` and `url` are exactly same (case insensitive), `short name` will be considered for duplication.


### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: Abdul Kapti <abdul.kapti@siemens-healthineers.com>