### PR TITLE
feat(ProjectUI):License Info In the Spreadsheet Exported from Project License Clearing

### DIFF
--- a/libraries/datahandler/src/main/thrift/components.thrift
+++ b/libraries/datahandler/src/main/thrift/components.thrift
@@ -252,6 +252,9 @@ struct Release {
     36: optional set<string> subscribers, // List of subscribers
     37: optional map<string,set<string>> roles, //customized roles with set of mail addresses
 
+    65: optional set<string> mainLicenseIds,
+    66: optional set<string> otherLicenseIds,
+
     40: optional Vendor vendor,
     41: optional string vendorId,
 
@@ -262,8 +265,6 @@ struct Release {
     55: optional EccInformation eccInformation,
     56: optional set<string> softwarePlatforms,
 
-    65: optional set<string> mainLicenseIds,
-    66: optional set<string> otherLicenseIds,
     // Urls for the project
     70: optional string sourceCodeDownloadurl, // URL for download page for this release source code
     71: optional string binaryDownloadurl, // URL for download page for this release binaries

--- a/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseExporter.java
+++ b/libraries/exporters/src/main/java/org/eclipse/sw360/exporter/ReleaseExporter.java
@@ -46,6 +46,7 @@ public class ReleaseExporter extends ExcelExporter<Release, ReleaseHelper> {
         nameToDisplayName.put(Release._Fields.ECC_INFORMATION.getFieldName(), "ECC information");
         nameToDisplayName.put(Release._Fields.COTS_DETAILS.getFieldName(), "COTS details");
         nameToDisplayName.put(Release._Fields.MAIN_LICENSE_IDS.getFieldName(), "main license IDs");
+        nameToDisplayName.put(Release._Fields.OTHER_LICENSE_IDS.getFieldName(), "other license IDs");
         nameToDisplayName.put(Release._Fields.SOURCE_CODE_DOWNLOADURL.getFieldName(), "Source Code Downloadurl");
         nameToDisplayName.put(Release._Fields.BINARY_DOWNLOADURL.getFieldName(), "Binary Downloadurl");
         nameToDisplayName.put(Release._Fields.RELEASE_ID_TO_RELATIONSHIP.getFieldName(), "releases with relationship");
@@ -63,6 +64,8 @@ public class ReleaseExporter extends ExcelExporter<Release, ReleaseHelper> {
             .add(COMPONENT_ID)
             .add(NAME)
             .add(VERSION)
+            .add(MAIN_LICENSE_IDS)
+            .add(OTHER_LICENSE_IDS)
             .add(CLEARING_STATE)
             .add(ECC_INFORMATION)
             .add(VENDOR)


### PR DESCRIPTION


Signed-off-by: afsahsyeda <afsah.syeda@siemens-healhtineers.com>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)


Description:
- Spreadsheet exported from 'Project with linked releases' will have two additional columns i.e. 'main license IDs' and 'other license IDs' next to the 'clearing state' column.

Issue: #1717 

### How To Test?
1) Navigate to Projects tab
2) Open a project and go to License Clearing section
3) Click on 'Export Spreadsheet' and select 'Projects with linked releases'. The downloaded spreadsheet should contain 'main license IDs' and 'other license IDs' columns.

![image](https://user-images.githubusercontent.com/115608771/204204372-e98c9fd5-b372-4066-9791-3c1814b2b8b3.png)


