### PR TITLE
Fix(REST): Fix bug update project without vendor information will remove existing vendor information

### DIFF
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/project/Sw360ProjectService.java
@@ -199,6 +199,10 @@ public class Sw360ProjectService implements AwareOfRestServices<Project> {
             }
         }
 
+        if (project.getVendor() != null && project.getVendorId() == null) {
+            project.setVendorId(project.getVendor().getId());
+        }
+
         RequestStatus requestStatus = sw360ProjectClient.updateProject(project, sw360User);
         if (requestStatus == RequestStatus.NAMINGERROR) {
             throw new HttpMessageNotReadableException("Project name field cannot be empty or contain only whitespace character");


### PR DESCRIPTION
Fix bug update project without vendor information will remove existing vendor information

Fix issue 3 of #1770 

### How To Test?

Precondition:

There is a project (project name: P1, a vendor A was linked to P1
Step 1: Update project P1 via API http://{server_ip:port}/resource/api/projects/{IdProject}
{
"name": "P2",
"description": "This is a sample project",
}
Step 2. Check vendor information via API/GUI
Expected output: Vendor A won't be removed.
