### PR TITLE
feat(ProjectUI): Load License info header text based on project group

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -539,7 +539,7 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
 
     private void fillDefaults(Project project) {
         if(!project.isSetLicenseInfoHeaderText()) {
-            project.setLicenseInfoHeaderText(getDefaultLicenseInfoHeaderText());
+            project.setLicenseInfoHeaderText(getDefaultLicenseInfoHeaderText(null));
         }
         if(!project.isSetObligationsText()) {
             project.setObligationsText(getDefaultObligationsText());
@@ -825,7 +825,10 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
     }
 
     @Override
-    public String getDefaultLicenseInfoHeaderText() {
+    public String getDefaultLicenseInfoHeaderText(String fileName) {
+        if (CommonUtils.isNotNullEmptyOrWhitespace(fileName)) {
+            return SW360Utils.dropCommentedLine(LicenseInfoHandler.class, fileName);
+        }
         return DEFAULT_LICENSE_INFO_TEXT;
     }
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -49,6 +49,7 @@ public class PortalConstants {
     public static final Boolean SEND_COMPONENT_SPREADSHEET_EXPORT_TO_MAIL_ENABLED;
     public static final String LOAD_OPEN_MODERATION_REQUEST = "loadOpenModerationRequest";
     public static final String LOAD_CLOSED_MODERATION_REQUEST = "loadClosedModerationRequest";
+    public static final String LICENSE_INFO_HEADER_TEXT_FILE_NAME_BY_PROJECT_GROUP;
 
     // DO NOT CHANGE THIS UNLESS YOU KNOW WHAT YOU ARE DOING !!!
     // - friendly url mapping files must be changed
@@ -696,6 +697,7 @@ public class PortalConstants {
         API_TOKEN_HASH_SALT = props.getProperty("rest.apitoken.hash.salt", "$2a$04$Software360RestApiSalt");
         API_WRITE_ACCESS_USERGROUP = UserGroup.valueOf(props.getProperty("rest.write.access.usergroup", UserGroup.ADMIN.name()));
         USER_ROLE_ALLOWED_TO_MERGE_OR_SPLIT_COMPONENT = UserGroup.valueOf(props.getProperty("user.role.allowed.to.merge.or.split.component", UserGroup.ADMIN.name()));
+        LICENSE_INFO_HEADER_TEXT_FILE_NAME_BY_PROJECT_GROUP = props.getProperty("org.eclipse.sw360.licensinfo.header.by.group", "");
         CLEARING_REPORT_TEMPLATE_TO_FILENAMEMAPPING = props.getProperty("org.eclipse.sw360.licensinfo.projectclearing.templatemapping", "");
         CLEARING_REPORT_TEMPLATE_FORMAT = props.getProperty("org.eclipse.sw360.licensinfo.projectclearing.templateformat", "docx");
         PREDEFINED_TAGS = props.getProperty("project.tag", "[]");

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortlet.java
@@ -909,7 +909,7 @@ public class ModerationPortlet extends FossologyAwarePortlet {
             actual_project = client.fillClearingStateSummary(Collections.singletonList(actual_project), user).get(0);
             is_used = client.projectIsUsed(actual_project.getId());
             request.setAttribute(PortalConstants.ACTUAL_PROJECT, actual_project);
-            request.setAttribute(PortalConstants.DEFAULT_LICENSE_INFO_HEADER_TEXT, getDefaultLicenseInfoHeaderText());
+            request.setAttribute(PortalConstants.DEFAULT_LICENSE_INFO_HEADER_TEXT, getDefaultLicenseInfoHeaderText(actual_project.getBusinessUnit()));
             request.setAttribute(IS_CLEARING_REQUEST_DISABLED_FOR_PROJECT_BU, true);
         } catch (TException e) {
             log.error("Could not retrieve project", e);
@@ -1070,10 +1070,16 @@ public class ModerationPortlet extends FossologyAwarePortlet {
         throw unsupportedActionException();
     }
 
-    private String getDefaultLicenseInfoHeaderText() {
+    private String getDefaultLicenseInfoHeaderText(String group) {
         final LicenseInfoService.Iface licenseInfoClient = thriftClients.makeLicenseInfoClient();
         try {
-            String defaultLicenseInfoHeaderText = licenseInfoClient.getDefaultLicenseInfoHeaderText();
+            String fileName = "";
+            if (CommonUtils.isNotNullEmptyOrWhitespace(PortalConstants.LICENSE_INFO_HEADER_TEXT_FILE_NAME_BY_PROJECT_GROUP) ) {
+                Map<String, String> groupToFileName = Arrays.stream(PortalConstants.LICENSE_INFO_HEADER_TEXT_FILE_NAME_BY_PROJECT_GROUP.split(","))
+                        .collect(Collectors.toMap(k -> k.split(":")[0].trim().toUpperCase(), v -> v.split(":")[1], (oldValue, newValue) -> oldValue));
+                fileName = groupToFileName.get(group.trim().toUpperCase());
+            }
+            String defaultLicenseInfoHeaderText = licenseInfoClient.getDefaultLicenseInfoHeaderText(fileName);
             return defaultLicenseInfoHeaderText;
         } catch (TException e) {
             log.error("Could not load default license info header text from backend.", e);

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -1590,12 +1590,12 @@ public class ProjectPortlet extends FossologyAwarePortlet {
     private void prepareDetailView(RenderRequest request, RenderResponse response) throws IOException, PortletException {
         User user = UserCacheHolder.getUserFromRequest(request);
         String id = request.getParameter(PROJECT_ID);
-        setDefaultRequestAttributes(request);
         request.setAttribute(DOCUMENT_ID, id);
         if (id != null) {
             try {
                 ProjectService.Iface client = thriftClients.makeProjectClient();
                 Project project = client.getProjectById(id, user);
+                setDefaultRequestAttributes(request, project.getBusinessUnit());
                 project = getWithFilledClearingStateSummary(project, user);
                 Map<String, String> sortedAdditionalData = getSortedMap(project.getAdditionalData(), true);
                 project.setAdditionalData(sortedAdditionalData);
@@ -2237,7 +2237,6 @@ public class ProjectPortlet extends FossologyAwarePortlet {
 
         User user = UserCacheHolder.getUserFromRequest(request);
         String id = request.getParameter(PROJECT_ID);
-        setDefaultRequestAttributes(request);
         Project project;
         Set<Project> usingProjects;
         int allUsingProjectCount = 0;
@@ -2251,6 +2250,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             try {
                 ProjectService.Iface client = thriftClients.makeProjectClient();
                 project = client.getProjectByIdForEdit(id, user);
+                setDefaultRequestAttributes(request, project.getBusinessUnit());
                 Map<String, String> sortedAdditionalData = getSortedMap(project.getAdditionalData(), true);
                 project.setAdditionalData(sortedAdditionalData);
                 usingProjects = client.searchLinkingProjects(id, user);
@@ -2287,6 +2287,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 project = new Project();
                 project.setBusinessUnit(user.getDepartment());
                 request.setAttribute(PROJECT, project);
+                setDefaultRequestAttributes(request, user.getDepartment());
                 PortletUtils.setCustomFieldsEdit(request, user, project);
                 setAttachmentsInRequest(request, project);
                 try {
@@ -2308,7 +2309,6 @@ public class ProjectPortlet extends FossologyAwarePortlet {
         User user = UserCacheHolder.getUserFromRequest(request);
         String id = request.getParameter(PROJECT_ID);
         request.setAttribute(IS_USER_AT_LEAST_CLEARING_ADMIN, PermissionUtils.isUserAtLeast(UserGroup.CLEARING_ADMIN, user));
-        setDefaultRequestAttributes(request);
         List<Organization> organizations = UserUtils.getOrganizations(request);
         request.setAttribute(ORGANIZATIONS, organizations);
 
@@ -2317,8 +2317,8 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 ProjectService.Iface client = thriftClients.makeProjectClient();
                 String emailFromRequest = LifeRayUserSession.getEmailFromRequest(request);
                 String department = user.getDepartment();
-
                 Project newProject = PortletUtils.cloneProject(emailFromRequest, department, client.getProjectById(id, user));
+                setDefaultRequestAttributes(request, newProject.getBusinessUnit());
                 Map<String, String> sortedAdditionalData = getSortedMap(newProject.getAdditionalData(), true);
                 newProject.setAdditionalData(sortedAdditionalData);
                 setAttachmentsInRequest(request, newProject);
@@ -2334,7 +2334,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 Project project = new Project();
                 project.setBusinessUnit(user.getDepartment());
                 setAttachmentsInRequest(request, project);
-
+                setDefaultRequestAttributes(request, user.getDepartment());
                 request.setAttribute(PROJECT, project);
                 PortletUtils.setCustomFieldsEdit(request, user, project);
                 putDirectlyLinkedProjectsInRequest(request, project, user);
@@ -2583,11 +2583,16 @@ public class ProjectPortlet extends FossologyAwarePortlet {
         writer.write(responseData.toString());
     }
 
-    private String getProjectDefaultLicenseInfoHeaderText() {
+    private String getProjectDefaultLicenseInfoHeaderText(String group) {
         final LicenseInfoService.Iface licenseInfoClient = thriftClients.makeLicenseInfoClient();
         try {
-            String defaultLicenseInfoHeaderText = licenseInfoClient.getDefaultLicenseInfoHeaderText();
-            return defaultLicenseInfoHeaderText;
+            String fileName = "";
+            if (CommonUtils.isNotNullEmptyOrWhitespace(PortalConstants.LICENSE_INFO_HEADER_TEXT_FILE_NAME_BY_PROJECT_GROUP) ) {
+                Map<String, String> groupToFileName = Arrays.stream(PortalConstants.LICENSE_INFO_HEADER_TEXT_FILE_NAME_BY_PROJECT_GROUP.split(","))
+                        .collect(Collectors.toMap(k -> k.split(":")[0].trim().toUpperCase(), v -> v.split(":")[1], (oldValue, newValue) -> newValue));
+                fileName = groupToFileName.get(group.trim().toUpperCase());
+            }
+            return licenseInfoClient.getDefaultLicenseInfoHeaderText(fileName);
         } catch (TException e) {
             log.error("Could not load default license info header text from backend.", e);
             return "";
@@ -3053,9 +3058,9 @@ public class ProjectPortlet extends FossologyAwarePortlet {
         return projectData;
     }
 
-    private void setDefaultRequestAttributes(RenderRequest request) {
+    private void setDefaultRequestAttributes(RenderRequest request, String group) {
         request.setAttribute(DOCUMENT_TYPE, SW360Constants.TYPE_PROJECT);
-        request.setAttribute(DEFAULT_LICENSE_INFO_HEADER_TEXT, getProjectDefaultLicenseInfoHeaderText());
+        request.setAttribute(DEFAULT_LICENSE_INFO_HEADER_TEXT, getProjectDefaultLicenseInfoHeaderText(CommonUtils.nullToEmptyString(group)));
         request.setAttribute(DEFAULT_OBLIGATIONS_TEXT, getProjectDefaultObligationsText());
     }
 

--- a/libraries/lib-datahandler/src/main/thrift/licenseinfo.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/licenseinfo.thrift
@@ -155,9 +155,9 @@ service LicenseInfoService {
     OutputFormatInfo getOutputFormatInfoForGeneratorClass(1: string generatorClassName);
 
     /**
-     * returns the default license info header text
+     * returns the default license info header text based on project group
      */
-    string getDefaultLicenseInfoHeaderText();
+    string getDefaultLicenseInfoHeaderText(1: string fileName);
 
     /**
      * returns the default obligations text


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

- `License Info Header` text can be configured based on project group, using the property `org.eclipse.sw360.licensinfo.header.by.group` in `sw360.properties` file.

Issue: #953 


### How To Test?

- Define a property key `org.eclipse.sw360.licensinfo.header.by.group` in `sw360.peoperties` files, with value as `GroupName : LicenseHeaderInfoTextFileName.txt` (comma separated for multiple group)
- For example: `org.eclipse.sw360.licensinfo.header.by.group = IT:IT_LicenseInfoHeader.txt`
- Create 2 projects, `project A` with group mentioned in above property and `Project B` with group which is NOT mentioned in above property 
- For example: `Project A` with group `IT`, and `Project B` with group `EC`
- Now loading of `project A` should load the `License Info Header` text from file configured for group `IT` in properties file and loading of `project B` should load the License Info Header text from default file

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
Signed-off-by: Abdul Kapti <abdul.kapti@siemens-healthineers.com>
