### PR TITLE
fix typing error

### DIFF
--- a/docker_build.sh
+++ b/docker_build.sh
@@ -51,7 +51,7 @@ for arg in "$@"; do
 done
 
 #shellcheck disable=SC2086
-docker compose \
+docker-compose \
     --file "$GIT_ROOT"/docker-compose.yml \
     build \
     --build-arg BUILDKIT_INLINE_CACHE=1 \


### PR DESCRIPTION
 The correct command name should be docker-compose

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
docker_build.sh not working due to typo error
> * Did you add or update any new dependencies that are required for your change?
No

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.
NO
### How To Test?
> How should these changes be tested by the reviewer?
run docker_build.sh can build sw360 normally now.
> Have you implemented any additional tests?
run docker_build.sh can build sw360 normally now.

### Checklist
Must:
- [V] All related issues are referenced in commit messages and in PR
