### PR TITLE
fix(UI): unset few field while create a duplicate in project and component tab

### DIFF
--- a/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
+++ b/backend/src-common/src/main/java/org/eclipse/sw360/datahandler/db/ProjectDatabaseHandler.java
@@ -572,7 +572,6 @@ public class ProjectDatabaseHandler extends AttachmentAwareDatabaseHandler {
         obligationRepository.add(obligation);
         Project project = getProjectById(obligation.getProjectId(), user);
         project.setLinkedObligationId(obligation.getId());
-        updateModifiedFields(project, user.getEmail());
         repository.update(project);
         project.unsetLinkedObligationId();
         dbHandlerUtil.addChangeLogs(obligation, null, user.getEmail(), Operation.CREATE, attachmentConnector,

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/common/PortletUtils.java
@@ -322,6 +322,9 @@ public class PortletUtils {
         newRelease.unsetCpeid();
         newRelease.unsetAttachments();
         newRelease.unsetClearingInformation();
+        newRelease.unsetModifiedBy();
+        newRelease.unsetModifiedOn();
+        newRelease.unsetAdditionalData();
 
         return newRelease;
     }
@@ -341,6 +344,9 @@ public class PortletUtils {
         //project specifics
         newProject.unsetAttachments();
         newProject.setClearingState(ProjectClearingState.OPEN);
+        newProject.unsetModifiedBy();
+        newProject.unsetModifiedOn();
+        newProject.unsetAdditionalData();
 
         return newProject;
     }

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/components/ComponentPortlet.java
@@ -1078,8 +1078,6 @@ public class ComponentPortlet extends FossologyAwarePortlet {
             String emailFromRequest = LifeRayUserSession.getEmailFromRequest(request);
 
             Release release = PortletUtils.cloneRelease(emailFromRequest, client.getAccessibleReleaseById(releaseId, user));
-            Map<String, String> sortedAdditionalData = getSortedMap(release.getAdditionalData(), true);
-            release.setAdditionalData(sortedAdditionalData);
 
             PortletUtils.setCustomFieldsEdit(request, user, release);
 

--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -2328,8 +2328,6 @@ public class ProjectPortlet extends FossologyAwarePortlet {
                 String department = user.getDepartment();
                 Project newProject = PortletUtils.cloneProject(emailFromRequest, department, client.getProjectById(id, user));
                 setDefaultRequestAttributes(request, newProject.getBusinessUnit());
-                Map<String, String> sortedAdditionalData = getSortedMap(newProject.getAdditionalData(), true);
-                newProject.setAdditionalData(sortedAdditionalData);
                 setAttachmentsInRequest(request, newProject);
                 PortletUtils.setCustomFieldsEdit(request, user, newProject);
                 request.setAttribute(PROJECT, newProject);


### PR DESCRIPTION
…onent

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? #1755 
> * Did you add or update any new dependencies that are required for your change?

Issue: 
When we do duplication in product and component (release) tab, few unnecessary information is also copied, so we unset those field as per the user request.

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
1: Login sw360 
2: Go to project tab and create a duplicate.
3: Go to component -> release tab and create duplicate.

> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
