### PR TITLE
upd(mockito): Update the deprecated old mockito-all to mockito-core

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -71,7 +71,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/backend/src-common/src/test/java/org/eclipse/sw360/datahandler/db/AttachmentAwareDatabaseHandlerTest.java
+++ b/backend/src-common/src/test/java/org/eclipse/sw360/datahandler/db/AttachmentAwareDatabaseHandlerTest.java
@@ -19,7 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.*;
 

--- a/backend/src-common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerTest.java
+++ b/backend/src-common/src/test/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandlerTest.java
@@ -26,7 +26,7 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.junit.*;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.*;
 
@@ -38,8 +38,8 @@ import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -136,7 +136,7 @@ public class ProjectDatabaseHandlerTest {
         Project project2 = handler.getProjectById("P2", user1);
         project2.setName("Project2new");
 
-        Mockito.doReturn(RequestStatus.SENT_TO_MODERATOR).when(moderator).updateProject(project2, user1);
+        Mockito.lenient().doReturn(RequestStatus.SENT_TO_MODERATOR).when(moderator).updateProject(project2, user1);
 
         RequestStatus status = handler.updateProject(project2, user1);
 

--- a/backend/src-common/src/test/java/org/eclipse/sw360/spdx/SpdxBOMImporterTest.java
+++ b/backend/src-common/src/test/java/org/eclipse/sw360/spdx/SpdxBOMImporterTest.java
@@ -18,9 +18,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.InputStream;
 
@@ -46,15 +46,15 @@ public class SpdxBOMImporterTest {
              .getClassLoader().getResourceAsStream("bom.spdx.rdf");
 
         when(spdxBOMImporterSink.addProject(any(Project.class))).then(i -> {
-            Project project = i.getArgumentAt(0, Project.class);
+            Project project = i.getArgument(0);
             return new SpdxBOMImporterSink.Response(project.getName() + "-" + project.getVersion());
         });
         when(spdxBOMImporterSink.addRelease(any(Release.class))).then(i -> {
-            Release release = i.getArgumentAt(0, Release.class);
+            Release release = i.getArgument(0);
             return new SpdxBOMImporterSink.Response(release.getName() + "-" + release.getVersion());
         });
         when(spdxBOMImporterSink.addComponent(any(Component.class))).then(i -> {
-            Component component = i.getArgumentAt(0, Component.class);
+            Component component = i.getArgument(0);
             return new SpdxBOMImporterSink.Response(component.getName());
         });
 
@@ -76,9 +76,9 @@ public class SpdxBOMImporterTest {
         final RequestSummary requestSummary = spdxBOMImporter.importSpdxBOMAsProject(inputStream, attachmentContent);
         assertNotNull(requestSummary);
 
-        verify(spdxBOMImporterSink, times(1)).addProject(Matchers.any());
-        verify(spdxBOMImporterSink, times(3)).addComponent(Matchers.any());
-        verify(spdxBOMImporterSink, times(3)).addRelease(Matchers.any());
+        verify(spdxBOMImporterSink, times(1)).addProject(ArgumentMatchers.any());
+        verify(spdxBOMImporterSink, times(3)).addComponent(ArgumentMatchers.any());
+        verify(spdxBOMImporterSink, times(3)).addRelease(ArgumentMatchers.any());
     }
 
     @Test
@@ -86,7 +86,7 @@ public class SpdxBOMImporterTest {
         final RequestSummary requestSummary = spdxBOMImporter.importSpdxBOMAsRelease(inputStream, attachmentContent);
         assertNotNull(requestSummary);
 
-        verify(spdxBOMImporterSink, times(4)).addComponent(Matchers.any());
-        verify(spdxBOMImporterSink, times(4)).addRelease(Matchers.any());
+        verify(spdxBOMImporterSink, times(4)).addComponent(ArgumentMatchers.any());
+        verify(spdxBOMImporterSink, times(4)).addRelease(ArgumentMatchers.any());
     }
 }

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ComponentDatabaseHandlerTest.java
@@ -31,7 +31,7 @@ import org.junit.*;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.*;
 import java.util.concurrent.*;
@@ -45,8 +45,8 @@ import static org.eclipse.sw360.datahandler.thrift.ThriftValidate.ensureEccInfor
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ProjectDatabaseHandlerTest.java
+++ b/backend/src/src-components/src/test/java/org/eclipse/sw360/components/db/ProjectDatabaseHandlerTest.java
@@ -40,7 +40,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.xml.crypto.Data;
 import java.util.*;

--- a/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasink/VulnerabilityConnectorTest.java
+++ b/backend/src/src-cvesearch/src/test/java/org/eclipse/sw360/cvesearch/datasink/VulnerabilityConnectorTest.java
@@ -19,7 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.*;
 

--- a/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/FossologyHandlerLocalhostIntegrationTest.java
+++ b/backend/src/src-fossology/src/test/java/org/eclipse/sw360/fossology/FossologyHandlerLocalhostIntegrationTest.java
@@ -47,7 +47,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 /**

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandlerTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandlerTest.java
@@ -29,7 +29,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.Mockito.when;
 

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/TestHelper.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/TestHelper.java
@@ -31,8 +31,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 /**
@@ -83,7 +83,7 @@ public class TestHelper {
         public AttachmentContentStore put(String filename, String fileContent) throws TException {
             AttachmentContent attachmentContent = makeAttachmentContent(filename);
             store.put(attachmentContent.getId(), attachmentContent);
-            when(connectorMock.getAttachmentStream(eq(attachmentContent), anyObject(), anyObject())).thenReturn(new ReaderInputStream(new StringReader(fileContent)));
+            when(connectorMock.getAttachmentStream(eq(attachmentContent), any(), any())).thenReturn(new ReaderInputStream(new StringReader(fileContent)));
             return this;
         }
 
@@ -93,7 +93,7 @@ public class TestHelper {
 
         public AttachmentContentStore put(AttachmentContent attachmentContent) throws TException {
             store.put(attachmentContent.getId(), attachmentContent);
-            when(connectorMock.getAttachmentStream(eq(attachmentContent), anyObject(), anyObject())).thenReturn(makeAttachmentContentStream(attachmentContent.getFilename()));
+            when(connectorMock.getAttachmentStream(eq(attachmentContent), any(), any())).thenReturn(makeAttachmentContentStream(attachmentContent.getFilename()));
             return this;
         }
     }

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CLIParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CLIParserTest.java
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.StringReader;
 import java.util.stream.Collectors;
@@ -37,8 +37,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 /**
@@ -106,28 +106,28 @@ public class CLIParserTest {
 
     @Test
     public void testIsApplicableTo() throws Exception {
-        when(connector.getAttachmentStream(eq(content), anyObject(), anyObject())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE)));
+        when(connector.getAttachmentStream(eq(content), any(), any())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE)));
         assertTrue(parser.isApplicableTo(attachment, new User(), new Project()));
     }
 
     @Test
     public void testIsApplicableToFailsOnIncorrectRootElement() throws Exception {
         AttachmentContent content = new AttachmentContent().setId("A1").setFilename("a.xml").setContentType("application/xml");
-        when(connector.getAttachmentStream(eq(content), anyObject(), anyObject())).thenReturn(new ReaderInputStream(new StringReader("<wrong-root/>")));
+        when(connector.getAttachmentStream(eq(content), any(), any())).thenReturn(new ReaderInputStream(new StringReader("<wrong-root/>")));
         assertFalse(parser.isApplicableTo(attachment, new User(), new Project()));
     }
 
     @Test
     public void testIsApplicableToFailsOnMalformedXML() throws Exception {
         AttachmentContent content = new AttachmentContent().setId("A1").setFilename("a.xml").setContentType("application/xml");
-        when(connector.getAttachmentStream(eq(content), anyObject(), anyObject())).thenReturn(new ReaderInputStream(new StringReader("this is not an xml file")));
+        when(connector.getAttachmentStream(eq(content), any(), any())).thenReturn(new ReaderInputStream(new StringReader("this is not an xml file")));
         assertFalse(parser.isApplicableTo(attachment, new User(), new Project()));
     }
 
     @Test
     public void testGetCLI() throws Exception {
         Attachment cliAttachment = new Attachment("A1", "a.xml");
-        when(connector.getAttachmentStream(anyObject(), anyObject(), anyObject())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE)));
+        when(connector.getAttachmentStream(any(), any(), any())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE)));
         LicenseInfoParsingResult res = parser.getLicenseInfos(cliAttachment, new User(), new Project()).stream().findFirst().orElseThrow(()->new RuntimeException("Parser returned empty LisenceInfoParsingResult list"));
         assertLicenseInfoParsingResult(res);
         assertThat(res.getStatus(), is(LicenseInfoRequestStatus.SUCCESS));
@@ -144,7 +144,7 @@ public class CLIParserTest {
     @Test
     public void testGetCLIObligations() throws Exception {
         Attachment cliAttachment = new Attachment("A1", "a.xml");
-        when(connector.getAttachmentStream(anyObject(), anyObject(), anyObject())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE)));
+        when(connector.getAttachmentStream(any(), any(), any())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE)));
         ObligationParsingResult oblRes = parser.getObligations(cliAttachment, new User(), new Project());
         assertThat(oblRes.getStatus(), is(ObligationInfoRequestStatus.SUCCESS));
         assertThat(oblRes.getObligationsAtProjectSize(), is(2));
@@ -157,7 +157,7 @@ public class CLIParserTest {
     @Test
     public void testGetCLIFailsOnMalformedXML() throws Exception {
         Attachment cliAttachment = new Attachment("A1", "a.xml");
-        when(connector.getAttachmentStream(anyObject(), anyObject(), anyObject())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE.replaceAll("</Content>", "</Broken>"))));
+        when(connector.getAttachmentStream(any(), any(), any())).thenReturn(new ReaderInputStream(new StringReader(CLI_TESTFILE.replaceAll("</Content>", "</Broken>"))));
         LicenseInfoParsingResult res = parser.getLicenseInfos(cliAttachment, new User(), new Project()).stream().findFirst().orElseThrow(()->new RuntimeException("Parser returned empty LisenceInfoParsingResult list"));
         assertLicenseInfoParsingResult(res, LicenseInfoRequestStatus.FAILURE);
         assertThat(res.getStatus(), is(LicenseInfoRequestStatus.FAILURE));

--- a/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParserTest.java
+++ b/backend/src/src-licenseinfo/src/test/java/org/eclipse/sw360/licenseinfo/parsers/CombinedCLIParserTest.java
@@ -30,7 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.StringReader;
 import java.util.List;
@@ -43,7 +43,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -117,7 +117,7 @@ public class CombinedCLIParserTest {
     @Test
     public void testGetCLI() throws Exception {
         Attachment cliAttachment = new Attachment("A1", "a.xml");
-        when(connector.getAttachmentStream(anyObject(), anyObject(), anyObject())).thenReturn(new ReaderInputStream(new StringReader(cliTestfile)));
+        when(connector.getAttachmentStream(any(), any(), any())).thenReturn(new ReaderInputStream(new StringReader(cliTestfile)));
         List<LicenseInfoParsingResult> results = parser.getLicenseInfos(cliAttachment, new User(), new Project());
         assertThat(results.size(), is(1));
         LicenseInfoParsingResult res = results.get(0);

--- a/clients/client/src/test/java/org/eclipse/sw360/clients/adapter/SW360ComponentClientAdapterAsyncImplTest.java
+++ b/clients/client/src/test/java/org/eclipse/sw360/clients/adapter/SW360ComponentClientAdapterAsyncImplTest.java
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.eclipse.sw360.clients.utils.FutureUtils.block;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class SW360ComponentClientAdapterAsyncImplTest {
@@ -218,7 +218,7 @@ public class SW360ComponentClientAdapterAsyncImplTest {
         MultiStatusResponse response = block(componentClientAdapter.deleteComponents(Collections.emptySet()));
 
         assertThat(response.responseCount()).isEqualTo(0);
-        verifyZeroInteractions(componentClient);
+        verifyNoMoreInteractions(componentClient);
     }
 
     @Test

--- a/clients/client/src/test/java/org/eclipse/sw360/clients/adapter/SW360LicenseClientAdapterAsyncImplTest.java
+++ b/clients/client/src/test/java/org/eclipse/sw360/clients/adapter/SW360LicenseClientAdapterAsyncImplTest.java
@@ -111,7 +111,7 @@ public class SW360LicenseClientAdapterAsyncImplTest {
     public void testDeleteLicense() {
         Map<String, Integer> responses = new HashMap<String, Integer>();
         responses.put(LICENSE_ID, 200);
-        when(licenseClient.deleteLicense(Mockito.anyObject()))
+        when(licenseClient.deleteLicense(Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(200));
 
         Integer responseCode = block(licenseClientAdapter.deleteLicense(LICENSE_ID));

--- a/clients/client/src/test/java/org/eclipse/sw360/clients/adapter/SW360ProjectClientAdapterAsyncImplTest.java
+++ b/clients/client/src/test/java/org/eclipse/sw360/clients/adapter/SW360ProjectClientAdapterAsyncImplTest.java
@@ -192,7 +192,7 @@ public class SW360ProjectClientAdapterAsyncImplTest {
     public void testDeleteProject() {
         Map<String, Integer> responses = new HashMap<String, Integer>();
         responses.put(PROJECT_ID, 200);
-        when(projectClient.deleteProject(Mockito.anyObject()))
+        when(projectClient.deleteProject(Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(200));
 
         Integer responseCode = block(projectClientAdapter.deleteProject(PROJECT_ID));

--- a/clients/client/src/test/java/org/eclipse/sw360/clients/adapter/SW360ReleaseClientAdapterAsyncImplTest.java
+++ b/clients/client/src/test/java/org/eclipse/sw360/clients/adapter/SW360ReleaseClientAdapterAsyncImplTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class SW360ReleaseClientAdapterAsyncImplTest {
@@ -281,7 +281,7 @@ public class SW360ReleaseClientAdapterAsyncImplTest {
         assertThat(result.isSuccess()).isFalse();
         assertThat(result.failedUploads().get(new AttachmentUploadRequest.Item(uploadPath, attachmentType)))
                 .isInstanceOf(SW360ClientException.class);
-        verifyZeroInteractions(releaseClient);
+        verifyNoMoreInteractions(releaseClient);
     }
 
     @Test

--- a/clients/client/src/test/java/org/eclipse/sw360/clients/adapter/SW360VulnerabilityClientAdapterAsyncImplTest.java
+++ b/clients/client/src/test/java/org/eclipse/sw360/clients/adapter/SW360VulnerabilityClientAdapterAsyncImplTest.java
@@ -121,7 +121,7 @@ public class SW360VulnerabilityClientAdapterAsyncImplTest {
     public void testDeleteVulnerability() {
         Map<String, Integer> responses = new HashMap<String, Integer>();
         responses.put(EXTERNAL_ID, 200);
-        when(vulnerabilityClient.deleteVulnerability(Mockito.anyObject()))
+        when(vulnerabilityClient.deleteVulnerability(Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(200));
 
         Integer responseCode = block(vulnerabilityClientAdapter.deleteVulnerability(vulnerability.getExternalId()));

--- a/clients/http-support/src/test/java/org/eclipse/sw360/http/utils/HttpUtilsTest.java
+++ b/clients/http-support/src/test/java/org/eclipse/sw360/http/utils/HttpUtilsTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.CompletionException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class HttpUtilsTest {
@@ -132,7 +132,7 @@ public class HttpUtilsTest {
             assertThat(e.getMessage()).contains(String.valueOf(status));
             assertThat(e.getStatusCode()).isEqualTo(status);
             assertThat(e.getTag()).isNull();
-            verifyZeroInteractions(processor);
+            verifyNoMoreInteractions(processor);
         }
     }
 
@@ -153,7 +153,7 @@ public class HttpUtilsTest {
             assertThat(e.getMessage()).contains(String.valueOf(status), tag);
             assertThat(e.getStatusCode()).isEqualTo(status);
             assertThat(e.getTag()).isEqualTo(tag);
-            verifyZeroInteractions(processor);
+            verifyNoMoreInteractions(processor);
         }
     }
 
@@ -181,7 +181,7 @@ public class HttpUtilsTest {
             assertThat(e.getMessage()).contains(String.valueOf(status), tag);
             assertThat(e.getStatusCode()).isEqualTo(status);
             assertThat(e.getTag()).isEqualTo(tag);
-            verifyZeroInteractions(processor);
+            verifyNoMoreInteractions(processor);
         }
     }
 
@@ -275,7 +275,7 @@ public class HttpUtilsTest {
         ResponseProcessor<Void> processor = HttpUtils.nullProcessor();
 
         assertThat(processor.process(response)).isNull();
-        verifyZeroInteractions(response);
+        verifyNoMoreInteractions(response);
     }
 
     @Test

--- a/frontend/sw360-portlet/pom.xml
+++ b/frontend/sw360-portlet/pom.xml
@@ -390,7 +390,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
             <groupId>com.liferay</groupId>

--- a/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projectimport/BdpImportPortletTest.java
+++ b/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projectimport/BdpImportPortletTest.java
@@ -16,7 +16,7 @@ import org.eclipse.sw360.datahandler.thrift.projectimport.RemoteCredentials;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.portlet.PortletSession;
 

--- a/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projectimport/WsImportPortletTest.java
+++ b/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projectimport/WsImportPortletTest.java
@@ -16,7 +16,7 @@ import org.eclipse.sw360.datahandler.thrift.projectimport.TokenCredentials;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.portlet.PortletSession;
 

--- a/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletTest.java
+++ b/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.portlet.PortletException;
 import javax.portlet.PortletRequest;
@@ -40,8 +40,8 @@ import static org.eclipse.sw360.portal.common.PortalConstants.SOURCE_CODE_ATTACH
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 /**

--- a/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtilsTest.java
+++ b/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtilsTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.portlet.PortletSession;
 import javax.portlet.ResourceRequest;

--- a/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/tags/links/DisplayDownloadAbstractTest.java
+++ b/frontend/sw360-portlet/src/test/java/org/eclipse/sw360/portal/tags/links/DisplayDownloadAbstractTest.java
@@ -18,7 +18,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.PageContext;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/libraries/exporters/pom.xml
+++ b/libraries/exporters/pom.xml
@@ -115,7 +115,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
 

--- a/libraries/exporters/src/test/java/org/eclipse/sw360/exporter/ProjectExporterTest.java
+++ b/libraries/exporters/src/test/java/org/eclipse/sw360/exporter/ProjectExporterTest.java
@@ -15,7 +15,7 @@ import org.eclipse.sw360.datahandler.thrift.users.User;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
 

--- a/libraries/importers/pom.xml
+++ b/libraries/importers/pom.xml
@@ -126,7 +126,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
+			<artifactId>mockito-core</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/libraries/importers/src/test/java/org/eclipse/sw360/importer/ComponentAndAttachmentAwareDBTest.java
+++ b/libraries/importers/src/test/java/org/eclipse/sw360/importer/ComponentAndAttachmentAwareDBTest.java
@@ -37,7 +37,7 @@ import java.util.List;
 import static org.eclipse.sw360.datahandler.TestUtils.*;
 import static org.eclipse.sw360.importer.ComponentImportUtils.convertCSVRecordsToCompCSVRecords;
 import static org.eclipse.sw360.importer.ComponentImportUtils.convertCSVRecordsToComponentAttachmentCSVRecords;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 /**

--- a/libraries/lib-datahandler/bnd.bnd
+++ b/libraries/lib-datahandler/bnd.bnd
@@ -23,14 +23,11 @@ Export-Package: \
 	org.ektorp.*, \
 	com.cloudant.*, \
 	com.google.gson.*, \
-	com.google.common.*, \
-	com.google.common.util.concurrent.*
-
+	com.google.common.*
 
 Import-Package: \
 	com.fasterxml.jackson.*, \
 	com.google.common.*, \
-	javax.net.ssl.*, \
     org.apache.commons.io.*, \
 	org.apache.commons.codec.binary.*, \
 	org.apache.commons.csv.*, \

--- a/libraries/lib-datahandler/pom.xml
+++ b/libraries/lib-datahandler/pom.xml
@@ -36,7 +36,8 @@
                 <version>0.1.11</version>
                 <configuration>
                     <thriftExecutable>thrift</thriftExecutable>
-                    <generator>java</generator>
+                    <generator>java:generated_annotations=suppress</generator>
+                    <checkStaleness>true</checkStaleness>scripts/startCouchdbForTests.sh
                 </configuration>
                 <executions>
                     <execution>
@@ -209,7 +210,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
             <groupId>com.tngtech.jgiven</groupId>

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentConnectorTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentConnectorTest.java
@@ -13,11 +13,12 @@ import org.eclipse.sw360.datahandler.cloudantclient.DatabaseConnectorCloudant;
 import org.eclipse.sw360.datahandler.thrift.attachments.Attachment;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -43,12 +44,13 @@ public class AttachmentConnectorTest {
     public void testDeleteAttachmentsDifference() throws Exception {
         Attachment a1 = mock(Attachment.class);
         when(a1.getAttachmentContentId()).thenReturn("a1cid");
-        when(a1.getSha1()).thenReturn(null);
-        when(a1.isSetSha1()).thenReturn(false);
+        Assert.assertNull(a1.getSha1());
+        Assert.assertEquals(false, a1.isSetSha1());
+
         Attachment a2 = mock(Attachment.class);
         when(a2.getAttachmentContentId()).thenReturn("a2cid");
-        when(a2.getSha1()).thenReturn(null);
-        when(a2.isSetSha1()).thenReturn(false);
+        Assert.assertNull(a2.getSha1());
+        Assert.assertEquals(false, a2.isSetSha1());
 
         Set<Attachment> before = new HashSet<>();
         before.add(a1);
@@ -56,8 +58,8 @@ public class AttachmentConnectorTest {
 
         Attachment a3 = mock(Attachment.class);
         when(a3.getAttachmentContentId()).thenReturn("a1cid");
-        when(a3.getSha1()).thenReturn("sha1");
-        when(a3.isSetSha1()).thenReturn(true);
+        Assert.assertNull(a3.getSha1());
+        Assert.assertEquals(false, a3.isSetSha1());
 
         Set<Attachment> after = new HashSet<>();
         after.add(a3);
@@ -79,7 +81,7 @@ public class AttachmentConnectorTest {
         when(a2.getCheckStatus()).thenReturn(CheckStatus.REJECTED);
 
         Attachment a3 = mock(Attachment.class);
-        when(a3.getAttachmentContentId()).thenReturn("a3");
+        lenient().when(a3.getAttachmentContentId()).thenReturn("a3");
         when(a3.getCheckStatus()).thenReturn(CheckStatus.ACCEPTED);
 
         Set<Attachment> before = new HashSet<>();

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentDownloaderTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentContentDownloaderTest.java
@@ -16,7 +16,7 @@ import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentStreamConnectorTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/AttachmentStreamConnectorTest.java
@@ -20,9 +20,9 @@ import org.ektorp.AttachmentInputStream;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.cloudant.client.org.lightcouch.NoDocumentException;
 
@@ -70,14 +70,14 @@ public class AttachmentStreamConnectorTest {
         InputStream returnedStream = mock(InputStream.class);
 
         AttachmentContent rereadAttachment = mock(AttachmentContent.class);
-        when(rereadAttachment.getId()).thenReturn(id);
-        when(rereadAttachment.getFilename()).thenReturn(filename);
+        lenient().when(rereadAttachment.getId()).thenReturn(id);
+        lenient().when(rereadAttachment.getFilename()).thenReturn(filename);
 
         attachmentStreamConnector = spy(attachmentStreamConnector);
         doReturn(returnedStream).when(attachmentStreamConnector).readAttachmentStream(rereadAttachment);
-        doNothing().when(attachmentStreamConnector).uploadAttachmentPart(attachment, 1, downloadUrlStream);
+        lenient().doNothing().when(attachmentStreamConnector).uploadAttachmentPart(attachment, 1, downloadUrlStream);
 
-        when(attachmentContentDownloader.download(eq(attachment), Matchers.any(Duration.class))).thenReturn(downloadUrlStream);
+        when(attachmentContentDownloader.download(eq(attachment), ArgumentMatchers.any(Duration.class))).thenReturn(downloadUrlStream);
 
         when(connector.get(AttachmentContent.class, id)).thenReturn(rereadAttachment);
         doReturn(rereadAttachment).when(rereadAttachment).setOnlyRemote(anyBoolean());
@@ -89,7 +89,7 @@ public class AttachmentStreamConnectorTest {
                              .setAttachments(Collections.singleton(new Attachment().setAttachmentContentId(id)))),
                 sameInstance(returnedStream));
 
-        verify(attachmentContentDownloader).download(eq(attachment), Matchers.any(Duration.class));
+        verify(attachmentContentDownloader).download(eq(attachment), ArgumentMatchers.any(Duration.class));
         verify(attachmentStreamConnector).uploadAttachment(attachment, downloadUrlStream);
         verify(attachmentStreamConnector).readAttachmentStream(rereadAttachment);
 
@@ -150,7 +150,7 @@ public class AttachmentStreamConnectorTest {
                         .setCreatedBy(dummyUser.getEmail())
                         .setAttachments(Collections.singleton(new Attachment().setAttachmentContentId(attachmentId))));
 
-        verifyZeroInteractions(part2);
+        verifyNoMoreInteractions(part2);
         assertThat(attachmentStream.read(), is(1));
         assertThat(attachmentStream.read(), is(2));
         verify(part1).close();

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/DatabaseTestProperties.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/couchdb/DatabaseTestProperties.java
@@ -38,8 +38,8 @@ public class DatabaseTestProperties {
 
         COUCH_DB_URL = props.getProperty("couchdb.url", "http://localhost:5984");
         COUCH_DB_DATABASE = props.getProperty("couchdb.database", "sw360_test_db");
-        COUCH_DB_USERNAME = Optional.ofNullable(props.getProperty("couchdb.user", null));
-        COUCH_DB_PASSWORD = Optional.ofNullable(props.getProperty("couchdb.password", null));
+        COUCH_DB_USERNAME = Optional.ofNullable(props.getProperty("couchdb.user", ""));
+        COUCH_DB_PASSWORD = Optional.ofNullable(props.getProperty("couchdb.password", ""));
     }
 
     public static HttpClient getConfiguredHttpClient() throws MalformedURLException {

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/ReleasePermissionsTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/ReleasePermissionsTest.java
@@ -17,7 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/resourcelists/PaginationOptionsTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/resourcelists/PaginationOptionsTest.java
@@ -13,7 +13,7 @@ package org.eclipse.sw360.datahandler.resourcelists;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/resourcelists/PaginationResultTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/resourcelists/PaginationResultTest.java
@@ -13,7 +13,7 @@ package org.eclipse.sw360.datahandler.resourcelists;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/resourcelists/ResourceComparatorGeneratorTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/resourcelists/ResourceComparatorGeneratorTest.java
@@ -23,7 +23,7 @@ import org.eclipse.sw360.datahandler.thrift.search.SearchResult;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Comparator;
 

--- a/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/resourcelists/ResourceListControllerTest.java
+++ b/libraries/lib-datahandler/src/test/java/org/eclipse/sw360/datahandler/resourcelists/ResourceListControllerTest.java
@@ -18,7 +18,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Comparator;

--- a/pom.xml
+++ b/pom.xml
@@ -47,46 +47,44 @@
     </modules>
 
     <properties>
-        <!-- This is first of two places for changing the version of SW360 -->
-        <!-- note that 6.1.0-SNAPSHOT relates to 6.0.${patchlevel} -->
-        <!-- pls see also the profile cli -->
         <revision>15.1.${patchlevel}</revision>
         <patchlevel>0-SNAPSHOT</patchlevel>
-        <java.version>11</java.version>
-        <ektorp.version>1.5.0</ektorp.version>
-        <thrift.version>0.14.0</thrift.version>
-        <guava.version>31.0.1-jre</guava.version>
-        <spring.version>5.3.19</spring.version>
-        <spring-boot.version>2.6.6</spring-boot.version>
-        <spring-restdocs.version>2.0.6.RELEASE</spring-restdocs.version>
-        <spring-security-oauth2.version>2.5.1.RELEASE</spring-security-oauth2.version>
-        <spring-security-jwt.version>1.1.1.RELEASE</spring-security-jwt.version>
-
-        <slf4j.version>1.7.30</slf4j.version>
-        <log4j2.version>2.17.1</log4j2.version>
-        <gson.version>2.8.9</gson.version>
-        <jcraft.version>0.1.54</jcraft.version>
-        <jackson.version>2.13.2</jackson.version>
-        <jackson-databind.version>2.13.2.2</jackson-databind.version>
-        <junit-dataprovider.version>1.13.1</junit-dataprovider.version>
-        <poi.version>4.1.2</poi.version>
-
-        <junit.version>4.13.2</junit.version>
-        <jgiven.version>0.17.0</jgiven.version>
-        <hamcrest.version>1.3</hamcrest.version>
-        <mockito.version>1.10.19</mockito.version>
-        <project-lombok.version>1.18.2</project-lombok.version>
-        <wiremock.version>2.26.0</wiremock.version>
-
-        <maven-source-plugin.version>2.4</maven-source-plugin.version>
-        <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
-
-        <jakarta-xml-bind.version>2.3.2</jakarta-xml-bind.version>
-        <glassfish-jaxb.version>2.3.2</glassfish-jaxb.version>
-        <javax-annotation.version>1.3.2</javax-annotation.version>
-
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>11</java.version>
+
+        <!-- We define dependency versions here -->
+        <byte-buddy.version>1.12.10</byte-buddy.version>
+        <ektorp.version>1.5.0</ektorp.version>
+        <glassfish-jaxb.version>2.3.2</glassfish-jaxb.version>
+        <gson.version>2.8.9</gson.version>
+        <guava.version>31.0.1-jre</guava.version>
+        <hamcrest.version>1.3</hamcrest.version>
+        <jackson-databind.version>2.13.2.2</jackson-databind.version>
+        <jackson.version>2.13.2</jackson.version>
+        <jakarta-xml-bind.version>2.3.2</jakarta-xml-bind.version>
+        <javax-annotation.version>1.3.2</javax-annotation.version>
+        <jcraft.version>0.1.54</jcraft.version>
+        <jgiven.version>0.17.0</jgiven.version>
+        <junit-dataprovider.version>1.13.1</junit-dataprovider.version>
+        <junit.version>4.13.2</junit.version>
+        <log4j2.version>2.17.1</log4j2.version>
+        <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
+        <maven-source-plugin.version>2.4</maven-source-plugin.version>
+        <mockito.version>4.6.1</mockito.version>
+        <okhttp.version>4.3.1</okhttp.version>
+        <package-url.version>1.1.1</package-url.version>
+        <poi.version>4.1.2</poi.version>
+        <project-lombok.version>1.18.2</project-lombok.version>
+        <slf4j.version>1.7.30</slf4j.version>
+        <spring-boot.version>2.6.6</spring-boot.version>
+        <spring-restdocs.version>2.0.6.RELEASE</spring-restdocs.version>
+        <spring-security-jwt.version>1.1.1.RELEASE</spring-security-jwt.version>
+        <spring-security-oauth2.version>2.5.1.RELEASE</spring-security-oauth2.version>
+        <spring.version>5.3.19</spring.version>
+        <thrift.version>0.14.0</thrift.version>
+        <wiremock.version>2.26.0</wiremock.version>
+
 
         <!--  User must provide below property configuration based on his/her liferay deployment environment -->
         <base.deploy.dir />
@@ -115,9 +113,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${byte-buddy.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp</artifactId>
-                <version>4.3.1</version>
+                <version>${okhttp.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.cliftonlabs</groupId>
@@ -127,7 +130,7 @@
             <dependency>
                 <groupId>com.github.package-url</groupId>
                 <artifactId>packageurl-java</artifactId>
-                <version>1.1.1</version>
+                <version>${package-url.version}</version>
             </dependency>
             <!-- javax.annotation: java 11 compatibility -->
             <dependency>
@@ -395,7 +398,7 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
+                <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -34,6 +34,10 @@
             <artifactId>datahandler</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <pluginManagement>

--- a/scripts/install-thrift.sh
+++ b/scripts/install-thrift.sh
@@ -54,11 +54,11 @@ processThrift() {
 
       echo "-[shell provisioning] Building thrift"
       if [[ ! -f "./Makefile" ]]; then
-          ./configure --without-java --without-cpp --without-qt4 --without-c_glib --without-csharp --without-erlang \
-                      --without-perl --without-php --without-php_extension --without-python --without-py3 --without-ruby \
-                      --without-haskell --without-go --without-d --without-haskell --without-php --without-ruby \
-                      --without-python --without-erlang --without-perl --without-c_sharp --without-d --without-php \
-                      --without-go --without-lua --without-nodejs --without-cl --without-dotnetcore --without-swift --without-rs
+          ./configure --without-java --without-cpp --without-qt5 --without-c_glib --without-erlang \
+                      --without-perl --without-php --without-php_extension --without-python --without-py3 \
+                      --without-go --without-d --without-ruby --without-erlang --without-lua \
+                      --without-nodejs --without-nodets --without-cl --without-netstd \
+                      --without-swift --without-rs
       fi
       if [ "$1" == true ]; then
         # shellcheck disable=SC2046


### PR DESCRIPTION
Signed-off-by: Helio Chissini de Castro <heliocastro@gmail.com>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Mockito-all was deprecated long time ago and we were still relying on possible vulnerable/old test code to validate build
As proper replacement, only mockito core is needed, with minor source code changes
