### PR TITLE
fix(deps): Fixed wrong dependency download

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Ignore base files on copy
+deploy?
+*/*/build
+*/*/target

--- a/.github/testForLicenseHeaders.sh
+++ b/.github/testForLicenseHeaders.sh
@@ -31,7 +31,7 @@ while read file ; do
     echo "$(tput bold)ERROR: no EPL-2.0 licensing is specified in $file$(tput sgr0)"
     failure=true
 done <<< "$(git ls-files \
-    | grep -Ev '\.(csv|rdf|ent|dtd|lar|png|gif|psd|ico|jpg|docx|gitignore|cert|jks|spdx|rdf|MockMaker|json)' \
+    | grep -Ev '\.(csv|rdf|ent|dtd|lar|png|gif|psd|ico|jpg|docx|gitignore|dockerignore|cert|jks|spdx|rdf|MockMaker|json)' \
     | grep -Ev '(LICENSE|NOTICE|README|CHANGELOG|CODE_OF_CONDUCT|CONTRIBUTING|Language|Language_vi)' \
     | grep -v 'id_rsa' \
     | grep -Ev '*/asciidoc/*')"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,6 @@ ARG MAVEN_VERSION
 ARG LIFERAY_VERSION
 ARG LIFERAY_SOURCE
 
-# Lets get dependencies as buildkit cached
-ENV SW360_DEPS_DIR=/var/cache/deps
-COPY ./scripts/download_dependencies.sh /var/tmp/deps.sh
-
-RUN --mount=type=cache,mode=0755,target=/var/cache/deps,sharing=locked \
-    chmod +x /var/tmp/deps.sh \
-    && /var/tmp/deps.sh
-
 RUN --mount=type=cache,mode=0755,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,mode=0755,target=/var/lib/apt,sharing=locked \
     apt-get update \
@@ -49,6 +41,14 @@ RUN --mount=type=cache,mode=0755,target=/var/cache/apt,sharing=locked \
     unzip \
     zip \
     && rm -rf /var/lib/apt/lists/*
+
+# Lets get dependencies as buildkit cached
+ENV SW360_DEPS_DIR=/var/cache/deps
+COPY ./scripts/download_dependencies.sh /var/tmp/deps.sh
+
+RUN --mount=type=cache,mode=0755,target=/var/cache/deps,sharing=locked \
+    chmod +x /var/tmp/deps.sh \
+    && /var/tmp/deps.sh
 
 # Prepare maven from binary to avoid wrong java dependencies and proxy
 RUN --mount=type=cache,mode=0755,target=/var/cache/deps \

--- a/scripts/download_dependencies.sh
+++ b/scripts/download_dependencies.sh
@@ -24,7 +24,7 @@ jar_dependencies=(
   https://search.maven.org/remotecontent?filepath=com/fasterxml/jackson/core/jackson-annotations/2.13.3/jackson-annotations-2.13.3.jar
   https://search.maven.org/remotecontent?filepath=com/fasterxml/jackson/core/jackson-core/2.13.3/jackson-core-2.13.3.jar
   https://search.maven.org/remotecontent?filepath=com/fasterxml/jackson/core/jackson-databind/2.13.3/jackson-databind-2.13.3.jar
-  https://search.maven.org/remotecontent?filepath=com/google/guava/guava/31.0.1-jre/guava-31.1-jre.jar
+  https://search.maven.org/remotecontent?filepath=com/google/guava/guava/31.1-jre/guava-31.1-jre.jar
   https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.20/commons-compress-1.20.jar
   https://repo1.maven.org/maven2/org/apache/thrift/libthrift/"$THRIFT_VERSION"/libthrift-"$THRIFT_VERSION".jar
 )


### PR DESCRIPTION
Guava dependency was pointing out to wrong directory and not providing
any error on output, so creating an invalid file that failis only on
unpacking level.
If this kept used, in future maven should do the download automatically
instead of a script.

This provided possibility to alter Dockerfile deps download position,
and avoid recreate the build layer all the time.

In addition, a dockerignore file is added to avoid copy deploy / target
/ buiid massive outputs if local build is used to build docker too.

Signed-off-by: Helio Chissini de Castro <heliocastro@gmail.com>