### PR TITLE
fix(docker): Deploy libraries in correct place

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -190,7 +190,7 @@ RUN --mount=type=bind,target=/build/sw360,rw \
     -Dsurefire.failIfNoSpecifiedTests=false \
     -Dbase.deploy.dir=. \
     -Djars.deploy.dir=/sw360_deploy \
-    -Dliferay.deploy.dir=/sw360_tomcat_webapps \
+    -Dliferay.deploy.dir=/sw360_deploy \
     -Dbackend.deploy.dir=/sw360_tomcat_webapps \
     -Drest.deploy.dir=/sw360_tomcat_webapps \
     -Dhelp-docs=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
     tty: true
     volumes:
       - etc:/etc/sw360
-      - document_library:/app/sw360/data/document_library
       - ./config:/app/sw360/config
 
   postgresdb:
@@ -68,7 +67,6 @@ volumes:
   postgres: null
   couchdb: null
   etc: null
-  document_library: null
 
 networks:
   default:


### PR DESCRIPTION
- Liferayy need to deploy theme in own deploy directory, not tomcat one.
- Disabled docker-compose document_library volume as never used

Thanks @GMishx 