### PR TITLE
feat(ProjectUi): Enable Release with only one non-approved CLI for 'Adding License Infor To Release' and 'Displaying Obligations'

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/LicenseInfoHandler.java
@@ -742,10 +742,12 @@ public class LicenseInfoHandler implements LicenseInfoService.Iface {
         }
 
         for (Entry<Release, Map<String, Boolean>> entry : filteredRelToSelAttIds.entrySet()) {
-            List<Attachment> filteredAttachments = SW360Utils.getApprovedClxAttachmentForRelease(entry.getKey());
-
-            if (filteredAttachments.size() == 1) {
-                final String acceptedAttachmentContentId = filteredAttachments.get(0).getAttachmentContentId();
+            List<Attachment> approvedCliAttachments = SW360Utils.getApprovedClxAttachmentForRelease(entry.getKey());
+            if (approvedCliAttachments.isEmpty()) {
+                approvedCliAttachments = SW360Utils.getClxAttachmentForRelease(entry.getKey());
+            }
+            if (approvedCliAttachments.size() == 1) {
+                final String acceptedAttachmentContentId = approvedCliAttachments.get(0).getAttachmentContentId();
                 final String releaseId = entry.getKey().getId();
 
                 if (releaseIdToAcceptedCLI.containsKey(releaseId) && releaseIdToAcceptedCLI.get(releaseId).equals(acceptedAttachmentContentId)) {

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/clearingStatus.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/clearingStatus.jsp
@@ -901,33 +901,23 @@ AUI().use('liferay-portlet-url', function () {
                         if (response && response.status) {
                             oneList = $('<ul/>');
                             multipleList = $('<ul/>');
-                            nilList = $('<ul/>');
                             if (response.one.length) {
                                 response.one.forEach(function(rel, index) {
                                     let url = makeReleaseViewUrl(rel.id),
-                                        viewUrl = $("<a/>").attr({href: url, target: "_blank"}).css("word-break", "break-word").text(rel.name + rel.version);
+                                        viewUrl = $("<a/>").attr({href: url, target: "_blank"}).css("word-break", "break-word").text(rel.name + " (" + rel.version + ")");
                                     oneList.append('<li>' + viewUrl[0].outerHTML + '</li>');
                                 });
                             }
                             if (response.mul.length) {
                                 response.mul.forEach(function(rel, index) {
                                     let url = makeReleaseViewUrl(rel.id),
-                                        viewUrl = $("<a/>").attr({href: url, target: "_blank"}).css("word-break", "break-word").text(rel.name + rel.version);
+                                        viewUrl = $("<a/>").attr({href: url, target: "_blank"}).css("word-break", "break-word").text(rel.name + " (" + rel.version + ")");
                                     multipleList.append('<li>' + viewUrl[0].outerHTML + '</li>');
                                 });
                             }
-                            if (response.nil.length) {
-                                response.nil.forEach(function(rel, index) {
-                                    let url = makeReleaseViewUrl(rel.id),
-                                        viewUrl = $("<a/>").attr({href: url, target: "_blank"}).css("word-break", "break-word").text(rel.name + rel.version);
-                                    nilList.append('<li>' + viewUrl[0].outerHTML + '</li>');
-                                });
-                            }
+
                             if ($(multipleList).find('li').length) {
-                                $dialog.warning('<liferay-ui:message key="multiple.approved.cli.are.found.in.the.release" />: <b>' + $(multipleList).find('li').length + '</b>' + multipleList[0].outerHTML);
-                            }
-                            if ($(nilList).find('li').length) {
-                                $dialog.warning('<liferay-ui:message key="approved.cli.not.found.in.the.release" />: <b>' + $(nilList).find('li').length + '</b>' + nilList[0].outerHTML);
+                                $dialog.warning('<liferay-ui:message key="multiple.cli.are.found.in.the.release" />: <b>' + $(multipleList).find('li').length + '</b>' + multipleList[0].outerHTML);
                             }
                             if ($(oneList).find('li').length) {
                                 $dialog.success('<liferay-ui:message key="success.please.reload.page.to.see.the.changes" />: <b>' + $(oneList).find('li').length + '</b>');

--- a/frontend/sw360-portlet/src/main/resources/content/Language.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language.properties
@@ -915,7 +915,6 @@ oidc.client=OIDC Client
 on=on
 only.administrators.can.edit.a.closed.project=Only administrators can edit a closed project.
 only.admin.users.can.delete.obligations=Only admin users can delete obliations!
-only.approved.cli.files.obligations.will.be.shown.here=Only <b>Approved</b> CLI files Obligations will be shown here.
 only.approved=Only Approved
 only.current.or.future.date.is.considered.as.valid=Only current or future date is considered as valid
 open=Open

--- a/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_ja.properties
@@ -914,7 +914,6 @@ ok=OK
 on=on
 only.administrators.can.edit.a.closed.project=閉じたプロジェクトを編集できるのは管理者だけです。
 only.admin.users.can.delete.todos=アドミンユーザのみがToDoを削除可能
-only.approved.cli.files.obligations.will.be.shown.here=ここでは、<b>承認済み</b>のCLIファイルのみが表示されます。
 only.approved=承認のみ
 only.current.or.future.date.is.considered.as.valid=Only current or future date is considered as valid
 open=開く

--- a/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
+++ b/frontend/sw360-portlet/src/main/resources/content/Language_vi.properties
@@ -917,7 +917,6 @@ ok=OK
 on=on
 only.administrators.can.edit.a.closed.project=Chỉ quản trị viên có thể dự án đã đóng
 do.you.really.want.to.delete.the.obligation.x=Chỉ người dùng quản trị mới có thể xóa Việc cần làm!
-only.approved.cli.files.obligations.will.be.shown.here=Chỉ <b>Được phê duyệt</b> Các tệp CLI Nghĩa vụ sẽ được hiển thị tại đây.
 only.approved=Only Approved
 only.current.or.future.date.is.considered.as.valid=Only current or future date is considered as valid
 open=Mở

--- a/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
+++ b/libraries/datahandler/src/main/java/org/eclipse/sw360/datahandler/common/SW360Utils.java
@@ -231,6 +231,14 @@ public class SW360Utils {
         return release.getAttachments().stream().filter(isApprovedCLI).collect(Collectors.toList());
     }
 
+    public static List<Attachment> getClxAttachmentForRelease(Release release) {
+        Predicate<Attachment> isCLI = attachment -> AttachmentType.COMPONENT_LICENSE_INFO_XML.equals(attachment.getAttachmentType());
+        if (release.getAttachments() == null) {
+            return new ArrayList<Attachment>();
+        }
+        return release.getAttachments().stream().filter(isCLI).collect(Collectors.toList());
+    }
+
     public static Map<String, String> getReleaseIdtoAcceptedCLIMappings(Map<String, ObligationStatusInfo> obligationStatusMap) {
         if (null == obligationStatusMap) {
             return Maps.newHashMap();


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Please provide a summary of your changes here.

- `Add License Info to Release` feature at project-level will work for release with only one `non-Approved CLI` as well.
- `Obligations` will now be pulled from those release where only on non-approved CLI is present.


Issue: #1763 


### How To Test?

Use Case 1:
1. Add only one CLI (xml/rdf) file (say `CLI X`) containing `License A` and `Obligations B` in release (say `Release A`) as attachment.
2. Link the release from step 1 `Release A` to a project (say: `project A`)
3. Loading of `project A` should load `Obligations B` from `CLI X` in `Release A` into Project details page `Obligations` tab.
4. Clicking of `Add License Info to Release` button in Project details page `License Clearing` tab should successfully add `License A` from `CLI X` into `Release A` License field (main license / other license).

Use Case 2:

5. Add one more CLI (xml/rdf) file (say `CLI Y`) containing `License C` and `Obligations D` in release from step 1 `Release A` as attachment.
6. NO obligations should load from `CLI X` and `CLI Y` in `Release A` into Project details page `Obligations` tab -> because Obligations should be pulled only from release which contains only one Approved CLI or only one non-Approved CLI, but right now the `Release A` contains `TWO` non-Approved CLI (same condition applies to `Step 7`).
7. Clicking of `Add License Info to Release` button in Project details page `License Clearing` tab should fail with error: `Multiple CLI are found in release`.

Use Case 3:

8. Approve  `CLI Y` (xml/rdf) file containing `License C` and `Obligations D` from step 5 in `Release A` attachments.
9. Loading of `project A` should load `Obligations D` from `CLI Y` in `Release A` into Project details page `Obligations` tab -> because Obligations should be pulled only from release which contains only one Approved CLI or only one non-Approved CLI, & right now the `Release A` contains only one Approved CLI  (same condition applies to `Step 10`).
10. Clicking of `Add License Info to Release` button in Project details page `License Clearing` tab should successfully add `License C` from `CLI Y` into `Release A` License field (main license / other license).



### Checklist
Must:
- [x] All related issues are referenced in commit messages and in PR

Signed-off-by: akapti <abdul.kapti@siemens-healthineers.com>
