### PR TITLE
fix(rest): Added component type tag in release api

### DIFF
--- a/libraries/lib-datahandler/src/main/thrift/components.thrift
+++ b/libraries/lib-datahandler/src/main/thrift/components.thrift
@@ -223,6 +223,7 @@ struct Release {
     6: required string version, // version or release name (e.g. 0.9.1)
     7: required string componentId, // Id of the parent component
     8: optional string releaseDate,
+    99: optional ComponentType componentType,
 
     // information from external data sources
     9: optional  map<string, string> externalIds,

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -465,7 +465,8 @@ public class JacksonCustomizations {
                 "setModifiedOn",
                 "modifiedOn",
                 "setModifiedBy",
-                "modifiedBy"
+                "modifiedBy",
+                "setComponentType"
         })
         static abstract class ReleaseMixin extends Release {
             @Override

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/RestControllerHelper.java
@@ -480,7 +480,7 @@ public class RestControllerHelper<T> {
     }
 
     public Release convertToEmbeddedReleaseWithDet(Release release) {
-        List<String> fields = List.of("id", "name", "version", "cpeid", "createdBy", "createdOn", "componentId",
+        List<String> fields = List.of("id", "name", "version", "cpeid", "createdBy", "createdOn", "componentId","componentType",
                 "additionalData", "clearingState", "mainLicenseIds", "binaryDownloadurl", "sourceCodeDownloadurl",
                 "releaseDate", "externalIds", "languages", "operatingSystems", "softwarePlatforms", "vendor",
                 "mainlineState");

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ProjectSpecTest.java
@@ -25,6 +25,8 @@ import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
 import org.eclipse.sw360.datahandler.thrift.attachments.LicenseInfoUsage;
 import org.eclipse.sw360.datahandler.thrift.attachments.UsageData;
 import org.eclipse.sw360.datahandler.thrift.components.ClearingState;
+import org.eclipse.sw360.datahandler.thrift.components.Component;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
 import org.eclipse.sw360.datahandler.thrift.components.ECCStatus;
 import org.eclipse.sw360.datahandler.thrift.components.EccInformation;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
@@ -316,6 +318,9 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         release.setReleaseDate("2016-12-07");
         release.setVersion("2.3.0");
         release.setCreatedOn("2016-12-18");
+        Component compo = new Component();
+        compo.setComponentType(ComponentType.OSS);
+        release.setComponentType(compo.getComponentType());
         EccInformation eccInformation = new EccInformation();
         eccInformation.setEccStatus(ECCStatus.APPROVED);
         release.setEccInformation(eccInformation);
@@ -339,6 +344,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         release2.setComponentId("12356115");
         release2.setClearingState(ClearingState.APPROVED);
         release2.setExternalIds(Collections.singletonMap("mainline-id-component", "1771"));
+        release2.setComponentType(ComponentType.COTS);
 
         Release rel = new Release();
         Map<String, String> releaseExternalIds = new HashMap<>();
@@ -355,6 +361,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
         rel.setSourceCodeDownloadurl("http://www.google.com");
         rel.setBinaryDownloadurl("http://www.google.com/binaries");
         rel.setComponentId("17653524");
+        rel.setComponentType(ComponentType.OSS);
         rel.setClearingState(ClearingState.APPROVED);
         rel.setExternalIds(releaseExternalIds);
         rel.setAdditionalData(Collections.singletonMap("Key", "Value"));
@@ -1446,6 +1453,7 @@ public class ProjectSpecTest extends TestRestDocsSpecBase {
                                      parameterWithName("sort").description("Defines order of the releases")
                                      ),
                              responseFields(
+                                     subsectionWithPath("_embedded.sw360:releases.[]componentType").description("The component type, possible values are: " + Arrays.asList(ComponentType.values())),
                                      subsectionWithPath("_embedded.sw360:releases.[]name").description("The name of the release, optional"),
                                      subsectionWithPath("_embedded.sw360:releases.[]version").description("The version of the release"),
                                      subsectionWithPath("_embedded.sw360:releases.[]createdBy").description("Email of the release creator"),

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/ReleaseSpecTest.java
@@ -189,6 +189,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         release.setClearingState(ClearingState.APPROVED);
         release.setMainlineState(MainlineState.SPECIFIC);
         release.setExternalIds(releaseExternalIds);
+        release.setComponentType(ComponentType.OSS);
         release.setAdditionalData(Collections.singletonMap("Key", "Value"));
         release.setAttachments(attachments);
         release.setLanguages(new HashSet<>(Arrays.asList("C++", "Java")));
@@ -212,6 +213,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         release2.setBinaryDownloadurl("http://www.google.com/binaries");
         release2.setModerators(new HashSet<>(Arrays.asList("admin@sw360.org", "jane@sw360.org")));
         release2.setComponentId(component.getId());
+        release2.setComponentType(ComponentType.OSS);
         release2.setClearingState(ClearingState.APPROVED);
         release2.setMainlineState(MainlineState.MAINLINE);
         release2.setExternalIds(release2ExternalIds);
@@ -277,9 +279,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                         .setId(UUID.randomUUID().toString()));
         given(this.licenseServiceMock.getLicenseById("GPL-2.0-or-later")).willReturn(
                 new License("GNU General Public License 2.0").setText("GNU General Public License 2.0 Text")
-                        .setShortname("GPL-2.0-or-later")
-                        .setId(UUID.randomUUID().toString()));
-
+                        .setShortname("GPL-2.0-or-later").setId(UUID.randomUUID().toString()));
         ExternalToolProcess fossologyProcess = new ExternalToolProcess();
         fossologyProcess.setAttachmentId("5345ab789");
         fossologyProcess.setAttachmentHash("535434657567");
@@ -367,6 +367,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 linkWithRel("curies").description("The curies for documentation")
                         ),
                         responseFields(
+                                subsectionWithPath("_embedded.sw360:releases.[]componentType").description("The componentType of the release, possible values are " + Arrays.asList(ComponentType.values())),
                                 subsectionWithPath("_embedded.sw360:releases.[]name").description("The name of the release, optional"),
                                 subsectionWithPath("_embedded.sw360:releases.[]version").description("The version of the release"),
                                 subsectionWithPath("_embedded.sw360:releases.[]createdBy").description("Email of the release creator"),
@@ -454,6 +455,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                                 fieldWithPath("cpeId").description("The CPE id"),
                                 fieldWithPath("releaseDate").description("The date of this release"),
                                 fieldWithPath("createdOn").description("The creation date of the internal sw360 release"),
+                                fieldWithPath("componentType").description("The componentType of the release, possible values are " + Arrays.asList(ComponentType.values())),
                                 fieldWithPath("mainlineState").description("the mainline state of the release, possible values are: " + Arrays.asList(MainlineState.values())),
                                 fieldWithPath("sourceCodeDownloadurl").description("the source code download url of the release"),
                                 fieldWithPath("binaryDownloadurl").description("the binary download url of the release"),
@@ -510,7 +512,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
     public void should_document_update_release() throws Exception {
         Release updateRelease = new Release();
         release.setName("Updated release");
-
+        release.setComponentType(ComponentType.OSS);
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
         mockMvc.perform(patch("/api/releases/" + releaseId)
                 .contentType(MediaTypes.HAL_JSON)
@@ -655,7 +657,6 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
         Map<String, String> release = new HashMap<>();
         release.put("version", "1.0");
         release.put("componentId", component.getId());
-
         String accessToken = TestHelper.getAccessToken(mockMvc, testUserId, testUserPassword);
         this.mockMvc.perform(post("/api/releases")
                 .contentType(MediaTypes.HAL_JSON)
@@ -732,6 +733,7 @@ public class ReleaseSpecTest extends TestRestDocsSpecBase {
                         fieldWithPath("clearingState").description("The clearing of the release, possible values are " + Arrays.asList(ClearingState.values())),
                         fieldWithPath("cpeId").description("The CPE id"),
                         fieldWithPath("releaseDate").description("The date of this release"),
+                        fieldWithPath("componentType").description("The componentType of the release, possible values are " + Arrays.asList(ComponentType.values())),
                         fieldWithPath("createdOn").description("The creation date of the internal sw360 release"),
                         fieldWithPath("mainlineState").description("the mainline state of the release, possible values are: " + Arrays.asList(MainlineState.values())),
                         fieldWithPath("sourceCodeDownloadurl").description("the source code download url of the release"),


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? #1607 
> * Did you add or update any new dependencies that are required for your change? yes, I added component type tag under release API.

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
1) Go to component tab and click on any component name.
2) If you need to change in the exiting component or you can select Release Overview tab.
3)click on version and copy release Id and test it in postman.
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
