### PR TITLE
feat(ui): Add banner to broadcast messages

### DIFF
--- a/frontend/liferay-theme/src/main/webapp/css/portal/_header.scss
+++ b/frontend/liferay-theme/src/main/webapp/css/portal/_header.scss
@@ -24,6 +24,27 @@
 		}
 	}
 
+        #updateMessage {
+            padding: 20px;
+            background-color: #F4A460;
+            color: white;
+        }
+
+        .closebtn {
+            margin-left: 15px;
+            color: white;
+            font-weight: bold;
+            float: right;
+            font-size: 22px;
+            line-height: 20px;
+            cursor: pointer;
+            transition: 0.3s;
+        }
+
+        .closebtn:hover {
+            color: black;
+        }
+
 	.header-toolbar {
 		display: flex;
 		justify-content: flex-end;

--- a/frontend/liferay-theme/src/main/webapp/js/banner.js
+++ b/frontend/liferay-theme/src/main/webapp/js/banner.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright Siemens AG, 2022. Part of the SW360 Portal Project.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+function closeBanner() {
+	sessionStorage.setItem('header', true);
+	document.getElementById('updateMessage').style.display = 'none';
+}
+
+function pageLoad() {
+	if (sessionStorage.getItem('header') == 'true') {
+		document.getElementById('updateMessage').style.display = 'none';
+	}
+}
+window.addEventListener("DOMContentLoaded", pageLoad );
+

--- a/frontend/liferay-theme/src/main/webapp/templates/portal_normal.ftl
+++ b/frontend/liferay-theme/src/main/webapp/templates/portal_normal.ftl
@@ -38,9 +38,15 @@
 
 <#assign preferences = freeMarkerPortletPreferences.getPreferences({"portletSetupPortletDecoratorId": "sw360", "destination": "/search"}) />
 <#assign login_css = is_signed_in?then("signed-in", "not-signed-in") />
+<#assign liferay_user = themeDisplay.getUser() />
+<#assign js_folder = theme_display.getPathThemeJavaScript() />
+<#assign js_banner_file = htmlUtil.escape(portalUtil.getStaticResourceURL(request, "${js_folder}/banner.js")) />
+
 <html class="${root_css_class}" dir="<@liferay.language key="lang.dir" />" lang="${w3c_language_id}">
 
 <head>
+	<script type="text/javascript" src ="${js_banner_file}" > </script>
+
 	<title>${the_title} - ${company_name}</title>
 
 	<meta content="initial-scale=1.0, width=device-width" name="viewport" />
@@ -59,6 +65,15 @@
 <div id="wrapper" class="${hide_portlet_edit_decorators_css} ${login_css}">
 	<header id="banner" role="banner">
 		<div id="heading" class="container">
+            <#if is_signed_in>
+                <#assign expandoAttribute = liferay_user.getExpandoBridge().getAttribute("BannerMessage") />
+                <#if expandoAttribute?has_content>
+                    <div id="updateMessage">
+                        <span class="closebtn" onclick="closeBanner()">&times;</span>
+                        <strong>${expandoAttribute}</strong>
+                    </div>
+                </#if>
+            </#if>
 			<div class="row">
 				<div class="col-3">
 					<a class="${logo_css_class}" href="${site_default_url}" title="<@liferay.language_format arguments="${site_name}" key="go-to-x" />">

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/CustomFieldHelper.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/CustomFieldHelper.java
@@ -46,6 +46,7 @@ import static org.eclipse.sw360.portal.common.PortalConstants.CUSTOM_FIELD_COMPO
 import static org.eclipse.sw360.portal.common.PortalConstants.CUSTOM_FIELD_PREFERRED_CLEARING_DATE_LIMIT;
 import static org.eclipse.sw360.portal.common.PortalConstants.CUSTOM_FIELD_PROJECT_GROUP_FILTER;
 import static org.eclipse.sw360.portal.common.PortalConstants.CUSTOM_FIELD_VULNERABILITIES_VIEW_SIZE;
+import static org.eclipse.sw360.portal.common.PortalConstants.CUSTOM_FIELD_BANNER_MESSAGE;
 
 public class CustomFieldHelper {
 
@@ -166,6 +167,7 @@ public class CustomFieldHelper {
     private static ExpandoBridge getUserExpandoBridge(PortletRequest request, User user) throws PortalException, SystemException {
         com.liferay.portal.kernel.model.User liferayUser = UserUtils.findLiferayUser(request, user);
         ensureUserCustomFieldExists(liferayUser, CUSTOM_FIELD_PROJECT_GROUP_FILTER, ExpandoColumnConstants.STRING);
+        ensureUserCustomFieldExists(liferayUser, CUSTOM_FIELD_BANNER_MESSAGE, ExpandoColumnConstants.STRING);
         ensureUserCustomFieldExists(liferayUser, CUSTOM_FIELD_COMPONENTS_VIEW_SIZE, ExpandoColumnConstants.INTEGER);
         ensureUserCustomFieldExists(liferayUser, CUSTOM_FIELD_VULNERABILITIES_VIEW_SIZE, ExpandoColumnConstants.INTEGER);
         ensureUserCustomFieldExists(liferayUser, CUSTOM_FIELD_PREFERRED_CLEARING_DATE_LIMIT, ExpandoColumnConstants.INTEGER);

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -376,6 +376,7 @@ public class PortalConstants {
     public static final String CUSTOM_FIELD_COMPONENTS_VIEW_SIZE = "ComponentsViewSize";
     public static final String CUSTOM_FIELD_VULNERABILITIES_VIEW_SIZE = "VulnerabilitiesViewSize";
     public static final String CUSTOM_FIELD_PREFERRED_CLEARING_DATE_LIMIT = "PreferredClearingDateLimit";
+    public static final String CUSTOM_FIELD_BANNER_MESSAGE = "BannerMessage";
 
     //! Specialized keys for scheduling
     public static final String CVESEARCH_IS_SCHEDULED = "cveSearchIsScheduled";

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MySubscriptionsPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/homepage/MySubscriptionsPortlet.java
@@ -23,6 +23,9 @@ import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 
+import org.eclipse.sw360.portal.common.CustomFieldHelper;
+import static org.eclipse.sw360.portal.common.PortalConstants.CUSTOM_FIELD_BANNER_MESSAGE;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -57,6 +60,7 @@ public class MySubscriptionsPortlet extends Sw360Portlet {
 
         try {
             final User user = UserCacheHolder.getUserFromRequest(request);
+            CustomFieldHelper.loadField(String.class, request, user, CUSTOM_FIELD_BANNER_MESSAGE);
             ComponentService.Iface componentClient = thriftClients.makeComponentClient();
             components = componentClient.getSubscribedComponents(user);
             releases  = componentClient.getSubscribedReleases(user);

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/init.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/init.jsp
@@ -22,3 +22,15 @@
 <%@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util"%>
 
 <%@ taglib uri="http://example.com/tld/customTags.tld" prefix="sw360"%>
+
+<script>
+
+function portletLoad() {
+    if (sessionStorage.getItem('header') == 'true') {
+	    document.getElementById('updateMessage').style.display = 'none';
+    }
+}
+
+Liferay.on('allPortletsReady', portletLoad);
+
+</script>


### PR DESCRIPTION
Signed-off-by: rchopra <rudra.chopra@siemens.com>

Issue:  Add banner to broadcast messages (#1595)

Description : This functionality can be edited by Admins only.

### How To Test?

1) Click on 9 dots on the top right section of the page
2) Go to control panel -> click custom fields under configuration
3) Select User under Resource section
4) There you will see BannerMessage custom field.
5) Click on three dots to edit this field. Here you can enter message that you want to be displayed.
6) Right click on three dots and give view permission to all sw360 users/roles and change other permissions too. (Refer the ss for this step)


### Screenshots

![controlPanel](https://user-images.githubusercontent.com/58290634/182588983-92b2f981-1949-4f4f-91ba-419fdc94ad5d.PNG)
Click custom field under control panel section

![User](https://user-images.githubusercontent.com/58290634/182589248-64b68bf4-a4bd-450a-a846-3758de83b4f7.PNG)
Select User under resource section

![bannerMessage](https://user-images.githubusercontent.com/58290634/182589718-7a16fd51-2ac7-4480-93f9-5591c5f7c95a.PNG)
Banner Message custom field should look like this

![Permissions](https://user-images.githubusercontent.com/58290634/182589850-f6942245-df6f-4bc3-850b-33a3d80f65e6.PNG)
Give view permission to all sw360users/roles and make changes in other permissions too

![welcomePage](https://user-images.githubusercontent.com/58290634/182589171-1655f032-5b37-4628-9f15-89ee39d3f10e.PNG)
Banner message on top of the page

