### PR TITLE
fix(vulnerability): apache commons-text vulnerability CVE-2022-42889 …

### DIFF
--- a/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTools.java
+++ b/backend/src/src-licenseinfo/src/main/java/org/eclipse/sw360/licenseinfo/parsers/SPDXParserTools.java
@@ -16,7 +16,7 @@ import com.google.common.collect.Sets;
 import org.eclipse.sw360.datahandler.common.CommonUtils;
 import org.eclipse.sw360.datahandler.thrift.attachments.AttachmentContent;
 import org.eclipse.sw360.datahandler.thrift.licenseinfo.*;
-import org.apache.jena.ext.xerces.util.XMLChar;
+import org.apache.jena.util.XMLChar;
 
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <liferay.util.bridges.version>9.0.6</liferay.util.bridges.version>
     <liferay.util.java.version>17.1.2</liferay.util.java.version>
     <liferay.util.taglib.version>8.4.8</liferay.util.taglib.version>
-    <log4j2.version>2.17.1</log4j2.version>
+    <log4j2.version>2.19.0</log4j2.version>
     <mockito.version>4.7.0</mockito.version>
     <okhttp.version>4.10.0</okhttp.version>
     <package-url.version>1.1.1</package-url.version>
@@ -136,7 +136,7 @@
     <spring-restdocs-asciidoctor.version>2.0.6.RELEASE</spring-restdocs-asciidoctor.version>
     <thrift.version>0.16.0</thrift.version>
     <wiremock.version>2.26.0</wiremock.version>
-    <org.spdx.tools.java.version>1.1.0</org.spdx.tools.java.version>
+    <org.spdx.tools.java.version>1.1.5</org.spdx.tools.java.version>
     <com.googlecode.json-simple.version>1.1.1</com.googlecode.json-simple.version>
 
     <!--  User must provide below property configuration based on his/her liferay deployment environment -->


### PR DESCRIPTION
…#1864

[//]: # (Copyright Bosch.IO GmbH 2020)
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.
> * Which issue is this pull request belonging to and how is it solving it? (*Refer to issue here*)
> * Did you add or update any new dependencies that are required for your change?

Issue: 

### Suggest Reviewer
> You can suggest reviewers here with an @mention.

### How To Test?
> How should these changes be tested by the reviewer?
> Have you implemented any additional tests?

### Checklist
Must:
- [ ] All related issues are referenced in commit messages and in PR
