### PR TITLE
fix(Project and Component UI): Formatting Issues in Import SBOM- 783

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/importBom.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/importBom.jspf
@@ -61,7 +61,7 @@
                         </div>
                     </div>
                 </div>
-                <div id="spdxBomUploadStatus"></div>
+                <div class="modal-body container d-none" id="spdxBomUploadStatus"></div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-light" data-dismiss="modal">Close</button>
                 </div>
@@ -94,7 +94,6 @@
                     urls.newAttachment = data.newAttachmentUrl;
                     urls.uploadAttachmentPart = data.uploadAttachmentPartUrl;
                     urls.importBom = data.importBomUrl;
-
                     function getAttachmentIdPromise(file) {
                         var data = {};
                         data[portletNamespace + "fileName"] = file.fileName || file.name;
@@ -125,7 +124,8 @@
                         simultaneousUploads: 1,
                         generateUniqueIdentifier: getAttachmentIdPromise,
                         chunkRetryInterval: 2000,
-                        maxChunkRetries: 3
+                        maxChunkRetries: 3,
+                        fileType: ['rdf']
                     });
 
                     r.assignBrowse($('#fileupload-browse')[0]);
@@ -134,9 +134,9 @@
                     r.on('fileAdded', function (file) {
                         console.log("fileAdded...");
                         contentDiv.hide();
-                        statusDiv.show();
+                        statusDiv.removeClass('d-none');
                         r.upload();
-                        statusDiv.html("<h2>Uploading ...</h2>");
+                        statusDiv.html("<h2>Uploading " + file.fileName + " file</h2>");
                     });
                     r.on('fileProgress', function (file) {
                         console.log("fileProgress...");

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/importBomForComponent.jspf
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/utils/includes/importBomForComponent.jspf
@@ -59,7 +59,7 @@
                         </div>
                     </div>
                 </div>
-                <div id="spdxBomUploadStatus"></div>
+                <div class="modal-body container d-none" id="spdxBomUploadStatus"></div>
                 <div id="spdxBomUploadAction" class="modal-footer">
                     <button id="importSBOM" type="button" class="btn btn-primary" data-dismiss="modal" style="display: none">Import</button>
                     <button id="importSBOMAsNew" type="button" class="btn btn-secondary" data-dismiss="modal" style="display: none">Import As New</button>
@@ -152,7 +152,8 @@
             simultaneousUploads: 1,
             generateUniqueIdentifier: getAttachmentIdPromise,
             chunkRetryInterval: 2000,
-            maxChunkRetries: 3
+            maxChunkRetries: 3,
+            fileType: ['rdf']
         });
 
         r.assignBrowse($('#spdx-fileupload-browse')[0]);
@@ -162,9 +163,9 @@
             console.log("fileAdded...");
             contentDiv.hide();
             $('#cancelImportSBOM').hide();
-            statusDiv.show();
+            statusDiv.removeClass("d-none");
             r.upload();
-            statusDiv.html("<h2>Uploading ...</h2>");
+            statusDiv.html("<h2>Uploading " + file.fileName + " file</h2>");
         });
         r.on('fileProgress', function (file) {
             console.log("fileProgress...");


### PR DESCRIPTION


Signed-off-by: afsahsyeda <afsah.syeda@siemens-healhtineers.com>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)


> The status div in the Import SBOM Modal has been aligned properly.
> The type of files that can be 'browsed' or 'drag and dropped' to the modal has been limited to .rdf
> The message 'Uploading...' has been changed to 'Uploading <file_name> File'.

Issue: 
1) Improper alignment of the status div in the Import SBOM modal.


### How To Test?
> Click on the 'Import SBOM' button in Project or Component Portlet.

![image](https://user-images.githubusercontent.com/115608771/197142333-5898a080-51bb-4a54-acd6-86474d6735d4.png)

