### PR TITLE
Use only provided tarball to generate resources

### DIFF
--- a/.github/workflows/githubactions.yml
+++ b/.github/workflows/githubactions.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Install Thrift
       run: |
         chmod +x scripts/install-thrift.sh
-        bash scripts/install-thrift.sh --no-cleanup
+        bash scripts/install-thrift.sh
 
     - name: Build SW360
       run: |

--- a/scripts/download_dependencies.sh
+++ b/scripts/download_dependencies.sh
@@ -21,8 +21,6 @@ jar_dependencies=(
   https://search.maven.org/remotecontent?filepath=com/fasterxml/jackson/core/jackson-core/2.13.3/jackson-core-2.13.3.jar
   https://search.maven.org/remotecontent?filepath=com/fasterxml/jackson/core/jackson-databind/2.13.3/jackson-databind-2.13.3.jar
   https://search.maven.org/remotecontent?filepath=com/google/guava/guava/31.1-jre/guava-31.1-jre.jar
-  https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.20/commons-compress-1.20.jar
-  https://repo1.maven.org/maven2/org/apache/thrift/libthrift/"$THRIFT_VERSION"/libthrift-"$THRIFT_VERSION".jar
 )
 
 dependencies=(


### PR DESCRIPTION
Thrift need to be built inside docker, but was only compiler, not
required jar, which is downloaded as external dependency.

Now both compiler and jar are generated on the fly from same build, and
using cmake based build. Boost and ssl dev dependencies are no more
necessary to the builder base image, reducing size and install time for
base build system.