### PR TITLE
fix(SPDX):  Import SPDX licenses with new SPDX library (tools-java 1.0.4)

### DIFF
--- a/backend/src/src-licenseinfo/pom.xml
+++ b/backend/src/src-licenseinfo/pom.xml
@@ -29,23 +29,12 @@
         </dependency>
         <dependency>
             <groupId>org.spdx</groupId>
-            <artifactId>spdx-tools</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
+            <artifactId>tools-java</artifactId>
         </dependency>
-        <!-- Needed by spdx-tools -->
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>

--- a/backend/src/src-licenses/pom.xml
+++ b/backend/src/src-licenses/pom.xml
@@ -31,7 +31,11 @@
     <dependencies>
         <dependency>
             <groupId>org.spdx</groupId>
-            <artifactId>spdx-tools</artifactId>
+            <artifactId>tools-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
         </dependency>
         <!-- Needed by spdx-tools -->
         <dependency>

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/db/LicenseDatabaseHandler.java
@@ -59,6 +59,7 @@ import org.eclipse.sw360.datahandler.db.DatabaseHandlerUtil;
 import org.eclipse.sw360.datahandler.thrift.changelogs.Operation;
 import com.google.common.collect.Lists;
 import org.eclipse.sw360.datahandler.common.DatabaseSettings;
+import org.spdx.library.InvalidSPDXAnalysisException;
 
 /**
  * Class for accessing the CouchDB database
@@ -879,7 +880,12 @@ public class LicenseDatabaseHandler {
                     log.error("Failed to find SpdxListedLicense with id=" + spdxId);
                 }
             }else{
-                boolean matches = SpdxConnector.matchesSpdxLicenseText(sw360license,spdxId);
+                boolean matches = false;
+                try {
+                    matches = SpdxConnector.matchesSpdxLicenseText(sw360license,spdxId);
+                } catch (InvalidSPDXAnalysisException e) {
+                    throw new RuntimeException("the license which does not match the SPDX licensee"+ e.getMessage());
+                }
                 if (matches) {
                     log.info("The SPDX license with id=" + spdxId + " is already in the DB");
                 }else {

--- a/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/tools/SpdxConnector.java
+++ b/backend/src/src-licenses/src/main/java/org/eclipse/sw360/licenses/tools/SpdxConnector.java
@@ -15,11 +15,11 @@ import org.apache.logging.log4j.Logger;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.licenses.License;
 import org.eclipse.sw360.datahandler.thrift.Quadratic;
-import org.spdx.compare.LicenseCompareHelper;
-import org.spdx.compare.SpdxCompareException;
-import org.spdx.rdfparser.InvalidSPDXAnalysisException;
-import org.spdx.rdfparser.license.LicenseInfoFactory;
-import org.spdx.rdfparser.license.SpdxListedLicense;
+import org.spdx.library.InvalidSPDXAnalysisException;
+import org.spdx.library.model.license.LicenseInfoFactory;
+import org.spdx.library.model.license.SpdxListedLicense;
+import org.spdx.utility.compare.LicenseCompareHelper;
+import org.spdx.utility.compare.SpdxCompareException;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,7 +32,8 @@ public class SpdxConnector {
     private static final Logger log = LogManager.getLogger(SpdxConnector.class);
 
     public static List<String> getAllSpdxLicenseIds() {
-        return Arrays.asList(LicenseInfoFactory.getSpdxListedLicenseIds());
+        return LicenseInfoFactory.getSpdxListedLicenseIds();
+
     }
 
     protected static Optional<SpdxListedLicense> getSpdxLicense(String licenseId) {
@@ -51,20 +52,24 @@ public class SpdxConnector {
                 .flatMap(SpdxConnector::getSpdxLicenseAsSW360License);
     }
 
-    public static Optional<License> getSpdxLicenseAsSW360License(SpdxListedLicense spdxListedLicense){
-        Quadratic isOSIApproved = spdxListedLicense.isOsiApproved() ? Quadratic.YES : Quadratic.NA;
-        Quadratic isFSFLibre = spdxListedLicense.isFsfLibre() ? Quadratic.YES : Quadratic.NA;
+    public static Optional<License> getSpdxLicenseAsSW360License(SpdxListedLicense spdxListedLicense) {
+        try {
+            Quadratic isOSIApproved = spdxListedLicense.isOsiApproved() ? Quadratic.YES : Quadratic.NA;
+            Quadratic isFSFLibre = spdxListedLicense.isFsfLibre() ? Quadratic.YES : Quadratic.NA;
 
-        License license = new License()
-                .setId(spdxListedLicense.getLicenseId())
-                .setShortname(spdxListedLicense.getLicenseId())
-                .setFullname(spdxListedLicense.getName())
-                .setText(spdxListedLicense.getLicenseText())
-                .setOSIApproved(isOSIApproved)
-                .setFSFLibre(isFSFLibre)
-                .setExternalLicenseLink("https://spdx.org/licenses/" + spdxListedLicense.getLicenseId()+ ".html")
-                .setExternalIds(Collections.singletonMap("SPDX-License-Identifier", spdxListedLicense.getLicenseId()));
-        return Optional.of(license);
+            License license = new License()
+                    .setId(spdxListedLicense.getLicenseId())
+                    .setShortname(spdxListedLicense.getLicenseId())
+                    .setFullname(spdxListedLicense.getName())
+                    .setText(spdxListedLicense.getLicenseText())
+                    .setOSIApproved(isOSIApproved)
+                    .setFSFLibre(isFSFLibre)
+                    .setExternalLicenseLink("https://spdx.org/licenses/" + spdxListedLicense.getLicenseId()+ ".html")
+                    .setExternalIds(Collections.singletonMap("SPDX-License-Identifier", spdxListedLicense.getLicenseId()));
+            return Optional.of(license);
+        } catch (InvalidSPDXAnalysisException e) {
+            throw new RuntimeException("Error get spdx license: "+e.getMessage());
+        }
     }
 
     /**
@@ -72,11 +77,11 @@ public class SpdxConnector {
      * @param license
      * @return
      */
-    public static boolean matchesSpdxLicenseText(License license) {
+    public static boolean matchesSpdxLicenseText(License license) throws InvalidSPDXAnalysisException {
         return matchesSpdxLicenseText(license, license.getShortname());
     }
 
-    public static boolean matchesSpdxLicenseText(License license, String spdxId) {
+    public static boolean matchesSpdxLicenseText(License license, String spdxId) throws InvalidSPDXAnalysisException {
         final Optional<SpdxListedLicense> spdxLicense = getSpdxLicense(spdxId);
         if(!spdxLicense.isPresent()) {
             // A license, which has no SPDX counterpart, does not not match its SPDX-license
@@ -85,7 +90,7 @@ public class SpdxConnector {
         return matchesSpdxLicenseText(license, spdxLicense.get());
     }
 
-    private static boolean matchesSpdxLicenseText(License license, SpdxListedLicense spdxLicense) {
+    private static boolean matchesSpdxLicenseText(License license, SpdxListedLicense spdxLicense) throws InvalidSPDXAnalysisException {
         return matchesLicenseText(license, spdxLicense.getLicenseText());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,8 @@
         <thrift.version>0.16.0</thrift.version>
         <wiremock.version>2.26.0</wiremock.version>
         <org.spdx.tools.java.version>1.1.0</org.spdx.tools.java.version>
+        <com.googlecode.json-simple.version>1.1.1</com.googlecode.json-simple.version>
+
 
         <!--  User must provide below property configuration based on his/her liferay deployment environment -->
         <base.deploy.dir>
@@ -343,27 +345,14 @@
             </dependency>
             <dependency>
                 <groupId>org.spdx</groupId>
-                <artifactId>spdx-tools</artifactId>
-                <version>2.2.3</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.commons</groupId>
-                        <artifactId>commons-lang3</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-log4j12</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.spdx</groupId>
                 <artifactId>tools-java</artifactId>
                 <version>${org.spdx.tools.java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.googlecode.json-simple</groupId>
+                <artifactId>json-simple</artifactId>
+                <version>${com.googlecode.json-simple.version}</version>
+                <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.velocity</groupId>


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: #1699

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
1. Go to License Page in Tab Admin
2. Click button Import SPDX Information
3. Check License in tab License in Home Page


### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
