### PR TITLE
fix(User): CountryId does not exists while creating user with new Organization

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortalConstants.java
@@ -50,6 +50,7 @@ public class PortalConstants {
     public static final String LOAD_OPEN_MODERATION_REQUEST = "loadOpenModerationRequest";
     public static final String LOAD_CLOSED_MODERATION_REQUEST = "loadClosedModerationRequest";
     public static final String LICENSE_INFO_HEADER_TEXT_FILE_NAME_BY_PROJECT_GROUP;
+    public static final String DEFAULT_COUNTRY_NAME;
 
     // DO NOT CHANGE THIS UNLESS YOU KNOW WHAT YOU ARE DOING !!!
     // - friendly url mapping files must be changed
@@ -696,6 +697,7 @@ public class PortalConstants {
         PROJECT_OBLIGATIONS_ACTION_SET = CommonUtils.splitToSet(props.getProperty("project.obligation.actions", "Action 1,Action 2,Action 3"));
         IS_PROJECT_OBLIGATIONS_ENABLED = Boolean.parseBoolean(props.getProperty("project.obligations.enabled", "true"));
         CUSTOM_WELCOME_PAGE_GUIDELINE = Boolean.parseBoolean(props.getProperty("custom.welcome.page.guideline", "false"));
+        DEFAULT_COUNTRY_NAME = props.getProperty("liferay.default.country.name", "united-states");
         // SW360 REST API Constants
         API_TOKEN_ENABLE_GENERATOR = Boolean.parseBoolean(props.getProperty("rest.apitoken.generator.enable", "false"));
         REST_API_WRITE_ACCESS_TOKEN_IN_PREFERENCES = Boolean.parseBoolean(props.getProperty("rest.api.write.access.token.in.preferences", "false"));

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/UserPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/admin/UserPortlet.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.portlet.PortletResponseUtil;
 import com.liferay.portal.kernel.security.auto.login.AutoLoginException;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptorUtil;
 import com.liferay.portal.kernel.service.*;
+import com.liferay.portal.kernel.service.persistence.CountryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -38,7 +39,6 @@ import org.eclipse.sw360.datahandler.common.ThriftEnumUtils;
 import org.eclipse.sw360.datahandler.couchdb.lucene.LuceneAwareDatabaseConnector;
 import org.eclipse.sw360.datahandler.thrift.SW360Exception;
 import org.eclipse.sw360.datahandler.thrift.users.ClientMetadata;
-import org.eclipse.sw360.datahandler.thrift.users.UserAccess;
 import org.eclipse.sw360.datahandler.thrift.users.UserGroup;
 import org.eclipse.sw360.datahandler.thrift.users.UserService;
 import org.eclipse.sw360.portal.common.ErrorMessages;
@@ -933,6 +933,7 @@ public class UserPortlet extends Sw360Portlet {
         Map<String, Long> organizationIds = new HashMap<>();
         ServiceContext serviceContext = ServiceContextFactory.getInstance(request);
         long companyId = UserUtils.getCompanyId(request);
+        Country country = CountryServiceUtil.getCountryByName(companyId, PortalConstants.DEFAULT_COUNTRY_NAME);
         for (String headDepartment : headDepartments) {
 
             long organizationId;
@@ -943,7 +944,7 @@ public class UserPortlet extends Sw360Portlet {
             }
 
             if (organizationId == 0) { // The organization does not yet exist
-                Organization organization = createOrganization(serviceContext, headDepartment, OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID);
+                Organization organization = createOrganization(serviceContext, headDepartment, country.getCountryId(), OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID);
 
                 organizationId = organization.getOrganizationId();
             }
@@ -958,18 +959,18 @@ public class UserPortlet extends Sw360Portlet {
                 organizationId = 0;
             }
             if (organizationId == 0) { // The organization does not yet exist
-                createOrganization(serviceContext, department, organizationIds.get(extractHeadDept(department)).intValue());
+                createOrganization(serviceContext, department, country.getCountryId(), organizationIds.get(extractHeadDept(department)).intValue());
             }
         }
     }
 
-    private Organization createOrganization(ServiceContext serviceContext, String headDepartment, int parentId) throws PortalException, SystemException {
+    private Organization createOrganization(ServiceContext serviceContext, String headDepartment, long countryId, int parentId) throws PortalException, SystemException {
         return OrganizationServiceUtil.addOrganization(
                 parentId,
                 headDepartment,
                 OrganizationConstants.TYPE_ORGANIZATION,
                 RegionConstants.DEFAULT_REGION_ID,
-                CountryConstants.DEFAULT_COUNTRY_ID,
+                countryId,
                 ListTypeConstants.ORGANIZATION_STATUS_DEFAULT,
                 "",
                 false,

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/OrganizationHelper.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/users/OrganizationHelper.java
@@ -17,12 +17,13 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.*;
 import com.liferay.portal.kernel.security.membershippolicy.OrganizationMembershipPolicyUtil;
+import com.liferay.portal.kernel.service.CountryServiceUtil;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 
 import org.eclipse.sw360.datahandler.common.CommonUtils;
-
+import org.eclipse.sw360.portal.common.PortalConstants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -80,12 +81,13 @@ public class OrganizationHelper {
             log.info(String.format("Organization %s already exists", organizationName));
         } catch (NoSuchOrganizationException e) {
             User defaultUser = UserLocalServiceUtil.loadGetDefaultUser(companyId);
-            organization = addOrganization(organizationName, defaultUser);
+            Country country = CountryServiceUtil.getCountryByName(companyId, PortalConstants.DEFAULT_COUNTRY_NAME);
+            organization = addOrganization(organizationName, country.getCountryId(), defaultUser);
         }
         return organization;
     }
 
-    private Organization addOrganization(String organizationName, User user) throws SystemException {
+    private Organization addOrganization(String organizationName, long countryId, User user) throws SystemException {
         log.info("OrganizationHelper adds the organization " + organizationName);
         Organization organization = null;
         try {
@@ -97,7 +99,7 @@ public class OrganizationHelper {
                             organizationName,
                             TYPE_REGULAR_ORGANIZATION,
                             RegionConstants.DEFAULT_REGION_ID,
-                            CountryConstants.DEFAULT_COUNTRY_ID,
+                            countryId,
                             ListTypeConstants.ORGANIZATION_STATUS_DEFAULT,
                             "Automatically created during LDAP import",
                             false,

--- a/frontend/sw360-portlet/src/main/resources/sw360.properties
+++ b/frontend/sw360-portlet/src/main/resources/sw360.properties
@@ -236,3 +236,6 @@ rest.api.write.access.token.in.preferences=false
 # This property is used to disable the Clearing Request feature for the projects based on project Business Unit (BU) / Group.
 # Add the list of BU for which you want to disable the Clearing Request feature.
 #org.eclipse.sw360.disable.clearing.request.for.project.group=DEPARTMENT
+
+## This property is to set the default country for Liferay
+#liferay.default.country.name=unites-states


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

- Fetch the `countryid` based on `companyid` and `name` instead of using the default countryid (`19`) provided by Liferay, 


Issue: #1707 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
1. Create a user from SW360 admin portlet with the new department (should not be present in Liferay PostgreSQL DB)
 ![image](https://user-images.githubusercontent.com/50870174/200390355-b7f85d68-59a7-43be-a1eb-6b78c1216858.png)
 
3. Upload the users with new department from csv file.
 ![image](https://user-images.githubusercontent.com/50870174/200390556-f8ae869e-0aa4-4d8c-ba70-2253f7b49e9c.png)

4. Creation of user should be successful in both of the above steps.

> Have you implemented any additional tests?

- No

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: akapti <abdul.kapti@siemens-healthineers.com>