### PR TITLE
Avoids key error in migration script 048

### DIFF
--- a/scripts/migrations/048_add_component_businessunit.py
+++ b/scripts/migrations/048_add_component_businessunit.py
@@ -95,13 +95,13 @@ def run():
 
         # set the creator organization.
         if not 'businessUnit' in component:
-            creator = component['createdBy']
+            creator = component.get('createdBy')
             if creator in user_departments:
                 department = user_departments[creator]
                 component['businessUnit'] = department
             else:
                 component['businessUnit'] = DEFAULT_BUSINESS_UNIT
-                addFieldsList['warn'] = 'Failed to get ' + creator + ' department.'
+                addFieldsList['warn'] = 'Failed to get ' + str(creator) + ' department.'
 
             addFieldsList['businessUnit'] = component['businessUnit']
 


### PR DESCRIPTION
To avoid this error

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

This pull request resolves this issue https://github.com/eclipse/sw360/issues/1821#issue-1565917274  in the migrationscript 048
Issue: 

### Suggest Reviewer
@KoukiHama 

