### PR TITLE
fix(docker): add missing dependencies

### DIFF
--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -17,10 +17,10 @@ on:
     branches: [ release ]
 
 env:
-  DOCKER_IMAGE_ROOT: eclipse
+  DOCKER_IMAGE_ROOT: ghcr.io/eclipse
   CLUCENE_VERSION: 2.1.0
   MAVEN_VERSION: 3.8.6
-  THRIFT_VERSION: 0.17.0
+  THRIFT_VERSION: 0.16.0
   LIFERAY_VERSION: 7.4.3.18-ga18
   LIFERAY_SOURCE: liferay-ce-portal-tomcat-7.4.3.18-ga18-20220329092001364.tar.gz
   REGISTRY: ghcr.io
@@ -53,7 +53,7 @@ jobs:
           context: .
           target: sw360thrift
           build-args: |
-            THRIFT_VERSION=0.17.0
+            THRIFT_VERSION=${{ env.THRIFT_VERSION }}
           push: true
           tags: |
             ${{ env.DOCKER_IMAGE_ROOT }}/sw360thrift:latest
@@ -95,6 +95,8 @@ jobs:
         with:
           context: .
           target: sw360
+          build-args: |
+            MAVEN_VERSION=${{ env.MAVEN_VERSION }}
           push: true
           tags: |
             ${{ env.DOCKER_IMAGE_ROOT }}/sw360:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ RUN --mount=type=cache,mode=0755,target=/var/cache/apt,sharing=locked \
 FROM ubuntu:jammy AS sw360thrift
 
 ARG BASEDIR="/build"
-ARG THRIFT_VERSION=0.17.0
+ARG THRIFT_VERSION=0.16.0
 
 RUN --mount=type=cache,mode=0755,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,mode=0755,target=/var/lib/apt,sharing=locked \
@@ -179,12 +179,12 @@ RUN --mount=type=bind,target=/build/sw360,rw \
     -Dsurefire.failIfNoSpecifiedTests=false \
     -Dbase.deploy.dir=. \
     -Djars.deploy.dir=/sw360_deploy \
-    -Dliferay.deploy.dir=/sw360_tomcat_webapps \
+    -Dliferay.deploy.dir=/sw360_deploy \
     -Dbackend.deploy.dir=/sw360_tomcat_webapps \
     -Drest.deploy.dir=/sw360_tomcat_webapps \
     -Dhelp-docs=true
 
-# # Generate slim war files
+# Generate slim war files
 WORKDIR /sw360_tomcat_webapps/
 
 COPY scripts/create-slim-war-files.sh /bin/slim.sh
@@ -193,7 +193,7 @@ RUN bash /bin/slim.sh
 
 #--------------------------------------------------------------------------------------------------
 # Runtime image
-FROM eclipse/sw360base:latest as sw360
+FROM ghcr.io/eclipse/sw360base:latest as sw360
 
 WORKDIR /app/
 
@@ -222,4 +222,3 @@ STOPSIGNAL SIGINT
 WORKDIR /app/sw360
 
 ENTRYPOINT [ "/app/entry_point.sh" ]
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ version: '3.8'
 
 services:
   sw360:
-    image: 'eclipse/sw360:latest'
+    image: 'ghcr.io/eclipse/sw360:latest'
     restart: unless-stopped
     container_name: sw360
     depends_on:
@@ -42,6 +42,11 @@ services:
       options:
         max-size: 10m
         max-file: "2"
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready --dbname $$POSTGRES_DB --username $$POSTGRES_USER" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   couchdb:
     image: couchdb
@@ -51,9 +56,14 @@ services:
       - COUCHDB_PASSWORD=password
       - COUCHDB_CREATE_DATABASE=yes
     ports:
-      - 5984:5984
+      - "5984:5984"
     volumes:
       - couchdb:/opt/couchdb/data
+    healthcheck:
+      test: [ "CMD-SHELL", "curl --fail -s http://localhost:5984/_up" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   postgres: null

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
         <dom4j.version>2.1.3</dom4j.version>
         <ektorp.version>1.5.0</ektorp.version>
         <ektorplucene.version>0.2.0</ektorplucene.version>
+        <failureaccess.version>1.0.1</failureaccess.version>
         <findbugs-annotations.version>1.3.9-1</findbugs-annotations.version>
         <glassfish-jaxb.version>2.3.2</glassfish-jaxb.version>
         <gson.version>2.8.9</gson.version>
@@ -242,7 +243,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>failureaccess</artifactId>
-                <version>1.0.1</version>
+                <version>${failureaccess.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-cli</groupId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -36,9 +36,9 @@
                         <configuration>
                             <!-- <outputDirectory>${session.executionRootDirectory}/deps/jars</outputDirectory> -->
                             <outputDirectory>${jars.deploy.dir}</outputDirectory>
-                            <overwriteReleases>false</overwriteReleases>
-                            <overwriteSnapshots>false</overwriteSnapshots>
-                            <overwriteIfNewer>true</overwriteIfNewer>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
                             <excludeTransitive>true</excludeTransitive>
                         </configuration>
                     </execution>
@@ -84,6 +84,11 @@
             <version>${commons-collection4.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${commons-compress.version}</version>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>${commons-io.version}</version>
@@ -102,6 +107,16 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
             <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>failureaccess</artifactId>
+            <version>${failureaccess.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+            <version>${thrift.version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Add missing OSGI dependencies:
1. `commons-compress`
2. `failureaccess`
3. `libthrift`

In `docker_deploy.yml`:
1. Fix the docker image root to use `ghcr.io` registry
2. Fix Thrift version to `0.16.0` to match `pom.xml`

In `docker-compose.yml`:
1. Add `ghcr.io/` registry to sw360 image.
2. Add healthcheck to postgres and couchdb

In `Dockerfile`:
1. Fix thrift version to `0.16.0` to match `pom.xml`
2. Fix `liferay.deploy.dir` path to liferay/deploy
3. Add `ghcr.io/` registry to image path to prevent using Docker Hub.

### Suggest Reviewer
> @ag4ums
> @heliocastro

### How To Test?
> Perform a clean install and check catalina log. The issues because of missing OSGI dependencies should be resolved.
>
> Building the Docker image should also resolve multiple issues.

### Known issue
The package `org.spdx:tools-java:1.0.4` depends on `org.yaml:snakeyaml:1.23` and springboot depends on `org.yaml:snakeyaml:1.29`. Due to this dependency conflict, the loading of `resource` and `authentication` packages fails in Docker container (since all third party JARs are placed in common shared location). This also causes `sw360users` DB to be not created in couchdb.

If the JARs are not slimmed using `scripts/create-slim-war-files.sh`, the Docker container loads normally and all portlet works as well. However, doing so, the Docker image size goes up to 3+ GB from 1.3 GB.

### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR
