### PR TITLE
fix(AdminUI): Prevent license type duplication with case insensitive check

### DIFF
--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
@@ -10,7 +10,6 @@
  */
 package org.eclipse.sw360.licenses.db;
 
-import org.apache.xmlbeans.impl.xb.xsdschema.Attribute;
 import org.eclipse.sw360.components.summary.SummaryType;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseRepositoryCloudantClient;
@@ -594,17 +593,9 @@ public class LicenseDatabaseHandler {
     }
 
     private boolean isDuplicate(LicenseType licenseType) {
-        List<String> existLicenseTypes = new ArrayList<>();
-        String type = licenseType.getLicenseType();
+        String type = licenseType.getLicenseType().trim().toLowerCase();
         List<LicenseType> duplicates = licenseTypeRepository.searchByLicenseType(type);
-
-        for (LicenseType duplicate : duplicates) {
-            existLicenseTypes.add(duplicate.getLicenseType());
-        }
-        if (existLicenseTypes.contains(type)) {
-            return true;
-        }
-        return false;
+        return isNotEmpty(duplicates);
     }
 
     public List<LicenseType> addLicenseTypes(List<LicenseType> licenseTypes, User user) {

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseTypeRepository.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseTypeRepository.java
@@ -17,8 +17,6 @@ import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.cloudantclient.DatabaseRepositoryCloudantClient;
 import org.eclipse.sw360.datahandler.thrift.licenses.LicenseType;
 import com.cloudant.client.api.model.DesignDocument.MapReduce;
-import org.ektorp.support.View;
-import org.ektorp.support.Views;
 
 import java.util.List;
 
@@ -28,7 +26,7 @@ import java.util.List;
 
 public class LicenseTypeRepository extends DatabaseRepositoryCloudantClient<LicenseType> {
     private static final String ALL = "function(doc) { if (doc.type == 'licenseType') emit(null, doc._id) }";
-    private static final String BYLICENSETYPE = "function(doc) { if(doc.type == 'licenseType') { emit(doc.licenseType, doc) } }";
+    private static final String BYLICENSETYPE = "function(doc) { if(doc.type == 'licenseType') { emit(doc.licenseType.trim().toLowerCase(), doc) } }";
 
     public LicenseTypeRepository(DatabaseConnectorCloudant db) {
         super(db, LicenseType.class);

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/licenses/includes/detailText.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/licenses/includes/detailText.jspf
@@ -18,9 +18,7 @@
     </thead>
     <tr>
         <td>
-            <pre style="white-space: pre-line;">
-                <sw360:out value="${licenseDetail.text}"/>
-            </pre>
+            <pre style="white-space: pre-wrap;"><sw360:out value="${licenseDetail.text}" stripNewlines="false"/></pre>
         </td>
     </tr>
 </table>


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

- Restrict the duplication of `License Type` - by adding case insensitive check and trimming the leading and trailing whitespaces.
- Changed the `License Text` format in `License Details page` to retain the new line and whitespaces.

Issue: #1562 


### How To Test?

- User should not be able to create a duplicate `License Type` by changing case and adding trailing / leading whitespaces.
- `License Text` in `License Details page` should retain whitespace and new lines to improve readability.

### Screenshot for reference:
![image](https://user-images.githubusercontent.com/50870174/174012892-e20f18b7-d417-4c56-a5e0-96fe007c4b30.png)


### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: Abdul Kapti <abdul.kapti@siemens-healthineers.com>