### PR TITLE
feat(buildsystem): Rearrange dependencies and deployments

### DIFF
--- a/.github/testForLicenseHeaders.sh
+++ b/.github/testForLicenseHeaders.sh
@@ -13,18 +13,20 @@
 # initial author: maximilian.huber@tngtech.com
 # -----------------------------------------------------------------------------
 
-cd "$(dirname $0)/.."
+set -e
+
+cd "$(dirname "$0")/.." || exit 1
 
 failure=false
 
-while read file ; do
-    if ! head -15 $file | grep -q 'SPDX-License-Identifier:' $file; then
+while read -r file ; do
+    if ! head -15 "$file" | grep -q 'SPDX-License-Identifier:' $file; then
         echo "WARN: no 'SPDX-License-Identifier' in  $file"
     fi
-    if head -15 $file | grep -q 'https://www.eclipse.org/legal/epl-2.0/'; then
+    if head -15 "$file" | grep -q 'https://www.eclipse.org/legal/epl-2.0/'; then
         continue # epl found
     fi
-    if head -15 $file | grep -q 'SPDX-License-Identifier: EPL-2.0'; then
+    if head -15 "$file" | grep -q 'SPDX-License-Identifier: EPL-2.0'; then
         continue # edl found
     fi
 

--- a/.github/workflows/githubactions.yml
+++ b/.github/workflows/githubactions.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Prepare build environment
       run: |
         sudo apt-get update -qq
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq python3-pip build-essential libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake cmake libtool flex bison pkg-config libssl-dev git temurin-11-jdk maven
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq python3-pip build-essential libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config libssl-dev git temurin-11-jdk maven cmake
         pip install mkdocs mkdocs-material
 
     - name: Install Thrift

--- a/Dockerfile
+++ b/Dockerfile
@@ -169,7 +169,8 @@ RUN --mount=type=bind,target=/build/sw360,rw \
     -Dtest=org.eclipse.sw360.rest.resourceserver.restdocs.* \
     -Dsurefire.failIfNoSpecifiedTests=false \
     -Dbase.deploy.dir=. \
-    -Dliferay.deploy.dir=/sw360_deploy \
+    -Djars.deploy.dir=/sw360_deploy \
+    -Dliferay.deploy.dir=/sw360_tomcat_webapps \
     -Dbackend.deploy.dir=/sw360_tomcat_webapps \
     -Drest.deploy.dir=/sw360_tomcat_webapps \
     -Dhelp-docs=true
@@ -179,8 +180,7 @@ WORKDIR /sw360_tomcat_webapps/
 
 COPY scripts/create-slim-war-files.sh /bin/slim.sh
 COPY --from=clucenebuild /couchdb-lucene.war /sw360_tomcat_webapps
-RUN bash /bin/slim.sh \
-    && ls /sw360_tomcat_webapps
+RUN bash /bin/slim.sh
 
 #--------------------------------------------------------------------------------------------------
 # Runtime image

--- a/frontend/sw360-portlet/pom.xml
+++ b/frontend/sw360-portlet/pom.xml
@@ -10,8 +10,7 @@
   ~ SPDX-License-Identifier: EPL-2.0
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -21,33 +20,33 @@
     </parent>
 
     <artifactId>sw360-portlet</artifactId>
-    <packaging>jar</packaging>
+    <packaging>war</packaging>
 
     <properties>
-	    <artifact.deploy.dir>${liferay.deploy.dir}</artifact.deploy.dir>
+        <artifact.deploy.dir>${liferay.deploy.dir}</artifact.deploy.dir>
     </properties>
 
     <profiles>
-    <profile>
-         <id>help-docs</id>
-         <activation>
-             <property>
-                  <name>help-docs</name>
-                  <value>true</value>
-             </property>
-         </activation>
-	 <properties>
-		<packagePhase>prepare-package</packagePhase>
-	 </properties>
-   </profile>
-   </profiles>
-   <build>
-   <finalName>org.eclipse.sw360.portlet-${project.version}</finalName>
+        <profile>
+            <id>help-docs</id>
+            <activation>
+                <property>
+                    <name>help-docs</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <packagePhase>prepare-package</packagePhase>
+            </properties>
+        </profile>
+    </profiles>
+    <build>
+        <finalName>org.eclipse.sw360.portlet-${project.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>com.liferay</groupId>
                 <artifactId>com.liferay.css.builder</artifactId>
-                <version>3.1.0</version>
+                <version>${liferay.css.builder.version}</version>
                 <executions>
                     <execution>
                         <id>default-build-css</id>
@@ -101,29 +100,20 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                    </archive>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>com.github.fabienbarbero</groupId>
                 <artifactId>mkdocs-maven-plugin</artifactId>
                 <version>1.1.1</version>
                 <executions>
-                <execution>
-                    <id>generate-mkdocs</id>
-                    <phase>${packagePhase}</phase>
-                    <goals>
-                        <goal>build</goal>
-                    </goals>
-                    <configuration>
-                        <configFile>${basedir}/src/documentation/mkdocs.yml</configFile>
-                    </configuration>
-                </execution>
+                    <execution>
+                        <id>generate-mkdocs</id>
+                        <phase>${packagePhase}</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <configFile>${basedir}/src/documentation/mkdocs.yml</configFile>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/libraries/commonIO/pom.xml
+++ b/libraries/commonIO/pom.xml
@@ -25,7 +25,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <artifact.deploy.dir>${liferay.deploy.dir}</artifact.deploy.dir>
+        <artifact.deploy.dir>${jars.deploy.dir}</artifact.deploy.dir>
     </properties>
 
     <build>

--- a/libraries/datahandler/pom.xml
+++ b/libraries/datahandler/pom.xml
@@ -24,7 +24,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <artifact.deploy.dir>${liferay.deploy.dir}</artifact.deploy.dir>
+        <artifact.deploy.dir>${jars.deploy.dir}</artifact.deploy.dir>
     </properties>
 
     <build>

--- a/libraries/exporters/pom.xml
+++ b/libraries/exporters/pom.xml
@@ -25,7 +25,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <artifact.deploy.dir>${liferay.deploy.dir}</artifact.deploy.dir>
+        <artifact.deploy.dir>${jars.deploy.dir}</artifact.deploy.dir>
     </properties>
 
     <build>

--- a/libraries/importers/pom.xml
+++ b/libraries/importers/pom.xml
@@ -24,7 +24,7 @@
 	<packaging>jar</packaging>
 
 	<properties>
-		<artifact.deploy.dir>${liferay.deploy.dir}</artifact.deploy.dir>
+		<artifact.deploy.dir>${jars.deploy.dir}</artifact.deploy.dir>
 	</properties>
 
 	<build>

--- a/libraries/log4j-osgi-support/pom.xml
+++ b/libraries/log4j-osgi-support/pom.xml
@@ -24,7 +24,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <artifact.deploy.dir>${liferay.deploy.dir}</artifact.deploy.dir>
+        <artifact.deploy.dir>${jars.deploy.dir}</artifact.deploy.dir>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <module>frontend</module>
         <module>rest</module>
         <module>clients</module>
+        <module>utils</module>
     </modules>
 
     <properties>
@@ -135,14 +136,16 @@
         <wiremock.version>2.26.0</wiremock.version>
 
         <!--  User must provide below property configuration based on his/her liferay deployment environment -->
-        <base.deploy.dir />
+        <base.deploy.dir>
+            ${session.executionRootDirectory}/deploy
+        </base.deploy.dir>
 
         <!--
             This is were the liferay OSGi modules go to on upload:
                 - frontend/*
                 - libraries/*
         -->
-        <liferay.deploy.dir>${base.deploy.dir}/liferay</liferay.deploy.dir>
+        <liferay.deploy.dir>${base.deploy.dir}/tomcat</liferay.deploy.dir>
         <!--
             This is were the backend services go to on upload:
                 - backend/svc/*
@@ -153,6 +156,8 @@
                 - rest/*
         -->
         <rest.deploy.dir>${base.deploy.dir}/tomcat</rest.deploy.dir>
+        <!-- JAR dependencies from maven-->
+        <jars.deploy.dir>${base.deploy.dir}/jars</jars.deploy.dir>
 
         <!-- some mem optimization here -->
         <argLine>-Dcatalina.home=${project.build.directory}/home -Xms128m -Xmx256m -XX:MaxPermSize=512m</argLine>
@@ -273,7 +278,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
-                <artifactId>commons-collection4</artifactId>
+                <artifactId>commons-collections4</artifactId>
                 <version>${commons-collection4.version}</version>
             </dependency>
             <dependency>
@@ -608,7 +613,6 @@
                     <format>html</format>
                 </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Siemens AG, 2013-2015, 2019. Part of the SW360 Portal Project.
+  ~ With modifications from Bosch Software Innovations GmbH, 2015.
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sw360</artifactId>
+        <groupId>org.eclipse.sw360</groupId>
+        <version>${revision}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>deps</artifactId>
+    <packaging>pom</packaging>
+
+    <build>
+        <finalName>utils</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-deps</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <!-- <outputDirectory>${session.executionRootDirectory}/deps/jars</outputDirectory> -->
+                            <outputDirectory>${jars.deploy.dir}</outputDirectory>
+                            <overwriteReleases>false</overwriteReleases>
+                            <overwriteSnapshots>false</overwriteSnapshots>
+                            <overwriteIfNewer>true</overwriteIfNewer>
+                            <excludeTransitive>true</excludeTransitive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+          </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.annotations.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.databind.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>${commons-collection4.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>${commons-csv.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.2</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
- All maven dependencies are moved from the shell script to a maven process plugin
- sw360-portlet was proper moved to a war file
- Deployments of portlets now go to tomcat and libraries to deploy

Signed-off-by: Helio Chissini de Castro <heliocastro@gmail.com>