### PR TITLE
fix(attachmentsUploadModal) : The progress bar will be shown only after a file has been selected and is uploading

### DIFF
--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/utils/includes/attachmentsUpload.js
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/js/utils/includes/attachmentsUpload.js
@@ -171,7 +171,7 @@ define('utils/includes/attachmentsUpload', ['jquery', 'resumable', 'modules/dial
                 });
 
                 $progressContainer = $('<div class="row"></div>').appendTo($fileControllers);
-                $progressContainer.append('<div class="col"><div class="progress"></div></div>');
+                $progressContainer.append('<div class="col"><div class="progress d-none"></div></div>');
                 var $progress = $('<div style="width: 0%;" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>');
                 $fileControllers.find('.progress').append($progress);
 
@@ -190,6 +190,7 @@ define('utils/includes/attachmentsUpload', ['jquery', 'resumable', 'modules/dial
                 var controller = fileControllers[fileToId(file)],
                     progress = file.progress() * 100;
 
+                $('.progress').removeClass('d-none');
                 controller.$progress.width(progress + '%');
                 controller.$progress.attr('aria-valuenow', progress);
             };


### PR DESCRIPTION


[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)


Description:

- Upload bar in attachment upload modal will be hidden until the user clicks on upload button.
- This ensures an empty progress bar is not seen.

Issue: #1745 

 How To Test?

- >Edit a project/component
- >Go to Attachments tab
- >Click on 'Add Attachment' button.
- >Upload a file

Screenshots:
On selecting a file
![image](https://user-images.githubusercontent.com/115608771/211779260-8a6ed62e-f8d7-4ec2-a323-39278198456b.png)

On clicking 'Upload'
![image](https://user-images.githubusercontent.com/115608771/211779176-e33a8a7c-00db-4307-80a5-bbb575276501.png)
