### PR TITLE
fix(ui): cannot link Component with closed project

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/components/includes/releases/linkProject.js
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/components/includes/releases/linkProject.js
@@ -163,6 +163,14 @@ define('components/includes/releases/linkProject', ['jquery', 'bridges/datatable
 
                 $dialog.success($result, true);
             },
+            beforeSend : function (test) {
+                var projectState = $('#projectSearchResultstable input[name=project]:checked').parents('tr').find('td .stateBox.capsuleRight').prop('title');
+                if(projectState == "Closed") {
+                    callback();
+                    $dialog.alert('The release could not be linked to the closed project.');
+                    return false;
+                }
+            },
             error: function() {
                 callback();
                 $dialog.alert('The release could not be linked to the project.');


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 
User able to link the component to a closed project.
(#1583)

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
* Go to Release page of the component and then try to link a project to that release by clicking "Link to Project"
*  Now Select any closed state project and try to link it
*  You won't be able to link that project and will get a message, the release could not be linked to the closed project.

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
![ClosedProject](https://user-images.githubusercontent.com/58290634/177473525-07fd6d74-aa58-447f-9765-db48cb50cfc6.PNG)

