### PR TITLE
fix(UI): Text field is blank while ExportSpread in licenses

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/LicenseSummary.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/components/summary/LicenseSummary.java
@@ -39,6 +39,7 @@ public class LicenseSummary extends DocumentSummary<License> {
                 copyField(document, copy, _Fields.FULLNAME);
                 copyField(document, copy, _Fields.LICENSE_TYPE_DATABASE_ID);
                 copyField(document, copy, _Fields.CHECKED);
+                copyField(document, copy, _Fields.TEXT);
         }
 
         return copy;


### PR DESCRIPTION
Signed-off-by: Nikesh kumar <kumar.nikesh@simens.com>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
when we export spreadsheet in licenses tab, Text field column is blanks, So i  add the code to show the text data while export spreadsheet.
> * Which issue is this pull request belonging to and how is it solving it? #1709 
> * Did you add or update any new dependencies that are required for your change?

Issue: when we export spreadsheet in licenses tab, Text field column is blanks.

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
1. Login sw360 and go to licenses tab.
2. If licenses entries is empty then Add Licenses 
3. Export spreadsheet and check text column, data is coming or not.

> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
