### PR TITLE
Feat(UI): apply sorting in release versions when inspecting component

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -1566,7 +1566,6 @@ public class ComponentPortlet extends FossologyAwarePortlet {
                 Set<String> releaseIds = SW360Utils.getReleaseIds(component.getReleases());
 
                 setUsingDocs(request, user, client, releaseIds);
-
                 if (IS_COMPONENT_VISIBILITY_RESTRICTION_ENABLED) {
                     request.setAttribute(IS_USER_ALLOWED_TO_MERGE, PermissionUtils.isUserAtLeast(UserGroup.ADMIN, user));
                 } else {
@@ -1690,6 +1689,10 @@ public class ComponentPortlet extends FossologyAwarePortlet {
 
             component = client.getAccessibleComponentById(id, user);
             request.setAttribute(COMPONENT, component);
+            for (int i=0; i<component.releases.size(); i++) {
+                Collections.sort(component.releases, (release1, release2) -> release1.getVersion() .compareTo(release2.getVersion()) );
+            }
+            Collections.reverse(component.releases);
 
             addComponentBreadcrumb(request, response, component);
             if (release != null) {


### PR DESCRIPTION

Issue:  #1726 

### How To Test?
Go to component tab and click the release dropdown button when inspecting a release of that component.
The list of release versions should be in descending order (newest to oldest).

![image](https://user-images.githubusercontent.com/58290634/203301804-98aafcce-ad00-49b6-98e3-d9d3d43afae6.png)


