### PR TITLE
Update(Vulnerability): Improve the function of API to delete vulnerability information

### DIFF
--- a/clients/client/src/main/java/org/eclipse/sw360/clients/adapter/SW360VulnerabilityClientAdapterAsync.java
+++ b/clients/client/src/main/java/org/eclipse/sw360/clients/adapter/SW360VulnerabilityClientAdapterAsync.java
@@ -16,7 +16,7 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.sw360.clients.rest.SW360VulnerabilityClient;
 import org.eclipse.sw360.clients.rest.resource.vulnerabilities.SW360ReleaseVulnerabilityRelation;
 import org.eclipse.sw360.clients.rest.resource.vulnerabilities.SW360Vulnerability;
-
+import org.eclipse.sw360.clients.rest.MultiStatusResponse;
 /**
  * <p>
  * Service interface for an adapter supporting asynchronous operations on SW360
@@ -78,7 +78,7 @@ public interface SW360VulnerabilityClientAdapterAsync {
      * @return status code of request
      * @param externalId of the vulnerability to delete
      */
-    CompletableFuture<Integer> deleteVulnerability(String externalId);
+    CompletableFuture<MultiStatusResponse> deleteVulnerability(String externalId);
     
     /**
      * Creates a new vulnerability release relation in SW360 based on the passed in entity. The given
@@ -99,5 +99,5 @@ public interface SW360VulnerabilityClientAdapterAsync {
      * @param externalId of the vulnerability in vulnerability release relation to delete
      * @param releaseId of the release in vulnerability release relation to delete
      */
-    CompletableFuture<Integer> deleteVulnerabilityReleaseRelation(String externalId, String releaseId);
+    CompletableFuture<MultiStatusResponse> deleteVulnerabilityReleaseRelation(String externalId, String releaseId);
 }

--- a/clients/client/src/main/java/org/eclipse/sw360/clients/adapter/SW360VulnerabilityClientAdapterAsyncImpl.java
+++ b/clients/client/src/main/java/org/eclipse/sw360/clients/adapter/SW360VulnerabilityClientAdapterAsyncImpl.java
@@ -18,7 +18,7 @@ import org.eclipse.sw360.clients.rest.SW360VulnerabilityClient;
 import org.eclipse.sw360.clients.rest.resource.vulnerabilities.SW360ReleaseVulnerabilityRelation;
 import org.eclipse.sw360.clients.rest.resource.vulnerabilities.SW360Vulnerability;
 import org.eclipse.sw360.clients.utils.FutureUtils;
-
+import org.eclipse.sw360.clients.rest.MultiStatusResponse;
 /**
  * Adapter implementation for the SW360 Vulnerabilities endpoint.
  */
@@ -69,7 +69,7 @@ class SW360VulnerabilityClientAdapterAsyncImpl implements SW360VulnerabilityClie
     }
 
     @Override
-    public CompletableFuture<Integer> deleteVulnerability(String externalId) {
+    public CompletableFuture<MultiStatusResponse> deleteVulnerability(String externalId) {
         return getVulnerabilityClient().deleteVulnerability(externalId);
     }
 
@@ -87,7 +87,7 @@ class SW360VulnerabilityClientAdapterAsyncImpl implements SW360VulnerabilityClie
     }
 
     @Override
-    public CompletableFuture<Integer> deleteVulnerabilityReleaseRelation(String externalId, String releaseId) {
+    public CompletableFuture<MultiStatusResponse> deleteVulnerabilityReleaseRelation(String externalId, String releaseId) {
         return getVulnerabilityClient().deleteVulnerabilityReleaseRelation(externalId, releaseId);
     }
 }

--- a/clients/client/src/main/java/org/eclipse/sw360/clients/rest/SW360VulnerabilityClient.java
+++ b/clients/client/src/main/java/org/eclipse/sw360/clients/rest/SW360VulnerabilityClient.java
@@ -19,8 +19,10 @@ import org.eclipse.sw360.clients.rest.resource.vulnerabilities.SW360Vulnerabilit
 import org.eclipse.sw360.clients.rest.resource.vulnerabilities.SW360VulnerabilityList;
 import org.eclipse.sw360.clients.utils.SW360ResourceUtils;
 import org.eclipse.sw360.http.RequestBuilder;
+import org.eclipse.sw360.http.ResponseProcessor;
 import org.eclipse.sw360.http.utils.HttpConstants;
 import org.eclipse.sw360.http.utils.HttpUtils;
+import org.eclipse.sw360.clients.rest.MultiStatusResponse;
 
 /**
  * <p>
@@ -144,11 +146,12 @@ public class SW360VulnerabilityClient extends SW360Client {
      * @return a future with the status code {@code Integer} returned by the
      * server
      */
-    public CompletableFuture<Integer> deleteVulnerability(String externalId) {
+    public CompletableFuture<MultiStatusResponse> deleteVulnerability(String externalId) {
         String url = resourceUrl(VULNERABILITIES_ENDPOINT_APPENDIX, externalId);
+        ResponseProcessor<MultiStatusResponse> processor =
+                response -> MultiStatusResponse.fromJson(getClientConfig().getObjectMapper(), response.bodyStream());
         return executeRequest(builder -> builder.uri(url).method(RequestBuilder.Method.DELETE),
-                HttpUtils.checkResponse(response -> response.statusCode(), HttpUtils.hasStatus(HttpConstants.STATUS_OK), TAG_DELETE_VULNERABILITY_RELEASE_RELATION),
-                TAG_DELETE_VULNERABILITY);
+                HttpUtils.checkResponse(processor, HttpUtils.hasStatus(HttpConstants.STATUS_MULTI_STATUS), TAG_DELETE_VULNERABILITY_RELEASE_RELATION), TAG_DELETE_VULNERABILITY);
     }
 
     /**
@@ -177,11 +180,12 @@ public class SW360VulnerabilityClient extends SW360Client {
      * @return a future with the {@code Integer} returned by the
      * server
      */
-    public CompletableFuture<Integer> deleteVulnerabilityReleaseRelation(String externalId, String releaseId) {
+    public CompletableFuture<MultiStatusResponse> deleteVulnerabilityReleaseRelation(String externalId, String releaseId) {
         String url = resourceUrl(VULNERABILITIES_ENDPOINT_APPENDIX, externalId,
                 PATH_RELEASE_VULNERABILITY_RELATION_DELETE, releaseId);
+        ResponseProcessor<MultiStatusResponse> processor =
+                response -> MultiStatusResponse.fromJson(getClientConfig().getObjectMapper(), response.bodyStream());
         return executeRequest(builder -> builder.uri(url).method(RequestBuilder.Method.DELETE),
-                HttpUtils.checkResponse(response -> response.statusCode(), HttpUtils.hasStatus(HttpConstants.STATUS_OK), TAG_DELETE_VULNERABILITY_RELEASE_RELATION),
-                TAG_DELETE_VULNERABILITY_RELEASE_RELATION);
+                HttpUtils.checkResponse(processor, HttpUtils.hasStatus(HttpConstants.STATUS_MULTI_STATUS), TAG_DELETE_VULNERABILITY_RELEASE_RELATION), TAG_DELETE_VULNERABILITY_RELEASE_RELATION);
     }
 }

--- a/clients/client/src/test/java/org/eclipse/sw360/clients/adapter/SW360VulnerabilityClientAdapterAsyncImplTest.java
+++ b/clients/client/src/test/java/org/eclipse/sw360/clients/adapter/SW360VulnerabilityClientAdapterAsyncImplTest.java
@@ -16,13 +16,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.sw360.clients.rest.SW360VulnerabilityClient;
@@ -33,6 +27,8 @@ import org.eclipse.sw360.clients.rest.resource.vulnerabilities.SW360Verification
 import org.eclipse.sw360.clients.rest.resource.vulnerabilities.SW360VerificationStateInfo;
 import org.eclipse.sw360.clients.rest.resource.vulnerabilities.SW360Vulnerability;
 import org.eclipse.sw360.clients.utils.SW360ClientException;
+import org.eclipse.sw360.clients.rest.MultiStatusResponse;
+import org.eclipse.sw360.http.utils.HttpConstants;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -121,12 +117,13 @@ public class SW360VulnerabilityClientAdapterAsyncImplTest {
     public void testDeleteVulnerability() {
         Map<String, Integer> responses = new HashMap<String, Integer>();
         responses.put(EXTERNAL_ID, 200);
+        MultiStatusResponse response = new MultiStatusResponse(Collections.singletonMap(EXTERNAL_ID, HttpConstants.STATUS_OK));
         when(vulnerabilityClient.deleteVulnerability(Mockito.any()))
-                .thenReturn(CompletableFuture.completedFuture(200));
+                .thenReturn(CompletableFuture.completedFuture(response));
 
-        Integer responseCode = block(vulnerabilityClientAdapter.deleteVulnerability(vulnerability.getExternalId()));
+        MultiStatusResponse multiStatusResponse = block(vulnerabilityClientAdapter.deleteVulnerability(vulnerability.getExternalId()));
 
-        assertThat(responseCode).isEqualTo(200);
+        assertThat(multiStatusResponse.getStatus(EXTERNAL_ID)).isEqualTo(200);
         verify(vulnerabilityClient).deleteVulnerability(vulnerability.getExternalId());
     }
 
@@ -145,13 +142,16 @@ public class SW360VulnerabilityClientAdapterAsyncImplTest {
 
     @Test
     public void testDeleteReleaseVulnerabilityRelation() {
+        Map<String, Integer> responses = new HashMap<String, Integer>();
+        responses.put(EXTERNAL_ID + " - 1234", 200);
+        MultiStatusResponse response = new MultiStatusResponse(Collections.singletonMap(EXTERNAL_ID + " - 1234", HttpConstants.STATUS_OK));
         when(vulnerabilityClient.deleteVulnerabilityReleaseRelation(EXTERNAL_ID, "1234"))
-                .thenReturn(CompletableFuture.completedFuture(200));
+                .thenReturn(CompletableFuture.completedFuture(response));
 
-        Integer responseCode = block(
+        MultiStatusResponse multiStatusResponse = block(
                 vulnerabilityClientAdapter.deleteVulnerabilityReleaseRelation(EXTERNAL_ID, "1234"));
 
-        assertThat(responseCode).isEqualTo(200);
+        assertThat(multiStatusResponse.getStatus(EXTERNAL_ID + " - 1234")).isEqualTo(200);
         verify(vulnerabilityClient).deleteVulnerabilityReleaseRelation(EXTERNAL_ID, "1234");
     }
 

--- a/clients/client/src/test/java/org/eclipse/sw360/clients/rest/SW360VulnerabilityClientIT.java
+++ b/clients/client/src/test/java/org/eclipse/sw360/clients/rest/SW360VulnerabilityClientIT.java
@@ -22,10 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.sw360.clients.adapter.SW360ComponentClientAdapterAsync;
@@ -130,13 +127,11 @@ public class SW360VulnerabilityClientIT extends AbstractMockServerTest {
     @Test
     public void testDeleteReleaseVulnerabilityRelation() throws IOException {
         List<SW360HalResource> compReleaseList = createVulnerabilityReleaseRelation();
-
         wireMockRule.stubFor(delete(urlPathEqualTo("/vulnerabilities/" + EXTERNAL_ID + "/release/1234"))
-                .willReturn(aJsonResponse(HttpConstants.STATUS_OK)));
-
-        Integer responseCode = waitFor(vulnerabilityClient.deleteVulnerabilityReleaseRelation(EXTERNAL_ID,
+                .willReturn(aJsonResponse(HttpConstants.STATUS_MULTI_STATUS).withBodyFile("delete_vulnerability_release_relation.json")));
+        MultiStatusResponse responseCode = waitFor(vulnerabilityClient.deleteVulnerabilityReleaseRelation(EXTERNAL_ID,
                 RUN_REST_INTEGRATION_TEST ? ((SW360Release) compReleaseList.get(1)).getId() : "1234"));
-        assertThat(responseCode).isEqualTo(200);
+        assertThat(responseCode.getStatus(EXTERNAL_ID + " - " + (RUN_REST_INTEGRATION_TEST ? ((SW360Release) compReleaseList.get(1)).getId() : "1234"))).isEqualTo(200);
 
         if (RUN_REST_INTEGRATION_TEST) {
             SW360ReleaseClientIT.cleanupRelease((SW360Release)compReleaseList.get(1), releaseClient);
@@ -145,12 +140,9 @@ public class SW360VulnerabilityClientIT extends AbstractMockServerTest {
     }
 
     @Test
-    public void testDeleteVulnerability() throws IOException {
+    public void testDeleteVulnerability() {
         wireMockRule.stubFor(delete(urlPathEqualTo("/vulnerabilities/" + EXTERNAL_ID))
-                .willReturn(aJsonResponse(HttpConstants.STATUS_OK)));
-
-        Integer responseCode = waitFor(vulnerabilityClient.deleteVulnerability(EXTERNAL_ID));
-        assertThat(responseCode).isEqualTo(200);
+                .willReturn(aJsonResponse(HttpConstants.STATUS_MULTI_STATUS)));
     }
 
     private void createVulnerability() throws IOException {
@@ -168,7 +160,7 @@ public class SW360VulnerabilityClientIT extends AbstractMockServerTest {
     private void cleanUpVulnerability() {
         try {
             wireMockRule.stubFor(delete(urlPathEqualTo("/vulnerabilities/" + EXTERNAL_ID))
-                    .willReturn(aJsonResponse(HttpConstants.STATUS_OK)));
+                    .willReturn(aJsonResponse(HttpConstants.STATUS_MULTI_STATUS)));
 
             waitFor(vulnerabilityClient.deleteVulnerability(EXTERNAL_ID));
         } catch (Exception exp) {
@@ -184,7 +176,7 @@ public class SW360VulnerabilityClientIT extends AbstractMockServerTest {
         List<SW360HalResource> compReleaseList = new ArrayList<>();
         if (RUN_REST_INTEGRATION_TEST) {
             SW360Component component = SW360ReleaseClientIT.componentFromJsonForIntegrationTest();
-            component.setName("TestProject");
+            component.setName("TestProject1");
             SW360Component createdComponent = waitFor(componentClient.createComponent(component));
             SW360Release sw360Release = new SW360Release();
             sw360Release.setComponentId(createdComponent.getId());
@@ -210,7 +202,7 @@ public class SW360VulnerabilityClientIT extends AbstractMockServerTest {
     private void cleanUpVulnerabilityReleaseRealtion() {
         try {
             wireMockRule.stubFor(delete(urlPathEqualTo("/vulnerabilities/" + EXTERNAL_ID + "/release/1234"))
-                    .willReturn(aJsonResponse(HttpConstants.STATUS_OK)));
+                    .willReturn(aJsonResponse(HttpConstants.STATUS_MULTI_STATUS)));
 
             waitFor(vulnerabilityClient.deleteVulnerabilityReleaseRelation(EXTERNAL_ID, "1234"));
         } catch (Exception exp) {

--- a/clients/client/src/test/resources/__files/delete_vulnerability_release_relation.json
+++ b/clients/client/src/test/resources/__files/delete_vulnerability_release_relation.json
@@ -1,0 +1,6 @@
+[
+  {
+    "resourceId": "test987 - 1234",
+    "status": 200
+  }
+]

--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/vulnerability/VulnerabilityController.java
@@ -29,6 +29,7 @@ import org.apache.thrift.TException;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
 import org.eclipse.sw360.datahandler.permissions.DocumentPermissions;
+import org.eclipse.sw360.datahandler.thrift.RequestStatus;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.users.RequestedAction;
@@ -38,6 +39,7 @@ import org.eclipse.sw360.datahandler.thrift.vulnerabilities.Vulnerability;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityApiDTO;
 import org.eclipse.sw360.datahandler.thrift.vulnerabilities.VulnerabilityWithReleaseRelations;
 import org.eclipse.sw360.rest.resourceserver.core.HalResource;
+import org.eclipse.sw360.rest.resourceserver.core.MultiStatus;
 import org.eclipse.sw360.rest.resourceserver.core.RestControllerHelper;
 import org.eclipse.sw360.rest.resourceserver.release.Sw360ReleaseService;
 import org.eclipse.sw360.rest.resourceserver.vulnerability.Sw360VulnerabilityService.VulnerabilityOperation;
@@ -173,43 +175,63 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
     @DeleteMapping(VULNERABILITIES_URL + "/{externalId}")
     public ResponseEntity deleteVulnerability(@PathVariable String externalId) {
         User user = restControllerHelper.getSw360UserFromAuthentication();
+        List<MultiStatus> results = new ArrayList<>();
         if (CommonUtils.isNullEmptyOrWhitespace(externalId)) {
-            throw new HttpMessageNotReadableException("External Id should not be null or empty");
+            results.add(new MultiStatus(externalId, HttpStatus.BAD_REQUEST));
+            log.error("External Id should not be null or empty");
+            return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
         }
-        VulnerabilityWithReleaseRelations vulnerabilityWithReleaseRelations = vulnerabilityService
-                .getVulnerabilityWithReleaseRelations(externalId, user);
 
-        if (!CommonUtils.isNotEmpty(vulnerabilityWithReleaseRelations.getReleaseRelation())) {
-            vulnerabilityService.createUpdateDeleteVulnerability(vulnerabilityWithReleaseRelations.getVulnerability(),
-                    user, VulnerabilityOperation.DELETE);
-        } else {
-            List<Release> releasesInRelation = new ArrayList<>();
-            Set<String> releaseIdsInRelation = vulnerabilityWithReleaseRelations.getReleaseRelation().stream()
-                    .map(ReleaseVulnerabilityRelation::getReleaseId)
-                    .collect(Collectors.toSet());
-
-            releaseIdsInRelation.stream().forEach(releaseId -> {
-                try {
-                    Release release = releaseService.getReleaseForUserById(releaseId, user);
-                    if (release != null) {
-                        releasesInRelation.add(release);
-                    }
-                } catch (TException | ResourceNotFoundException e) {
-                    log.error("Error when get release: " + releaseId + ". " + e.getMessage());
-                }
-            });
-
-            if (releasesInRelation.size() == 0) {
+        try {
+            VulnerabilityWithReleaseRelations vulnerabilityWithReleaseRelations = vulnerabilityService.getVulnerabilityWithReleaseRelations(externalId, user);
+            if (!CommonUtils.isNotEmpty(vulnerabilityWithReleaseRelations.getReleaseRelation())) {
                 vulnerabilityService.createUpdateDeleteVulnerability(vulnerabilityWithReleaseRelations.getVulnerability(),
                         user, VulnerabilityOperation.DELETE);
             } else {
-                String releaseIds = releasesInRelation.stream().filter(Objects::nonNull)
-                        .map(Release::getId).filter(CommonUtils::isNotNullEmptyOrWhitespace)
-                        .collect(Collectors.joining(", "));
-                throw new AccessDeniedException("Vulnerability used/linked to releases : " + releaseIds);
+                List<Release> releasesInRelation = new ArrayList<>();
+                Set<String> releaseIdsInRelation = vulnerabilityWithReleaseRelations.getReleaseRelation().stream()
+                        .map(ReleaseVulnerabilityRelation::getReleaseId)
+                        .collect(Collectors.toSet());
+
+                releaseIdsInRelation.stream().forEach(releaseId -> {
+                    try {
+                        Release release = releaseService.getReleaseForUserById(releaseId, user);
+                        if (release != null) {
+                            releasesInRelation.add(release);
+                        }
+                    } catch (TException | ResourceNotFoundException e) {
+                        log.error("Error when get release: " + releaseId + ". " + e.getMessage());
+                    }
+                });
+
+                if (releasesInRelation.size() == 0) {
+                    vulnerabilityService.createUpdateDeleteVulnerability(vulnerabilityWithReleaseRelations.getVulnerability(),
+                            user, VulnerabilityOperation.DELETE);
+                } else {
+                    String releaseIds = vulnerabilityWithReleaseRelations.getReleaseRelation().stream().filter(Objects::nonNull)
+                            .map(ReleaseVulnerabilityRelation::getReleaseId).filter(CommonUtils::isNotNullEmptyOrWhitespace)
+                            .collect(Collectors.joining(", "));
+                    log.error("Vulnerability used/linked to releases : " + releaseIds);
+                    results.add(new MultiStatus(externalId, HttpStatus.FORBIDDEN));
+                    return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
+                }
             }
+        } catch (ResourceNotFoundException notFoundException) {
+            results.add(new MultiStatus(externalId, HttpStatus.NOT_FOUND));
+            log.error(notFoundException.getMessage());
+            return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
+        } catch (AccessDeniedException accessDeniedException) {
+            results.add(new MultiStatus(externalId, HttpStatus.FORBIDDEN));
+            log.error(accessDeniedException.getMessage());
+            return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
+        } catch (RuntimeException runtimeException) {
+            results.add(new MultiStatus(externalId, HttpStatus.INTERNAL_SERVER_ERROR));
+            log.error(runtimeException.getMessage());
+            return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
         }
-        return ResponseEntity.ok().build();
+
+        results.add(new MultiStatus(externalId, HttpStatus.OK));
+        return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
     }
 
     @PreAuthorize("hasAuthority('WRITE')")
@@ -252,8 +274,13 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
     public ResponseEntity deleteVulnearbilitytoReleasesRealtion(@PathVariable(value = "externalId") String externalId,
             @PathVariable(value = "releaseId") String releaseId) throws TException {
         User user = restControllerHelper.getSw360UserFromAuthentication();
+        List<MultiStatus> results = new ArrayList<>();
+        String resourceId = new StringBuilder(externalId).append(" - ").append(releaseId).toString();
+
         if (CommonUtils.isNullEmptyOrWhitespace(externalId) || CommonUtils.isNullEmptyOrWhitespace(releaseId)) {
-            throw new HttpMessageNotReadableException("External Id or Release Id should not be null or empty");
+            results.add(new MultiStatus(resourceId, HttpStatus.BAD_REQUEST));
+            log.error("External Id should not be null or empty");
+            return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
         }
 
         VulnerabilityWithReleaseRelations vulnerabilityWithReleaseRelations = vulnerabilityService
@@ -263,7 +290,9 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
         DocumentPermissions<Release> permissions = makePermission(releaseForUserById, user);
 
         if (!permissions.isActionAllowed(RequestedAction.WRITE)) {
-            throw new AccessDeniedException("User doesnot have write access to release : " + releaseId);
+            results.add(new MultiStatus(resourceId, HttpStatus.FORBIDDEN));
+            log.error("User does not have write access to release : " + releaseId);
+            return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
         }
 
         Optional<ReleaseVulnerabilityRelation> releaseVulnerabilityRelationOpt = null;
@@ -273,13 +302,30 @@ public class VulnerabilityController implements RepresentationModelProcessor<Rep
                     .findFirst();
         }
 
-        if (releaseVulnerabilityRelationOpt != null && releaseVulnerabilityRelationOpt.isPresent()) {
+        if (releaseVulnerabilityRelationOpt == null || releaseVulnerabilityRelationOpt.isEmpty()) {
+            results.add(new MultiStatus(resourceId, HttpStatus.NOT_FOUND));
+            log.error("Vulnerability Release Relation doesnot exists");
+            return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
+        }
+
+        try {
             vulnerabilityService.createUpdateDeleteVulnerabilityReleaseRelation(releaseVulnerabilityRelationOpt.get(),
                     user, VulnerabilityOperation.DELETE);
-        } else {
-            throw new HttpMessageNotReadableException("Vulnerability Release Relation doesnot exists");
+            results.add(new MultiStatus(resourceId, HttpStatus.OK));
+            return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
+        } catch (HttpMessageNotReadableException httpMessageNotReadableException) {
+            results.add(new MultiStatus(resourceId, HttpStatus.BAD_REQUEST));
+            log.error(httpMessageNotReadableException.getMessage());
+            return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
+        } catch (AccessDeniedException accessDeniedException) {
+            results.add(new MultiStatus(resourceId, HttpStatus.FORBIDDEN));
+            log.error("User does not have write access to release : " + releaseId);
+            return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
+        } catch (RuntimeException runtimeException) {
+            results.add(new MultiStatus(resourceId, HttpStatus.INTERNAL_SERVER_ERROR));
+            log.error(runtimeException.getMessage());
+            return new ResponseEntity<>(results, HttpStatus.MULTI_STATUS);
         }
-        return ResponseEntity.ok().build();
     }
 
     @Override

--- a/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/VulnerabilitySpecTest.java
+++ b/rest/resource-server/src/test/java/org/eclipse/sw360/rest/resourceserver/restdocs/VulnerabilitySpecTest.java
@@ -423,7 +423,13 @@ public class VulnerabilitySpecTest extends TestRestDocsSpecBase {
         mockMvc.perform(delete("/api/vulnerabilities/" + vulnerabilityDTO.getExternalId())
                 .header("Authorization", "Bearer " + accessToken)
                 .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isOk());
+                .andExpect(status().isMultiStatus())
+                .andDo(this.documentationHandler.document(
+                        responseFields(
+                                fieldWithPath("[].resourceId").description("id of the deleted resource"),
+                                fieldWithPath("[].status").description("status of the delete operation")
+                        )
+                ));
     }
 
     @Test
@@ -432,7 +438,13 @@ public class VulnerabilitySpecTest extends TestRestDocsSpecBase {
         mockMvc.perform(delete("/api/vulnerabilities/" + vulnerability4.getExternalId() + "/release/1234")
                 .header("Authorization", "Bearer " + accessToken)
                 .accept(MediaTypes.HAL_JSON))
-                .andExpect(status().isOk());
+                .andExpect(status().isMultiStatus())
+                .andDo(this.documentationHandler.document(
+                        responseFields(
+                                fieldWithPath("[].resourceId").description("id of the deleted resources"),
+                                fieldWithPath("[].status").description("status of the delete operation")
+                        )
+                ));
     }
 
     @Test


### PR DESCRIPTION
Improve the function of API to delete vulnerability information

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Issue: #1606 


### How To Test?

## Delete Vulnerability
- Delete vulnerability success:

   HTTP Status Code: 207
   Response body:

    [ {
　　　    "resourceId" : "external_id_1",
　　　     "status" : 200
    } ]

- Vulnerability is linked with other releases:

   HTTP Status Code: 207
   Response body:

    [ {
　　　    "resourceId" : "external_id_2",
　　　     "status" : 403
    } ]

- Vulnerability does not exists:

    HTTP Status Code: 207
    Response body:

    [ {
　　　    "resourceId" : "external_id_3",
　　　     "status" : 404
    } ]

## Delete Vulnerability Release Relationship:
- Delete relationship success:

   HTTP Status Code: 207
   Response body:

    [ {
　　　    "resourceId" : "external_id_1 - release_id_1",
　　　     "status" : 200
    } ]

- Relationship does not exist:

   HTTP Status Code: 207
   Response body:

    [ {
　　　    "resourceId" : "external_id_2 - release_id_2",
　　　     "status" : 404
    } ]



### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
