### PR TITLE
fix(ProjectUI):Stale data displayed after using the Group filter in Project Advance Search

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -1511,11 +1511,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
 
     private void loadAndStoreStickyProjectGroup(PortletRequest request, User user, Map<String, Set<String>> filterMap) {
         String groupFilterValue = request.getParameter(Project._Fields.BUSINESS_UNIT.toString());
-        if (null == groupFilterValue) {
-            addStickyProjectGroupToFilters(request, user, filterMap);
-        } else {
-            ProjectPortletUtils.saveStickyProjectGroup(request, user, groupFilterValue);
-        }
+        ProjectPortletUtils.saveStickyProjectGroup(request, user, groupFilterValue);
     }
 
     private Map<PaginationData, List<Project>> findProjectsByFiltersOrId(Map<String, Set<String>> filterMap, String id, User user, PaginationData pageData) {
@@ -1583,15 +1579,6 @@ public class ProjectPortlet extends FossologyAwarePortlet {
             request.setAttribute(filteredField.getFieldName(), nullToEmpty(parameter));
         }
         return filterMap;
-    }
-
-    private void addStickyProjectGroupToFilters(PortletRequest request, User user, Map<String, Set<String>> filterMap){
-        String stickyGroupFilter = ProjectPortletUtils.loadStickyProjectGroup(request, user);
-        if (!isNullOrEmpty(stickyGroupFilter)) {
-            String groupFieldName = Project._Fields.BUSINESS_UNIT.getFieldName();
-            filterMap.put(groupFieldName, Sets.newHashSet(stickyGroupFilter));
-            request.setAttribute(groupFieldName, stickyGroupFilter);
-        }
     }
 
     private void prepareDetailView(RenderRequest request, RenderResponse response) throws IOException, PortletException {


### PR DESCRIPTION


Signed-off-by: afsahsyeda <afsah.syeda@siemens-healhtineers.com>

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

Description:
After using the `Group` filter in Project Advance Search, the result displayed will be refreshed on switching tab/reloading of page.

Issue: #1753 

### How To Test?
Please refer #1753 

