### PR TITLE
fix(CrUi): fix the critical CR creation issue

### DIFF
--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/ModerationHandler.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/ModerationHandler.java
@@ -234,8 +234,10 @@ public class ModerationHandler implements ModerationService.Iface {
     }
 
     @Override
-    public int getCriticalClearingRequestCount() throws TException {
-        return handler.getCriticalClearingRequestCount();
+    public int getOpenCriticalCrCountByGroup(String group) throws TException {
+        // user department is being passed here
+        assertNotEmpty(group);
+        return handler.getOpenCriticalCrCountByGroup(group);
     }
 
     @Override

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -141,8 +141,8 @@ public class ModerationDatabaseHandler {
         return new HashSet<ClearingRequest>(clearingRequestRepository.getClearingRequestsByBU(businessUnit));
     }
 
-    public Integer getCriticalClearingRequestCount() {
-        return clearingRequestRepository.getCriticalClearingRequestCount();
+    public Integer getOpenCriticalCrCountByGroup(String group) {
+        return clearingRequestRepository.getOpenCriticalClearingRequestCount(group);
     }
 
     public ModerationRequest getRequest(String requestId) {

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
@@ -503,7 +503,7 @@ public class ModerationPortlet extends FossologyAwarePortlet {
                 }
             }
             if (clearingRequest.getTimestampOfDecision() > 1) {
-                Integer criticalCount = client.getCriticalClearingRequestCount();
+                Integer criticalCount = client.getOpenCriticalCrCountByGroup(user.getDepartment());
                 request.setAttribute(CRITICAL_CR_COUNT, criticalCount);
             }
             String dateLimit = CommonUtils.nullToEmptyString(ModerationPortletUtils.loadPreferredClearingDateLimit(request, user));
@@ -947,7 +947,7 @@ public class ModerationPortlet extends FossologyAwarePortlet {
             request.setAttribute(DOCUMENT_TYPE, SW360Constants.TYPE_PROJECT);
             setAttachmentsInRequest(request, actual_project);
             ModerationService.Iface modClient = thriftClients.makeModerationClient();
-            Integer criticalCount = modClient.getCriticalClearingRequestCount();
+            Integer criticalCount = modClient.getOpenCriticalCrCountByGroup(user.getDepartment());
             request.setAttribute(CRITICAL_CR_COUNT, criticalCount);
         } catch (TException e) {
             log.error("Error fetching project from backend!", e);

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortletUtils.java
@@ -143,7 +143,7 @@ public class ModerationPortletUtils {
         AddDocumentRequestSummary requestSummary = new AddDocumentRequestSummary().setRequestStatus(AddDocumentRequestStatus.FAILURE);
         try {
             ModerationService.Iface client = new ThriftClients().makeModerationClient();
-            Integer criticalCount = client.getCriticalClearingRequestCount();
+            Integer criticalCount = client.getOpenCriticalCrCountByGroup(user.getDepartment());
             String preferredDate = request.getParameter(ClearingRequest._Fields.REQUESTED_CLEARING_DATE.toString());
             String commentText = request.getParameter(ClearingRequest._Fields.REQUESTING_USER_COMMENT.toString());
             String priority = (criticalCount > 1) ? "" : request.getParameter(ClearingRequest._Fields.PRIORITY.toString());

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -467,7 +467,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             clearingRequest.setRequestingUser(user.getEmail());
             clearingRequest.setClearingState(ClearingRequestState.NEW);
             ModerationService.Iface modClient = thriftClients.makeModerationClient();
-            Integer criticalCount = modClient.getCriticalClearingRequestCount();
+            Integer criticalCount = modClient.getOpenCriticalCrCountByGroup(user.getDepartment());
             clearingRequest.setPriority(criticalCount > 1 ? null : clearingRequest.getPriority());
             LiferayPortletURL projectUrl = createDetailLinkTemplate(request);
             projectUrl.setParameter(PROJECT_ID, clearingRequest.getProjectId());
@@ -1482,7 +1482,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             request.setAttribute(PortalConstants.ORGANIZATIONS, organizations);
             String dateLimit = CommonUtils.nullToEmptyString(ModerationPortletUtils.loadPreferredClearingDateLimit(request, UserCacheHolder.getUserFromRequest(request)));
             request.setAttribute(CUSTOM_FIELD_PREFERRED_CLEARING_DATE_LIMIT, dateLimit);
-            Integer criticalCount = modClient.getCriticalClearingRequestCount();
+            Integer criticalCount = modClient.getOpenCriticalCrCountByGroup(user.getDepartment());
             request.setAttribute(CRITICAL_CR_COUNT, criticalCount);
         } catch(TException e) {
             log.error("Error in getting the projectList from backend ", e);
@@ -1633,7 +1633,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 String dateLimit = CommonUtils.nullToEmptyString(ModerationPortletUtils.loadPreferredClearingDateLimit(request, UserCacheHolder.getUserFromRequest(request)));
                 request.setAttribute(CUSTOM_FIELD_PREFERRED_CLEARING_DATE_LIMIT, dateLimit);
                 ModerationService.Iface modClient = thriftClients.makeModerationClient();
-                Integer criticalCount = modClient.getCriticalClearingRequestCount();
+                Integer criticalCount = modClient.getOpenCriticalCrCountByGroup(user.getDepartment());
                 request.setAttribute(IS_CLEARING_REQUEST_DISABLED_FOR_PROJECT_BU, false);
                 Set<String> groupsWithCrDisabled = Stream.of(PortalConstants.DISABLE_CLEARING_REQUEST_FOR_PROJECT_WITH_GROUPS.toLowerCase().split(",")).collect(Collectors.toSet());
                 if (CommonUtils.isNotEmpty(groupsWithCrDisabled) && groupsWithCrDisabled.contains(project.getBusinessUnit().toLowerCase())

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/moderation/view.jsp
@@ -790,8 +790,8 @@ AUI().use('liferay-portlet-url', function () {
                         projCell.data(renderLinkToProject(response[i].id, projName));
                         if (isOpenCrTable) {
                             let clearing = response[i].clearing,
-                                totalCount = d(clearing.newRelease) + d(clearing.underClearing) + d(clearing.sentToClearingTool) + d(clearing.reportAvailable) + d(clearing.approved) + d(clearing.scanAvailable),
-                                approvedCount = d(clearing.reportAvailable) + d(clearing.approved);
+                                totalCount = (!clearing) ? 0 : d(clearing.newRelease) + d(clearing.underClearing) + d(clearing.sentToClearingTool) + d(clearing.reportAvailable) + d(clearing.approved) + d(clearing.scanAvailable),
+                                approvedCount = (!clearing) ? 0 : d(clearing.reportAvailable) + d(clearing.approved);
                             compCell.data(totalCount - approvedCount);
                             if (!totalCount || $(table.cell('#'+crId, 4).node()).find('span.sw360-tt-ClearingRequestState-NEW').text()) {
                                 progressCell.data('<liferay-ui:message key="not.available" />');

--- a/libraries/lib-datahandler/src/main/thrift/moderation.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/moderation.thrift
@@ -269,7 +269,7 @@ service ModerationService {
     set<string> getRequestingUserDepts();
 
     /**
-     * get the count of CR with priority 'critical'
+     * get the count of open CR with priority 'critical' and user group
      **/
-    i32 getCriticalClearingRequestCount();
+    i32 getOpenCriticalCrCountByGroup(1: string group);
 }


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

SW360 user were not able to create the `critical` clearing request, 
The issue was due:
- The critical CR from other group / department were also considered while fetching the count.
- There were `closed` CR in `critical` state.

Changes: 
- This PR includes changes in logic of fetching the `critical` CR count from database.
- This PR will make the critical CR mutually exclusive from user group (department).
- Now only critical CR in `open` state and the CR that belong to user `group` will be counted.


Issue: #1564 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?

- Login as a user from department `X`, Create 2 `critical` CR for project belonged to department `X`.
- Now login as a user from department `Y`, and you should be able to create up to 2 `critical` CR for project belonged to department `Y`.


### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: Abdul Kapti <abdul.kapti@siemens-healthineers.com>
