### PR TITLE
fix(SBOM): Fixed Component type is not being set when components are …

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/spdx/SpdxBOMImporter.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/spdx/SpdxBOMImporter.java
@@ -19,6 +19,7 @@ import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentType;
 import org.eclipse.sw360.datahandler.thrift.attachments.CheckStatus;
 import org.eclipse.sw360.datahandler.thrift.components.Component;
+import org.eclipse.sw360.datahandler.thrift.components.ComponentType;
 import org.eclipse.sw360.datahandler.thrift.components.Release;
 import org.eclipse.sw360.datahandler.thrift.projects.Project;
 import org.spdx.library.model.enumerations.RelationshipType;
@@ -178,6 +179,7 @@ public class SpdxBOMImporter {
 
     private SpdxBOMImporterSink.Response importAsComponent(SpdxPackage spdxPackage) throws SW360Exception, InvalidSPDXAnalysisException {
         final Component component = createComponentFromSpdxPackage(spdxPackage);
+        component.setComponentType(ComponentType.OSS);
         return sink.addComponent(component);
     }
 


### PR DESCRIPTION
…created by importing SBOM

Signed-off-by: Nguyen Nhu Tuan <tuan2.nguyennhu@toshiba.co.jp>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: #1658 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
#### Import SPDX BOM in Project page
Use file [bom.spdx.rdf.zip](https://github.com/eclipse/sw360/files/9158059/bom.spdx.rdf.zip)

Steps
1. Go to project page
2. Click "Import SPDX BOM" button
3. Upload bom.spdx.rdf file

Validate
- "asoftware (1.1)" project was created
- "Browser", "Buffer" , "CompressionEng" components were created and Component type has been set "OSS"


#### Import SPDX BOM in Component page
Use file [bom.spdx.rdf.zip](https://github.com/eclipse/sw360/files/9158062/bom.spdx.rdf.zip)


Steps
1. Go to component page
2. Click "Import SPDX BOM" button
3. Upload bom.spdx.rdf file

Validate
- "asoftware", "Browser", "Buffer" , "CompressionEng" components were created  and Component type has been set "OSS"


### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
