### PR TITLE
Added access for deleting merge source release for clearing admin

### DIFF
--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/DocumentPermissions.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/permissions/DocumentPermissions.java
@@ -105,7 +105,7 @@ public abstract class DocumentPermissions<T> {
             case DELETE:
             case USERS:
             case CLEARING:
-                return PermissionUtils.isAdmin(user) || isModerator() || isUserOfOwnGroupHasRole(adminRoles, UserGroup.ADMIN);
+                return PermissionUtils.isAdmin(user) || isModerator() || isUserOfOwnGroupHasRole(adminRoles, UserGroup.ADMIN) || isUserOfOwnGroupHasRole(clearingAdminRoles, UserGroup.CLEARING_ADMIN);
             case WRITE_ECC:
                 return PermissionUtils.isAdmin(user) || isUserOfOwnGroupHasRole(adminRoles, UserGroup.ADMIN);
             default:

--- a/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissionsTest.java
+++ b/libraries/datahandler/src/test/java/org/eclipse/sw360/datahandler/permissions/ProjectPermissionsTest.java
@@ -67,7 +67,7 @@ public class ProjectPermissionsTest extends ScenarioTest<GivenProject, WhenCompu
 
                 //strangers: rights increase with user group
                 {GivenProject.ProjectRole.CREATED_BY, theUser, theOtherUser, USER, theDept, READ_ACTION},
-                {GivenProject.ProjectRole.CREATED_BY, theUser, theOtherUser, CLEARING_ADMIN, theDept, PRIVILEGED_ACTIONS_EXCEPT_ECC },
+                {GivenProject.ProjectRole.CREATED_BY, theUser, theOtherUser, CLEARING_ADMIN, theDept, ALL_ACTIONS_EXCEPT_ECC },
                 {GivenProject.ProjectRole.CREATED_BY, theUser, theOtherUser, CLEARING_ADMIN, theOtherDept, READ_ACTION},
                 {GivenProject.ProjectRole.CREATED_BY, theUser, theOtherUser, ECC_ADMIN, theDept, READ_ACTION},
                 {GivenProject.ProjectRole.CREATED_BY, theUser, theOtherUser, ADMIN, theDept, ALL_ACTIONS},


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Added a check so that 'clearing admin' user can merge components
> * Which issue is this pull request belonging to and how is it solving it? (#1669 )

Issue: 
Merge Components fails with error message #1669


### How To Test?

1. Log in as 'clearing admin' user
2. Open a component and click on merge button
3. Select another component to merge into and run through the entire dailog and eventually click on Finish button

Signed-off-by: Eldrin <eldrin.sanctis@siemens.com>