### PR TITLE
fix/svmcomponentids - do not copy svm component ids

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -1077,6 +1077,7 @@ public class ComponentPortlet extends FossologyAwarePortlet {
             request.setAttribute(RELEASE_LIST, Collections.emptyList());
             request.setAttribute(TOTAL_INACCESSIBLE_ROWS, 0);
             setUsingDocs(request, null, user, client);
+            release.unsetExternalIds();
             request.setAttribute(RELEASE, release);
             request.setAttribute(PortalConstants.ATTACHMENTS, Collections.emptySet());
 

--- a/frontend/sw360-portlet/src/main/resources/sw360.properties
+++ b/frontend/sw360-portlet/src/main/resources/sw360.properties
@@ -91,6 +91,7 @@
 #key.auth.givenname=GIVENNAME
 #key.auth.surname=SURNAME
 #key.auth.department=DEPARTMENT
+release.externalId.to.be.removed.while.cloning=
 
 ## OrganizationHelper
 #match.prefix=false


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (#1587 ) 
> * Did you add or update any new dependencies that are required for your change? No

Issue: 
Do not copy any SVM component ids #1587 


### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
1)Goto component tab
2)click on component name
3)select release overview
4)We will find the list of name, then click on version 
5)click on edit Release button
6)Add external ids and values, then update Release button
7) then go back and click on duplicate.
8) few fields will be editable in new page(duplicate page) ex : edit version 
9) click on create release button and verify external ids will  be  blank.

![image](https://user-images.githubusercontent.com/49710817/178424533-edeb7c5d-722f-4881-951c-ca450a3349b3.png)
 
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
