### PR TITLE
fix(rest): endpoint components/usedBy/CompId gives 500 msg when no release attach to component

### DIFF
--- a/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
+++ b/backend/src/src-projects/src/main/java/org/eclipse/sw360/projects/ProjectHandler.java
@@ -155,7 +155,6 @@ public class ProjectHandler implements ProjectService.Iface {
 
     @Override
     public Set<Project> searchByReleaseIds(Set<String> ids, User user) throws TException {
-        assertNotEmpty(ids);
         return handler.searchByReleaseId(ids, user);
     }
 


### PR DESCRIPTION

Issue:  #1825 

### How To Test?
Make a rest call for endpoint /components/usedBy/CompId.
Make sure this component does not have any releases.
The response for this rest call will be an empty list with 200 OK status message.

