### PR TITLE
fix(UI): Unresponsive UI & top align session message

### DIFF
--- a/frontend/liferay-theme/src/main/webapp/css/portal/_alert.scss
+++ b/frontend/liferay-theme/src/main/webapp/css/portal/_alert.scss
@@ -8,14 +8,15 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-.alert-notifications-fixed {
-	top: 0;
+#sw360-body .alert-container.cadmin .alert-notifications-fixed#ToastAlertContainer {
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: auto;
+}
 
-	.alert {
-		width: auto;
-		border-radius: 0;
-
-		padding: 1rem calc(3vw + 1rem); // 3vw corresponds to container width of 94vw
-		max-width: none !important;
-	}
+#sw360-body .alert-container.cadmin .alert-notifications-fixed#ToastAlertContainer .alert-dismissible {
+    min-width: 100%;
+    font-size: inherit;
+    padding-left: 4rem;
 }

--- a/frontend/liferay-theme/src/main/webapp/templates/portal_normal.ftl
+++ b/frontend/liferay-theme/src/main/webapp/templates/portal_normal.ftl
@@ -48,7 +48,7 @@
 	<@liferay_util["include"] page=top_head_include />
 </head>
 
-<body class="${css_class}">
+<body class="${css_class}" id="sw360-body">
 
 <@liferay_ui["quick-access"] contentId="#main-content" />
 


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)


- This PR fixes the unresponsive UI elements when Session Message pop-up is open.
- Also top align the session message with full screen width (like [Liferay 7.3 session message](https://github.com/eclipse/sw360/pull/1508#issuecomment-1190234101)).

Issue: #1688 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
Create and  Edit a `project / component / release` and you should see top align session message and all UI elements should be responsive.

Sample screenshot below:
![image](https://user-images.githubusercontent.com/50870174/197276903-8398e627-b8fb-4663-a2c6-4fd1e67cc578.png)

![image](https://user-images.githubusercontent.com/50870174/197277712-0b8d2a29-857a-419d-91c8-4c3178116a17.png)

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
Signed-off-by: akapti <abdul.kapti@siemens-healthineers.com>