### PR TITLE
fix(UI): ISR which will make the SW360 Release status as Scan Available

### DIFF
--- a/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
+++ b/backend/src/src-fossology/src/main/java/org/eclipse/sw360/fossology/FossologyHandler.java
@@ -463,7 +463,7 @@ public class FossologyHandler implements FossologyService.Iface {
         // that is added to the release
         Attachment attachment = CommonUtils.getNewAttachment(user, attachmentContent.getId(),
                 attachmentContent.getFilename());
-        attachment.setAttachmentType(AttachmentType.COMPONENT_LICENSE_INFO_XML);
+        attachment.setAttachmentType(AttachmentType.INITIAL_SCAN_REPORT);
         attachment.setSha1(attachmentConnector.getSha1FromAttachmentContentId(attachmentContent.getId()));
 
         // get release again because it has been updated in the meantime so version


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? #1789 
> * Did you add or update any new dependencies that are required for your change?

Issue: 
SW360 release, after the Successful FOSSology trigger is initial scan report and the report type is CLX which is wrong and which makes the SW360 status as "Report Available so we change report type is Initial Scan report this is the correct behavior.

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
1: Add Release in component.
2:In Attachement tab - Add the source file.
3:In Release overview tab - trigger the fossology  icon
![image](https://user-images.githubusercontent.com/49710817/209298698-ab70aca7-0b97-426e-9fc9-856e781b81ca.png)
![image](https://user-images.githubusercontent.com/49710817/209298829-0c53c92b-8fb2-4da8-ac0a-9bc6caaacd50.png)

> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
