### PR TITLE
fix(ui): Generate portlet X url inside portlet Y

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ChangeLogsPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/ChangeLogsPortletUtils.java
@@ -41,8 +41,6 @@ import org.eclipse.sw360.datahandler.thrift.changelogs.ChangeLogsService.Iface;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ChangedFields;
 import org.eclipse.sw360.datahandler.thrift.changelogs.ReferenceDocData;
 import org.eclipse.sw360.datahandler.thrift.users.User;
-import org.eclipse.sw360.portal.common.PortalConstants;
-import org.eclipse.sw360.portal.common.PortletUtils;
 import org.eclipse.sw360.portal.common.datatables.PaginationParser;
 import org.eclipse.sw360.portal.common.datatables.data.PaginationParameters;
 import org.eclipse.sw360.portal.users.UserCacheHolder;
@@ -51,16 +49,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
-import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 
 public class ChangeLogsPortletUtils {
@@ -140,8 +137,7 @@ public class ChangeLogsPortletUtils {
     }
 
     private LiferayPortletURL getModerationPortletUrl(PortletRequest request) {
-        Portlet portlet = PortletLocalServiceUtil.getPortletById(PortalConstants.MODERATION_PORTLET_NAME);
-        Optional<Layout> layout = LayoutLocalServiceUtil.getLayouts(portlet.getCompanyId()).stream()
+        Optional<Layout> layout = LayoutLocalServiceUtil.getLayouts(QueryUtil.ALL_POS, QueryUtil.ALL_POS).stream()
                 .filter(l -> ("/moderation").equals(l.getFriendlyURL())).findFirst();
         if (layout.isPresent()) {
             long plId = layout.get().getPlid();

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/moderation/ModerationPortletUtils.java
@@ -30,12 +30,11 @@ import org.eclipse.sw360.portal.common.CustomFieldHelper;
 import org.eclipse.sw360.portal.common.PortalConstants;
 import org.eclipse.sw360.portal.users.UserCacheHolder;
 
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
-import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 
 import static java.lang.Integer.parseInt;
 import static org.eclipse.sw360.portal.common.PortalConstants.CUSTOM_FIELD_PREFERRED_CLEARING_DATE_LIMIT;
@@ -185,9 +184,8 @@ public class ModerationPortletUtils {
     }
 
     private static LiferayPortletURL getProjectPortletUrl(PortletRequest request, String projectId) {
-        Portlet portlet = PortletLocalServiceUtil.getPortletById(PortalConstants.PROJECT_PORTLET_NAME);
-        Optional<Layout> layout = LayoutLocalServiceUtil.getLayouts(portlet.getCompanyId()).stream()
-                .filter(l -> ("/" + PortalConstants.PROJECTS.toLowerCase()).equals(l.getFriendlyURL())).findFirst();
+        Optional<Layout> layout = LayoutLocalServiceUtil.getLayouts(QueryUtil.ALL_POS, QueryUtil.ALL_POS).stream()
+            .filter(l -> ("/projects").equals(l.getFriendlyURL())).findFirst();
         if (layout.isPresent()) {
             long plId = layout.get().getPlid();
             LiferayPortletURL projectUrl = PortletURLFactoryUtil.create(request, PortalConstants.PROJECT_PORTLET_NAME, plId, PortletRequest.RENDER_PHASE);

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortletUtils.java
@@ -10,12 +10,11 @@
 package org.eclipse.sw360.portal.portlets.projects;
 
 import com.google.common.collect.*;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
-import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.common.SW360Utils;
@@ -505,8 +504,7 @@ public class ProjectPortletUtils {
     }
 
     public static String createVulnerabilityFriendlyUrl(ResourceRequest request) {
-        Portlet portlet = PortletLocalServiceUtil.getPortletById(PortalConstants.VULNERABILITIES_PORTLET_NAME);
-        Optional<Layout> layout = LayoutLocalServiceUtil.getLayouts(portlet.getCompanyId()).stream()
+        Optional<Layout> layout = LayoutLocalServiceUtil.getLayouts(QueryUtil.ALL_POS, QueryUtil.ALL_POS).stream()
                 .filter(l -> ("/vulnerabilities").equals(l.getFriendlyURL())).findFirst();
         if (layout.isPresent()) {
             long plId = layout.get().getPlid();
@@ -521,8 +519,7 @@ public class ProjectPortletUtils {
     }
 
     public static String createProjectPortletUrlWithViewSizeFriendlyUrl(RenderRequest request, String projectId) {
-        Portlet portlet = PortletLocalServiceUtil.getPortletById(PortalConstants.PROJECT_PORTLET_NAME);
-        Optional<Layout> layout = LayoutLocalServiceUtil.getLayouts(portlet.getCompanyId()).stream()
+        Optional<Layout> layout = LayoutLocalServiceUtil.getLayouts(QueryUtil.ALL_POS, QueryUtil.ALL_POS).stream()
                 .filter(l -> ("/projects").equals(l.getFriendlyURL())).findFirst();
         if (layout.isPresent()) {
             long plId = layout.get().getPlid();


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Changed the logic of how (portlet) layout details are fetched in java.

Issue: We cannot update the `clearing request` and also `X` portlet URL is not getting generated in `Y` portlet.

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
This PR fixes the above mentioned issues.
Now you should be able to update the clearing request.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: akapti <abdul.kapti@siemens-healthineers.com>