### PR TITLE
feat(UI):Made the table header collapsible wherever possible

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/main.scss
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/css/main.scss
@@ -191,14 +191,14 @@
 	}
 
 	table {
-            thead.cursor {
-                cursor: pointer;
-            }
-            td {
-                svg.cursor {
-                    cursor: pointer;
-                }
-            }
+		thead.cursor {
+			cursor: pointer;
+		}
+		td {
+			svg.cursor {
+			cursor: pointer;
+			}
+		}
 		div.actions {
 			display: flex;
 			justify-content: space-evenly;
@@ -226,6 +226,9 @@
 			a:last-child, img:last-child, svg:last-child {
 				margin-right: 0;
 			}
+		}
+		thead[data-toggle="collapse"] {
+			cursor: pointer;
 		}
 	}
 

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/summary.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/components/summary.jspf
@@ -17,11 +17,12 @@
 </core_rt:if>
 
 <table class="table label-value-table" id="componentOverview">
-    <thead>
+    <thead data-toggle="collapse" data-target="#componentOverviewBody" aria-expanded="true" aria-controls="componentOverviewBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
         <tr>
             <th colspan="2"><liferay-ui:message key="general" /></th>
         </tr>
     </thead>
+    <tbody id="componentOverviewBody" class="collapse show">
     <tr>
         <td><liferay-ui:message key="id" />:</td>
         <td id="documentId"><sw360:out value="${component.id}"/>
@@ -92,14 +93,16 @@
         <td><liferay-ui:message key="additional.data" />:</td>
         <td><ul id="list-data-additional-contentComponent" class="mapDisplayRootItem"></ul> </td>
     </tr>
+    </tbody>
 </table>
 
 <table class="table label-value-table" id="releaseAggregateTable">
-    <thead>
+    <thead data-toggle="collapse" data-target="#releaseAggregateTableBody" aria-expanded="true" aria-controls="releaseAggregateTableBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
         <tr>
             <th colspan="2"><liferay-ui:message key="release.aggregate.data" /></th>
         </tr>
     </thead>
+    <tbody id="releaseAggregateTableBody" class="collapse show">
     <tr>
         <td><liferay-ui:message key="vendors" />:</td>
         <td><sw360:DisplayCollection value="${component.vendorNames}"/></td>
@@ -122,14 +125,16 @@
             <sw360:DisplayCollection value="${component.mainLicenseIds}" />
         </td>
     </tr>
+    </tbody>
 </table>
 
 <table class="table label-value-table" id="componentRolesTable">
-    <thead>
+    <thead data-toggle="collapse" data-target="#componentRolesTableBody" aria-expanded="true" aria-controls="componentRolesTableBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
         <tr>
             <th colspan="2"><liferay-ui:message key="roles" /></th>
         </tr>
     </thead>
+    <tbody id="componentRolesTableBody" class="collapse show">
     <core_rt:if test="${componentVisibilityRestriction}">
         <tr>
             <td><liferay-ui:message key="group" />:</td>
@@ -164,4 +169,5 @@
         <td><liferay-ui:message key="additional.roles" />:</td>
         <td><sw360:DisplayMapOfEmailSets value="${component.roles}"/></td>
     </tr>
+    </tbody>
 </table>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/clearingDetails.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/clearingDetails.jspf
@@ -91,13 +91,13 @@
 <table class="table label-value-table" id="assessmentSummary"
         data-load-assessment-summary-info-url="<%=loadAssessmentSummaryInfoUrl%>"
         data-attachment-content-id="${cliDbid}" data-approved-attachment-content-id="${approvedCliDbid}">
-    <thead>
+    <thead data-toggle="collapse" data-target="#assessmentSummaryBody" aria-expanded="true" aria-controls="assessmentSummaryBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
         <tr>
             <th colspan="2"><liferay-ui:message key="assessment.summary" /> <liferay-ui:message key="info" />:</th>
         </tr>
     </thead>
 
-    <tbody class="btnBody">
+    <tbody id="assessmentSummaryBody" class="collapse show btnBody">
         <tr>
             <td colspan="2">
             <core_rt:choose>
@@ -117,7 +117,7 @@
             </td>
         </tr>
     </tbody>
-    <tbody class="dataBody d-none">
+    <tbody id="assessmentSummaryBody" class="collapse show dataBody d-none">
         <tr data-key="GeneralAssessment">
             <td>General Assessment</td>
             <td class="comment-text"></td>
@@ -146,10 +146,12 @@
 </table>
 
 <table class="table label-value-table" id="ReleaseClearingOverview">
+    <thead data-toggle="collapse" data-target="#ReleaseClearingOverviewBody" aria-expanded="true" aria-controls="ReleaseClearingOverviewBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
     <tr>
         <th colspan="2"><liferay-ui:message key="clearing.details" />: <sw360:ReleaseName release="${release}" /></th>
     </tr>
     </thead>
+    <tbody id="ReleaseClearingOverviewBody" class="collapse show">
     <tr>
         <td><liferay-ui:message key="clearing.state" />:</td>
         <td class="actions">
@@ -257,15 +259,16 @@
         <td><liferay-ui:message key="comments" />:</td>
         <td><sw360:out value="${clearingInfo.comment}"/></td>
     </tr>
+    </tbody>
 </table>
 
 <table class="table label-value-table" id="RequestInfo">
-    <thead>
+    <thead data-toggle="collapse" data-target="#RequestInfoBody" aria-expanded="true" aria-controls="RequestInfoBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
     <tr>
         <th colspan="2"><liferay-ui:message key="request.information" /></th>
     </tr>
     </thead>
-
+    <tbody id="RequestInfoBody" class="collapse show">
     <tr>
         <td><liferay-ui:message key="request.id" />:</td>
         <td><sw360:out value="${clearingInfo.requestID}"/></td>
@@ -282,14 +285,16 @@
         <td><liferay-ui:message key="evaluation.end" /></td>
         <td><sw360:out value="${clearingInfo.evaluated}"/></td>
     </tr>
+    </tbody>
 </table>
 
 <table class="table label-value-table" id="ReleaseSupplementalInfo">
-    <thead>
+    <thead data-toggle="collapse" data-target="#ReleaseSupplementalInfoBody" aria-expanded="true" aria-controls="ReleaseSupplementalInfoBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
     <tr>
         <th colspan="2"><liferay-ui:message key="supplemental.information" /></th>
     </tr>
     </thead>
+    <tbody id="ReleaseSupplementalInfoBody" class="collapse show">
     <tr>
         <td><liferay-ui:message key="external.supplier.id" />:</td>
         <td><sw360:out value="${clearingInfo.externalSupplierID}"/></td>
@@ -298,12 +303,12 @@
         <td><liferay-ui:message key="number.of.security.vulnerabilities" />:</td>
         <td><sw360:out value="${clearingInfo.countOfSecurityVn}"/></td>
     </tr>
+    </tbody>
 </table>
 
 
 <%--for javascript library loading --%>
 <%@ include file="/html/utils/includes/requirejs.jspf" %>
-<%@ include file="/html/utils/includes/pageSpinner.jspf" %>
 <script type="text/javascript">
     require(['jquery', 'modules/button', 'utils/includes/fossologyClearing', 'modules/dialog'], function ($, button, fossology, dialog) {
         var releaseToLicenseDetailsMap = new Map();

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/commercialDetails.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/commercialDetails.jspf
@@ -9,11 +9,12 @@
 --%>
 <core_rt:set var="cotsDetails" value="${release.cotsDetails}"/>
 <table class="table label-value-table" id="cotsDetailOverview">
-    <thead>
+    <thead data-toggle="collapse" data-target="#cotsDetailOverviewBody" aria-expanded="true" aria-controls="cotsDetailOverviewBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
     <tr>
         <th colspan="2"><liferay-ui:message key="commercial.details.administration" /></th>
     </tr>
     </thead>
+    <tbody  id="cotsDetailOverviewBody" class="collapse show">
     <tr>
         <td><liferay-ui:message key="usage.right.available" />:</td>
         <td><sw360:DisplayBoolean defined="${cotsDetails.setUsageRightAvailable}"
@@ -31,14 +32,16 @@
         <td><liferay-ui:message key="cots.clearing.report.url" />:</td>
         <td><sw360:out value="${cotsDetails.licenseClearingReportURL}"/></td>
     </tr>
+    </tbody>
 </table>
 
 <table class="table label-value-table" id="cotsOssInformation">
-    <thead>
+    <thead data-toggle="collapse" data-target="#cotsOssInformationBody" aria-expanded="true" aria-controls="cotsOssInformationBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
     <tr>
         <th colspan="2"><liferay-ui:message key="cots.oss.information" /></th>
     </tr>
     </thead>
+    <tbody  id="cotsOssInformationBody" class="collapse show">
     <tr>
         <td><liferay-ui:message key="used.license" />:</td>
         <td><sw360:out value="${cotsDetails.usedLicense}"/></td>
@@ -62,4 +65,5 @@
         <td><sw360:DisplayBoolean defined="${cotsDetails.setSourceCodeAvailable}"
                                   value="${cotsDetails.sourceCodeAvailable}"/></td>
     </tr>
+    </tbody>
 </table>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/eccDetails.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/eccDetails.jspf
@@ -11,11 +11,12 @@
 <core_rt:set var="eccInfo" value="${release.eccInformation}"/>
 
 <table class="table label-value-table" id="ECCInfo">
-    <thead>
+    <thead data-toggle="collapse" data-target="#ECCInfoBody" aria-expanded="true" aria-controls="ECCInfoBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
     <tr>
         <th colspan="2"><liferay-ui:message key="ecc.information" /></th>
     </tr>
     </thead>
+    <tbody id="ECCInfoBody" class="collapse show">
     <tr>
         <td><liferay-ui:message key="ecc.status" />:</td>
         <td><sw360:DisplayEnum value="${eccInfo.eccStatus}"/></td>
@@ -48,4 +49,5 @@
         <td><liferay-ui:message key="assessment.date" />:</td>
         <td><sw360:out value="${eccInfo.assessmentDate}"/></td>
     </tr>
+    </tbody>
 </table>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/summaryRelease.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/releases/summaryRelease.jspf
@@ -16,11 +16,12 @@
 
 <core_rt:if test="${release != null}">
     <table class="table label-value-table" id="ReleaseDetailOverview">
-        <thead>
+        <thead data-toggle="collapse" data-target="#ReleaseDetailOverviewBody" aria-expanded="true" aria-controls="ReleaseDetailOverviewBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
         <tr>
             <th colspan="2"><liferay-ui:message key="general" /></th>
         </tr>
         </thead>
+        <tbody id="ReleaseDetailOverviewBody" class="collapse show">
         <tr>
             <td><liferay-ui:message key="id" />:</td>
             <td id="documentId"><sw360:out value="${release.id}"/>
@@ -114,20 +115,22 @@
             <td><liferay-ui:message key="additional.data" />:</td>
             <td><ul id="list-data-additional-release" class="mapDisplayRootItem"></ul> </td>
         </tr>
+        </tbody>
     </table>
 
     <core_rt:if test="${release.setRepository}">
         <table class="table label-value-table" id="ReleaseRepository">
-            <thead>
+            <thead data-toggle="collapse" data-target="#ReleaseRepositoryBody" aria-expanded="true" aria-controls="ReleaseRepositoryBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
             <tr>
                 <th colspan="2"><liferay-ui:message key="release.repository" /></th>
             </tr>
             </thead>
-
+            <tbody id="ReleaseRepositoryBody" class="collapse show">
             <tr>
                 <td><liferay-ui:message key="repository" />:</td>
                 <td><sw360:DisplayLink target="${release.repository.url}"/> <sw360:out value="(${release.repository.repositorytype})"/></td>
             </tr>
+            </tbody>
         </table>
     </core_rt:if>
 

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/vendors/vendorDetail.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/components/includes/vendors/vendorDetail.jspf
@@ -9,11 +9,12 @@
 --%>
 
 <table class="table label-value-table" id="ReleaseDetailVendor">
-    <thead>
+    <thead data-toggle="collapse" data-target="#ReleaseDetailVendorBody" aria-expanded="true" aria-controls="ReleaseDetailVendorBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
         <tr>
             <th colspan="2"><liferay-ui:message key="release.vendor" /></th>
         </tr>
     </thead>
+    <tbody id="ReleaseDetailVendorBody" class="collapse show" >
     <tr>
         <td><liferay-ui:message key="full.name" />:</td>
         <td><sw360:out value="${release.vendor.fullname}"/></td>
@@ -26,4 +27,5 @@
         <td><liferay-ui:message key="url" />:</td>
         <td><sw360:out value="${release.vendor.url}"/></td>
     </tr>
+    </tbody>
 </table>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/administration.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/administration.jspf
@@ -9,11 +9,12 @@
 --%>
 
 <table class="table label-value-table" id="clearing">
-    <thead>
+    <thead data-toggle="collapse" data-target="#clearingBody" aria-expanded="true" aria-controls="clearingBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
     <tr>
         <th colspan="2"><liferay-ui:message key="clearing" /></th>
     </tr>
     </thead>
+    <tbody id="clearingBody" class="collapse show">
     <tr>
         <td><liferay-ui:message key="project.clearing.state" />:</td>
         <td><sw360:DisplayEnum value="${project.clearingState}"/></td>
@@ -87,14 +88,16 @@
             <textarea class="form-control" rows="5" id="remarksAdditionalRequirementsText" name="<portlet:namespace/><%=Project._Fields.REMARKS_ADDITIONAL_REQUIREMENTS%>" readonly><sw360:out value="${project.remarksAdditionalRequirements}" /></textarea>
         </td>
     </tr>
+    </tbody>
 </table>
 
 <table class="table label-value-table" id="lifecycle">
-    <thead>
+    <thead data-toggle="collapse" data-target="#lifecycleBody" aria-expanded="true" aria-controls="lifecycleBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
     <tr>
         <th colspan="2"><liferay-ui:message key="lifecycle" /></th>
     </tr>
     </thead>
+    <tbody id="lifecycleBody" class="collapse show">
     <tr>
         <td><liferay-ui:message key="project.state" />:</td>
         <td><sw360:DisplayEnum value="${project.state}"/></td>
@@ -115,19 +118,22 @@
         <td><liferay-ui:message key="phase.out.since" />:</td>
         <td><sw360:out value="${project.phaseOutSince}"/></td>
     </tr>
+    </tbody>
 </table>
 
 <table class="table label-value-table" id="LicenseInfoHeader" title="<liferay-ui:message key="license.info.header" />">
-    <thead>
+    <thead data-toggle="collapse" data-target="#LicenseInfoHeaderBody" aria-expanded="true" aria-controls="LicenseInfoHeaderBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
     <tr>
         <th><liferay-ui:message key="license.info.header" /></th>
     </tr>
     </thead>
+    <tbody id="LicenseInfoHeaderBody" class="collapse show">
     <tr>
         <td>
             <textarea class="form-control" rows="5" id="licenseInfoHeaderText" readonly><sw360:DisplayLicenseInfoHeader project="${project}" defaultText="${defaultLicenseInfoHeaderText}"/></textarea>
         </td>
     </tr>
+    </tbody>
 </table>
 
 <%--for javascript library loading --%>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/summary.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/summary.jspf
@@ -16,11 +16,12 @@
 </core_rt:if>
 
 <table class="table label-value-table" id="general">
-    <thead>
+    <thead data-toggle="collapse" data-target="#generalBody" aria-expanded="true" aria-controls="generalBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
     <tr>
         <th colspan="2"><liferay-ui:message key="general.information" /></th>
     </tr>
     </thead>
+    <tbody id="generalBody" class="collapse show">
     <tr>
         <td><liferay-ui:message key="id" />:</td>
         <td id="documentId"><sw360:out value="${project.id}"/>
@@ -81,14 +82,16 @@
         <td><liferay-ui:message key="external.urls" />:</td>
         <td><sw360:DisplayMapOfExternalUrls value="${project.externalUrls}"/></td>
     </tr>
+    </tbody>
 </table>
 
 <table class="table label-value-table" id="roles">
-    <thead>
+    <thead data-toggle="collapse" data-target="#rolesBody" aria-expanded="true" aria-controls="rolesBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
     <tr>
         <th colspan="2"><liferay-ui:message key="roles" /></th>
     </tr>
     </thead>
+    <tbody id="rolesBody" class="collapse show">
     <tr>
         <td><liferay-ui:message key="group" />:</td>
         <td><sw360:out value="${project.businessUnit}"/></td>
@@ -133,4 +136,5 @@
         <td><liferay-ui:message key="additional.roles" />:</td>
         <td><sw360:DisplayMapOfEmailSets value="${project.roles}"/></td>
     </tr>
+    </tbody>
 </table>

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/vendors/vendorDetail.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/vendors/vendorDetail.jspf
@@ -9,11 +9,12 @@
 --%>
 
 <table class="table label-value-table" id="projectDetailVendor">
-    <thead>
+    <thead data-toggle="collapse" data-target="#vendorBody" aria-expanded="true" aria-controls="vendorBody" title="<liferay-ui:message key="click.to.expand.or.collapse"/>">
         <tr>
             <th colspan="2"><liferay-ui:message key="project.vendor" /></th>
         </tr>
     </thead>
+    <tbody id="vendorBody" class="collapse show">
     <tr>
         <td><liferay-ui:message key="full.name" />:</td>
         <td><sw360:out value="${project.vendor.fullname}"/></td>
@@ -26,4 +27,5 @@
         <td><liferay-ui:message key="url" />:</td>
         <td><sw360:out value="${project.vendor.url}"/></td>
     </tr>
+    </tbody>
 </table>

--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -226,6 +226,7 @@ click.to.add.row.to.external.urls=Click to add row to External URLs
 click.to.add.secondary.department.and.roles=Click to add Secondary Department and Roles
 click.to.edit=Click to edit
 click.to.set.department=Click to set Department
+click.to.expand.or.collapse=Click to expand or collapse
 click.to.set.licenses=Click to set Licenses
 click.to.set.vendor=Click to set vendor
 client.id=Client Id

--- a/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
@@ -226,6 +226,7 @@ click.to.add.row.to.external.urls=クリックして外部URLの行を追加
 click.to.add.secondary.department.and.roles=クリックして第二所属部門とロールを追加
 click.to.edit=クリックして編集
 click.to.set.department=クリックして部門を設定
+click.to.expand.or.collapse=Click to expand or collapse
 click.to.set.licenses=クリックしてライセンスを設定
 click.to.set.vendor=クリックしてベンダーを設定
 client.id=クライアントID

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -227,6 +227,7 @@ click.to.add.row.to.external.urls=Click to add row to External URLs
 click.to.add.secondary.department.and.roles=Click to add Secondary Department and Roles
 click.to.edit=Bấm vào để chỉnh sửa
 click.to.set.department=Nhấn vào đây để đặt bộ phận
+click.to.expand.or.collapse=Click to expand or collapse
 click.to.set.licenses=Nhấn vào đây để đặt Giấy phép
 click.to.set.vendor=Nhấn vào đây để đặt nhà cung cấp
 client.id=Client Id


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Made the table header collapsible in project, components and release details page. (only in read mode and not in edit mode)

Issue: #1584 

### How To Test?

- Hover over any table header of `summary` tab in projects, components or release and it should display tooltip `click to expand or collapse`
- Clicking on header should expand or collapse the table body.


### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: Abdul Kapti <abdul.kapti@siemens-healthineers.com>

