### PR TITLE
fix(docker): Fix double called shutdown script

### DIFF
--- a/scripts/docker-config/entry_point.sh
+++ b/scripts/docker-config/entry_point.sh
@@ -42,9 +42,9 @@ stop_sw360() {
   echo "###############################################################################################################"
   echo "# Stopping SW360 server"
   echo "###############################################################################################################"
-  
+
   /app/sw360/tomcat/bin/shutdown.sh
-  rm /app/sw360/tomcat/webapps/*.war
+  find /app/sw360/tomcat/webapps/ -name \*.war -exec rm -f {} \;
 }
 
 tail_logs()
@@ -53,7 +53,7 @@ tail_logs()
 }
 
 # We catch the container end and call the termination
-trap 'stop_sw360' SIGTERM TERM SIGINT INT EXIT WINCH SIGWINCH
+trap 'stop_sw360' SIGTERM TERM EXIT WINCH SIGWINCH
 
 wait_couchdb
 start_sw360


### PR DESCRIPTION
When compose is properly called to end ( down ), two signals are raised,
SIGINT/INT and EXIT. As the trap condition on shutdown script was tracking
down both, sw360_stop was called twice, failing on second instance

Signed-off-by: Helio Chissini de Castro <heliocastro@gmail.com>

