### PR TITLE
fix(rest): Added release main licenses in the response

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -33,6 +33,7 @@ import org.eclipse.sw360.datahandler.thrift.components.ComponentService;
 import org.eclipse.sw360.datahandler.thrift.projects.ProjectService;
 import org.eclipse.sw360.datahandler.thrift.MainlineState;
 import org.eclipse.sw360.datahandler.thrift.ProjectReleaseRelationship;
+import org.eclipse.sw360.datahandler.thrift.Quadratic;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.rest.resourceserver.obligation.ObligationController;
 import org.eclipse.sw360.rest.resourceserver.project.Sw360ProjectService;
@@ -51,6 +52,7 @@ import org.apache.thrift.TFieldIdEnum;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.hateoas.*;
 import org.springframework.hateoas.server.core.EmbeddedWrapper;
 import org.springframework.hateoas.server.core.EmbeddedWrappers;
@@ -318,9 +320,18 @@ public class RestControllerHelper<T> {
         try {
             License licenseById = licenseService.getLicenseById(licenseId);
             embeddedLicense.setFullname(licenseById.getFullname());
+            embeddedLicense.setShortname(licenseId);
             Link licenseSelfLink = linkTo(UserController.class)
                     .slash("api" + LicenseController.LICENSES_URL + "/" + licenseById.getId()).withSelfRel();
             halLicense.add(licenseSelfLink);
+            return halLicense;
+        } catch (ResourceNotFoundException rne) {
+            LOGGER.error("cannot create a self link for license with id" + licenseId);
+            embeddedLicense.setShortname(licenseId);
+            embeddedLicense.setOSIApproved(Quadratic.NA);
+            embeddedLicense.setFSFLibre(Quadratic.NA);
+            embeddedLicense.setChecked(false);
+            embeddedLicense.setFullname(null);
             return halLicense;
         } catch (Exception e) {
             LOGGER.error("cannot create self link for license with id: " + licenseId);


### PR DESCRIPTION
Signed-off-by: Nikesh kumar <kumar.nikesh@simens.com>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

This is due to License not being present in SW360 license database.   
These license (at times invalid) are added into Release / Components via CLI XML without any validations at SW360 end.  
Once can add these license into SW360 database via REST or UI.

> * Which issue is this pull request belonging to and how is it solving it? #1566
> * Did you add or update any new dependencies that are required for your change? - NO

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
