### PR TITLE
feat(MailApi): enable control over trusting the email host

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/mail/MailUtil.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/mail/MailUtil.java
@@ -73,6 +73,7 @@ public class MailUtil extends BackendUtils {
     private String enableDebug;
     private String supportMailAddress;
     private String smtpSSLProtocol;
+    private String smtpSSLTrust;
 
     public MailUtil() {
         mailExecutor = fixedThreadPoolWithQueueSize(MAIL_ASYNC_SEND_THREAD_LIMIT, MAIL_ASYNC_SEND_QUEUE_LIMIT);
@@ -98,6 +99,7 @@ public class MailUtil extends BackendUtils {
         enableDebug = loadedProperties.getProperty("MailUtil_enableDebug", "false");
         supportMailAddress = loadedProperties.getProperty("MailUtil_supportMailAddress","");
         smtpSSLProtocol = loadedProperties.getProperty("MailUtil_smtpSSLProtocol", "");
+        smtpSSLTrust = loadedProperties.getProperty("MailUtil_smtpSSLTrust", "*");
     }
 
     private void setSession() {
@@ -111,7 +113,7 @@ public class MailUtil extends BackendUtils {
         properties.setProperty("mail.smtp.auth", isAuthenticationNecessary);
         properties.setProperty("mail.smtp.starttls.enable", enableStarttls);
         properties.setProperty("mail.smtp.ssl.enable", enableSsl);
-
+        properties.setProperty("mail.smtp.ssl.trust", smtpSSLTrust);
         properties.setProperty("mail.debug", enableDebug);
         properties.setProperty("mail.smtp.ssl.protocols", smtpSSLProtocol);
 

--- a/backend/src-common/src/main/resources/sw360.properties
+++ b/backend/src-common/src/main/resources/sw360.properties
@@ -26,6 +26,7 @@ MailUtil_password=
 MailUtil_enableDebug=
 MailUtil_supportMailAddress=
 MailUtil_smtpSSLProtocol=
+MailUtil_smtpSSLTrust=
 
 # text patterns for mail utility
 defaultBegin = \


### PR DESCRIPTION

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

Feature to control the trusted host while sending emails via property `MailUtil_smtpSSLTrust` in sw360.properties file, which in turn set the `mail.smtp.ssl.trust` in email session.

Issue: 

### Suggest Reviewer

### How To Test?
Please refer this guide on how can we can control the trusted host while sending an email via config `mail.smtp.ssl.trust`.
https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html

![image](https://user-images.githubusercontent.com/50870174/204031060-844e66f8-8b2b-413e-ad4d-f4bd8efa2038.png)



### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: akapti <abdul.kapti@siemens-healthineers.com>
