### PR TITLE
fix(ProjectUI): Changing Project group should update CR

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/entitlement/ProjectModerator.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/entitlement/ProjectModerator.java
@@ -95,6 +95,14 @@ public class ProjectModerator extends Moderator<Project._Fields, Project> {
         }
     }
 
+    public void updateClearingRequestForChangeInProjectBU(String crId, String businessUnit, User user) {
+        try {
+            ModerationService.Iface client = thriftClients.makeModerationClient();
+            client.updateClearingRequestForChangeInProjectBU(crId, businessUnit, user);
+        } catch (TException e) {
+            log.error("Failed to update project BU in CR : " + crId + ", by User " + user.getEmail(), e);
+        }
+    }
 
     public void unlinkClearingRequestForProjectDeletion(Project project, User user) {
         try {

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/ModerationHandler.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/ModerationHandler.java
@@ -285,6 +285,15 @@ public class ModerationHandler implements ModerationService.Iface {
     }
 
     @Override
+    public void updateClearingRequestForChangeInProjectBU(String crId, String businessUnit, User user) throws TException {
+        assertId(crId);
+        assertNotNull(businessUnit);
+        assertUser(user);
+
+        handler.updateClearingRequestForChangeInProjectBU(crId, businessUnit, user);
+    }
+
+    @Override
     public RequestStatus addCommentToClearingRequest(String id, Comment comment, User user) throws TException {
         assertId(id);
         assertNotNull(comment);

--- a/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
+++ b/backend/src/src-moderation/src/main/java/org/eclipse/sw360/moderation/db/ModerationDatabaseHandler.java
@@ -275,6 +275,16 @@ public class ModerationDatabaseHandler {
         clearingRequestRepository.update(clearingRequest);
     }
 
+    public void updateClearingRequestForChangeInProjectBU(String crId, String businessUnit, User user) {
+        try {
+            ClearingRequest clearingRequest = clearingRequestRepository.get(crId);
+            clearingRequest.setProjectBU(businessUnit);
+            clearingRequestRepository.update(clearingRequest);
+        } catch (Exception e) {
+            log.error("Failed to update CR-ID: %s with error: %s", crId, e.getMessage());
+        }
+    }
+
     public RequestStatus addCommentToClearingRequest(String id, Comment comment, User user) {
         try {
             comment.setCommentedOn(System.currentTimeMillis());

--- a/libraries/datahandler/src/main/thrift/moderation.thrift
+++ b/libraries/datahandler/src/main/thrift/moderation.thrift
@@ -239,6 +239,11 @@ service ModerationService {
     oneway void updateClearingRequestForProjectDeletion(1: Project project, 2: User user);
 
     /**
+     * update clearing request if project's BU is changed
+     **/
+    oneway void updateClearingRequestForChangeInProjectBU(1: string crId, 2: string businessUnit, 3: User user);
+
+    /**
      * get clearing request by Id for view/read
      **/
     ClearingRequest getClearingRequestById(1: string id, 2: User user);


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Changing `Business Unit (Group)` of `project` should change the `ProjectBU` field in Clearing Request.

Issue: #1665 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?

1. Login as user (let's say `U1`) from Group (Business Unit) `X`.
2. Create a new `project` (with Group as `X`), set visibility of project to `Everyone` and add linked `components`, and then raise the `clearing request` for the project (let's sat `CR1`).
3. Once `CR1` is created, logout from `U1` and login as another user with role `Clearing Expert` (let's say `CE1`) from Group `X`.
4. You should be able to see the `CR1` in `Open CR` table of `Request` portlet.
5. Logout from `CE1` and login as `U1` and change the project Group (Business Unit) to something else (`Y`).
6. Logout from `U1` and Login as `CE1` and now you should not be able to see this `CR1` in `Open CR` table of `Request` portlet. (because `Clearing Expert` should be able to see ONLY the `CR's` which belongs to their group / business unit.)
7. Now Login as another user with role `Clearing Expert` (let's say `CE2`) from Group `Y`.
8. User `CE2` from group `Y` should be able to see the above created `CR1` in `Open CR` table of `Request` portlet. 



### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: akapti <abdul.kapti@siemens-healthineers.com>