### PR TITLE
fix(ProjectUI): fixed Release filter bug in AttachmentUsage tab

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentUsagesRows.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/attachmentUsagesRows.jspf
@@ -109,7 +109,7 @@
                             }
                         </script>
                         </core_rt:if>
-                        <core_rt:if test="${attachment.attachmentType eq 'SOURCE'}">
+                        <core_rt:if test="${attachment.attachmentType eq 'SOURCE' or attachment.attachmentType eq 'SOURCE_SELF'}">
                         <script>
                             parId = "${releaseLink.nodeId}",
                             $tr = $('tr[data-tt-id='+parId+']');


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Fixed `release filter` in `Attachment usages` tab of `project` details page.

Issue: #1628 


### How To Test?
please refer issue description.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: akapti <abdul.kapti@siemens-healthineers.com>