### PR TITLE
fix(moderation_request): Added a check that if documentId is null then ignore

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ModerationSearchHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ModerationSearchHandler.java
@@ -29,6 +29,7 @@ public class ModerationSearchHandler {
                     "    var ret = new Document();" +
                     "    if(!doc.type) return ret;" +
                     "    if(doc.type != 'moderation') return ret;" +
+                    "	 if(!doc.documentId) return ret;" +
                     "    function idx(obj) {" +
                     "        for (var key in obj) {" +
                     "            switch (typeof obj[key]) {" +


### PR DESCRIPTION

Signed-off-by: Eldrin <eldrin.sanctis@siemens.com>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

For moderation request filtering, added a check that if documentId is null then ignore that document

> * Which issue is this pull request belonging to and how is it solving it? (#1747 )

Issue: Moderation requests: search/filter does not work



### How To Test?

1. Go to Requests tab
2. Filter the moderation request by searching for department 'SI' or 'ADV'
3. The search results an empty list even though there are many requests
