### PR TITLE
feat(ci): Add thrift binary to cache

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,6 +35,10 @@ jobs:
         chmod +x .github/testForLicenseHeaders.sh
         bash .github/testForLicenseHeaders.sh
 
+    - name: Set environment variables
+      run: |
+        cat .versions >> $GITHUB_ENV
+
     - name: Setup CouchDB
       run: scripts/startCouchdbForTests.sh
 
@@ -57,7 +61,17 @@ jobs:
         sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq python3-pip build-essential libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config libssl-dev git temurin-11-jdk maven cmake
         pip install mkdocs mkdocs-material
 
+    - name: Cache Thrift
+      id: cache-thrift
+      uses: actions/cache@v3
+      with:
+        path: |
+          /usr/local/bin/thrift
+          /usr/share/thrift/${{ env.THRIFT_VERSION }}
+        key: ${{ runner.os }}-thriftbin
+
     - name: Install Thrift
+      if: steps.cache-thrift.outputs.cache-hit != 'true'
       run: |
         chmod +x scripts/install-thrift.sh
         bash scripts/install-thrift.sh

--- a/scripts/install-thrift.sh
+++ b/scripts/install-thrift.sh
@@ -26,7 +26,6 @@ UNINSTALL=false
 has() { type "$1" &> /dev/null; }
 
 processThrift() {
-  set -x
   VERSION=$3
 
   echo "-[shell provisioning] Extracting thrift"
@@ -47,7 +46,6 @@ processThrift() {
     -DBUILD_C_GLIB=OFF \
     -DBUILD_JAVASCRIPT=OFF \
     -DBUILD_NODEJS=OFF \
-    -DBUILD_TESTS=OFF \
     -DWITH_OPENSSL=OFF \
     -DBUILD_PYTHON=OFF \
     -DBUILD_TESTING=OFF \
@@ -60,6 +58,8 @@ processThrift() {
 
   echo "-[shell provisioning] Executing make $2 on thrift"
   $SUDO_CMD make "$2"
+  $SUDO_CMD mkdir -p /usr/share/thrift
+  $SUDO_CMD touch "/usr/share/thrift/${THRIFT_VERSION}"
 }
 
 installThrift() {


### PR DESCRIPTION
A part of CI build time is dedicated to rebuild Thrift all the time.
To avoid this, we will cache the binary when exists.

