### PR TITLE
Fix (Component): Fix bug component list sorting

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -2290,9 +2290,6 @@ public class ComponentPortlet extends FossologyAwarePortlet {
         int sortParam = -1;
         if (paginationParameters.getSortingColumn().isPresent()) {
             sortParam = paginationParameters.getSortingColumn().get();
-            if (sortParam == 1 && Integer.valueOf(paginationParameters.getEcho()) == 1) {
-                sortParam = -1;
-            }
         }
         pageData.setSortColumnNumber(sortParam);
 


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)


Issue: #1223 

Currently, if the user goes to the component page at the first time, the components will be sorted by "CreatedOn". After that, the user goes to the next page, the components will be sorted by "Name".
The behavior is not incorrect, but it will cause misunderstanding for users.

### How To Test?
Refer to #1223 

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
