### PR TITLE
fix(PreferencesUI):Read Access has to be checked before Generating token

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/preferences/view.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/preferences/view.jsp
@@ -153,7 +153,7 @@
                                     <td><liferay-ui:message key="authorities" />:</td>
                                     <td>
                                         <div class="form-check">
-                                            <input type="checkbox" name="<portlet:namespace/><%=RestApiToken._Fields.AUTHORITIES%>READ"
+                                            <input type="checkbox" required checked name="<portlet:namespace/><%=RestApiToken._Fields.AUTHORITIES%>READ"
                                                 id="authorities_read" class="form-check-input" />
                                             <label class="form-check-label" for="authorities_read"><liferay-ui:message key="read.access" /></label>
                                             <br>
@@ -162,6 +162,9 @@
                                                 id="authorities_write" class="form-check-input" />
                                             <label class="form-check-label" for="authorities_write"><liferay-ui:message key="write.access" /></label>
                                             </core_rt:if>
+                                             <div class="invalid-feedback">
+                                                <liferay-ui:message key="read.access.is.required" />
+                                            </div>
                                         </div>
                                     </td>
                                 </tr>

--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -1061,6 +1061,7 @@ quick.filter=Quick Filter
 rate=Rate
 rational.team.concert=Rational Team Concert
 read.access=Read Access
+read.access.is.required=Read Access is required
 read.and.write.access=Read and Write Access
 recent.components=Recent Components
 recent.releases=Recent Releases

--- a/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
@@ -1061,6 +1061,7 @@ quick.filter=クイックフィルター
 rate=レート
 rational.team.concert=Rational チーム協力
 read.access=読み取りアクセス
+read.access.is.required=Read Access is required
 read.and.write.access=Read and Write Access
 recent.components=最近の成分
 recent.releases=最近のリリース

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -1059,6 +1059,7 @@ quick.filter=Bộ lọc nhanh
 rate=Tỷ lệ
 rational.team.concert=Buổi hòa nhạc nhóm hợp lý
 read.access=Đọc quyền truy cập
+read.access.is.required=Read Access is required
 read.and.write.access=Read and Write Access
 recent.components=Các thành phần gần đây
 recent.releases=Các bản phát hành gần đây


### PR DESCRIPTION
Signed-off-by: afsahsyeda <afsah.syeda@siemens-healhtineers.com>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)


Changes:
1) Read Access will be checked by default while generating token.
2) It is mandatory for Read access to be checked.
3) An error message saying 'Read Access is required' will be displayed if Read access is unchecked by user.

Issue: #1722 

### How To Test?
Click on 'Generate Token' with the Read Access box unchecked.

![image](https://user-images.githubusercontent.com/115608771/201929222-0c787ff5-31fa-4f24-be63-71674dba9ecf.png)

