### PR TITLE
feat(project): Added Email functionality for individual project spreadsheet export

### DIFF
--- a/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
+++ b/frontend/sw360-portlet/src/main/java/org/eclipse/sw360/portal/portlets/projects/ProjectPortlet.java
@@ -1104,7 +1104,7 @@ public class ProjectPortlet extends FossologyAwarePortlet {
 
     private void exportExcelWithEmail(ResourceRequest request, ResourceResponse response) {
         final User user = UserCacheHolder.getUserFromRequest(request);
-        final String projectId = request.getParameter(Project._Fields.ID.toString());
+        final String projectId = request.getParameter(PROJECT_ID);
         ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content.Language", request.getLocale(), getClass());
         String token = null;
 
@@ -1498,7 +1498,8 @@ public class ProjectPortlet extends FossologyAwarePortlet {
         final User user = UserCacheHolder.getUserFromRequest(request);
         Map<String, Set<String>> filterMap = loadFilterMapFromRequest(request);
         loadAndStoreStickyProjectGroup(request, user, filterMap);
-        String id = request.getParameter(Project._Fields.ID.toString());
+        String id = request.getParameter(Project._Fields.ID.toString()) == null ? request.getParameter(PROJECT_ID)
+                : request.getParameter(Project._Fields.ID.toString());
         return findProjectsByFiltersOrId(filterMap, id, user, pageData);
     }
 

--- a/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/clearingStatus.jsp
+++ b/frontend/sw360-portlet/src/main/resources/META-INF/resources/html/projects/includes/projects/clearingStatus.jsp
@@ -49,6 +49,11 @@
     <portlet:param name="<%=PortalConstants.PROJECT_ID%>" value="${docid}"/>
 </portlet:resourceURL>
 
+<portlet:resourceURL var="generateExcelReport">
+    <portlet:param name="<%=PortalConstants.ACTION%>" value="<%=PortalConstants.EMAIL_EXPORTED_EXCEL%>"/>
+    <portlet:param name="<%=PortalConstants.PROJECT_ID%>" value="${docid}"/>
+</portlet:resourceURL>
+
 <c:set var="pageName" value="<%= request.getParameter("pagename") %>" />
 
 <core_rt:if test='${not isCrDisabledForProjectBU}'>
@@ -868,12 +873,25 @@ AUI().use('liferay-portlet-url', function () {
         }
 
         function exportSpreadsheet(type) {
-            var portletURL = Liferay.PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RESOURCE_PHASE) %>')
+            var isEMailEnabled = <%=PortalConstants.SEND_PROJECT_SPREADSHEET_EXPORT_TO_MAIL_ENABLED%>;
+            if(isEMailEnabled){
+                var isWithReleases = (type === 'projectWithReleases' ? 'true' : 'false');
+                $.ajax({
+                    type: 'POST',
+                    url: '<%=generateExcelReport%>',
+                    cache: false,
+                    data: {
+                        "<portlet:namespace/><%=PortalConstants.EXTENDED_EXCEL_EXPORT%>": isWithReleases,
+                    }
+                });
+            }else {
+                var portletURL = Liferay.PortletURL.createURL('<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), themeDisplay.getPlid(), PortletRequest.RESOURCE_PHASE) %>')
                     .setParameter('<%=PortalConstants.ACTION%>', '<%=PortalConstants.EXPORT_TO_EXCEL%>');
-            portletURL.setParameter('<%=Project._Fields.ID%>','${project.id}');
-            portletURL.setParameter('<%=PortalConstants.EXTENDED_EXCEL_EXPORT%>', type === 'projectWithReleases' ? 'true' : 'false');
+                portletURL.setParameter('<%=Project._Fields.ID%>','${project.id}');
+                portletURL.setParameter('<%=PortalConstants.EXTENDED_EXCEL_EXPORT%>', type === 'projectWithReleases' ? 'true' : 'false');
 
-            window.location.href = portletURL.toString() + window.location.hash;
+                window.location.href = portletURL.toString() + window.location.hash;
+            }
         }
 
         $("button#addLicenseToRelease").on("click", function(event) {


### PR DESCRIPTION
[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

*  When the linked projects/releases size is large, then the downloading export spreadsheet is taking some time to download and which is blocking. These changes will enable emailing the download link after the spreadsheet writing is done. 

> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change? - No

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
* Enable the flag like `send.project.spreadsheet.export.to.mail.enabled=true` in `sw360.properties`.
* open individual project and go to "License Clearing" and "Export Spreadsheet"(both projects only and projects with linked releases). you should receive an email containing the download link.

> Have you implemented any additional tests? - No

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
